### PR TITLE
Adjustment for js/tsx frontend analysis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,6 +255,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "dbg_breakpoint"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb333c8dc699012c0694fe7c7eca7d625f2bceeeef44fd1de39008d6a6abf777"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +326,7 @@ dependencies = [
  "anyhow",
  "clap",
  "crossbeam",
+ "dbg_breakpoint",
  "env_logger",
  "glob",
  "indicatif",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ syntect = "5.1"
 memmap2 = "0.9"
 log = "0.4"
 env_logger = "0.10"
-
+dbg_breakpoint="0.1.1"
 [dev-dependencies]
 tempfile = "3.8"
 
@@ -66,3 +66,4 @@ path = "tests/integration/main.rs"
 [[test]]
 name = "end_to_end_tests"
 path = "tests/end_to_end/main.rs"
+

--- a/rules/backend_javascript/backend_security.ron
+++ b/rules/backend_javascript/backend_security.ron
@@ -1,0 +1,525 @@
+(
+    rules: [
+        // ==================== CWE-601: Server-side Open Redirect ====================
+        (
+            id: Some("js-server-open-redirect-001"),
+            name: Some("Server-side Open Redirect"),
+            category: Some("redirect"),
+            mode: "taint",
+            
+            sources: Some([
+                // Express.js request parameters
+                "req.query.*",
+                "req.params.*",
+                "req.body.*",
+                "request.query.*",
+                "request.params.*",
+                "request.body.*",
+                
+                // Fastify request parameters
+                "request.query.*",
+                "request.params.*",
+                "request.body.*",
+                
+                // Koa request parameters
+                "ctx.query.*",
+                "ctx.params.*",
+                "ctx.request.body.*",
+                "context.query.*",
+                "context.params.*",
+                "context.request.body.*",
+                
+                // URL parsing
+                "URLSearchParams",
+                "new URL",
+                "url.parse",
+                "decodeURIComponent",
+                "decodeURI",
+                
+                // Function parameters (common in redirect functions)
+                "options.location",
+                "options.url",
+                "options.redirect",
+                "redirectUrl",
+                "targetUrl",
+                "returnUrl",
+                "url",
+                "location",
+                
+                // Generic user input
+                "userInput",
+                "input",
+                "data",
+                
+                // HTTP headers
+                "req.headers.*",
+                "request.headers.*",
+                "ctx.headers.*"
+            ]),
+            
+            sinks: Some([
+                // Node.js HTTP response headers - more specific patterns
+                "res.writeHead(*,*Location*",
+                "response.writeHead(*,*Location*",
+                "res.setHeader(*Location*",
+                "response.setHeader(*Location*",
+                "res.setHeader('Location'*",
+                "res.setHeader(\"Location\"*",
+                "response.setHeader('Location'*",
+                "response.setHeader(\"Location\"*",
+                
+                // Express.js style redirects
+                "res.redirect",
+                "response.redirect",
+                
+                // Fastify style redirects
+                "reply.redirect",
+                
+                // Koa style redirects
+                "ctx.redirect",
+                "context.redirect",
+                
+                // Direct header manipulation
+                "*.headers.location",
+                "*.headers.Location"
+            ]),
+            
+            sanitizers: Some([
+                // URL validation
+                "isValidURL",
+                "validateURL",
+                "URL.parse",
+                "new URL(",
+                
+                // Domain validation
+                "isAllowedDomain",
+                "isSameDomain",
+                "allowedHosts.includes",
+                "whitelist.includes",
+                "ALLOWED_DOMAINS.includes",
+                
+                // Relative URL enforcement
+                "startsWith(\"/\")",
+                "isRelativeURL",
+                "makeRelative",
+                
+                // URL sanitization
+                "sanitizeURL",
+                "validateRedirectURL"
+            ]),
+            
+            finding_type: Some("Open Redirect"),
+            severity: Some("Medium"),
+            confidence: Some("High"),
+            
+            description: Some("User-controlled data flows to HTTP redirect headers without validation"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Frontend directories (exclude from backend analysis)
+                    "*/public/*", "*/static/*", "*/assets/*", "*/dist/*",
+                    "*/build/*", "*/frontend/*", "*/client/*",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*"
+                    
+                    // Note: Removed test file exclusions for backend analysis
+                    // Backend code can legitimately be in test files
+                ])
+            )),
+            
+            tags: Some(["open-redirect", "cwe-601", "server-side", "backend"])
+        ),
+
+        // ==================== CWE-78: Server-side Command Injection ====================
+        (
+            id: Some("js-server-command-injection-001"),
+            name: Some("Server-side Command Injection"),
+            category: Some("command-injection"),
+            mode: "taint",
+            
+            sources: Some([
+                // Request parameters
+                "req.query.*",
+                "req.params.*",
+                "req.body.*",
+                "request.query.*",
+                "request.params.*",
+                "request.body.*",
+                "ctx.query.*",
+                "ctx.params.*",
+                "ctx.request.body.*",
+                
+                // File uploads
+                "req.files.*",
+                "req.file.*",
+                
+                // Headers
+                "req.headers.*",
+                "request.headers.*",
+                
+                // Function parameters
+                "command",
+                "cmd",
+                "shellCommand",
+                "userInput",
+                "input"
+            ]),
+            
+            sinks: Some([
+                // Node.js child_process - more specific patterns
+                "*.exec(",
+                "*.execSync(",
+                "*.spawn(",
+                "*.spawnSync(",
+                "*.execFile(",
+                "*.execFileSync(",
+                "child_process.exec",
+                "child_process.execSync",
+                "child_process.spawn",
+                "child_process.spawnSync",
+                "child_process.execFile",
+                "child_process.execFileSync",
+                
+                // Shell execution
+                "sh",
+                "bash",
+                "cmd",
+                "powershell"
+            ]),
+            
+            sanitizers: Some([
+                // Command sanitization
+                "escapeShellArg",
+                "escapeShellCmd",
+                "shellEscape",
+                "sanitizeCommand",
+                
+                // Validation
+                "validateCommand",
+                "isValidCommand",
+                "commandWhitelist.includes",
+                
+                // Safe alternatives
+                "execFile", // When used with array arguments
+                "spawn" // When used with array arguments
+            ]),
+            
+            finding_type: Some("Command Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            
+            description: Some("User-controlled data flows to command execution without sanitization"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*/public/*", "*/static/*", "*/assets/*", "*/dist/*",
+                    "*/build/*", "*/frontend/*", "*/client/*",
+                    "*/node_modules/*", "*/lib/*", "*/vendor/*"
+                ])
+            )),
+            
+            tags: Some(["command-injection", "cwe-78", "server-side", "backend"])
+        ),
+
+        // ==================== CWE-89: Server-side SQL Injection ====================
+        (
+            id: Some("js-server-sql-injection-001"),
+            name: Some("Server-side SQL Injection"),
+            category: Some("sql-injection"),
+            mode: "taint",
+            
+            sources: Some([
+                // Request parameters
+                "req.query.*",
+                "req.params.*",
+                "req.body.*",
+                "request.query.*",
+                "request.params.*",
+                "request.body.*",
+                "ctx.query.*",
+                "ctx.params.*",
+                "ctx.request.body.*",
+                
+                // Headers
+                "req.headers.*",
+                "request.headers.*",
+                
+                // Function parameters
+                "userInput",
+                "input",
+                "data",
+                "searchTerm",
+                "query"
+            ]),
+            
+            sinks: Some([
+                // Raw SQL execution - more specific patterns
+                "*.query(",
+                "*.execute(",
+                "*.exec(",
+                "*.run(",
+                
+                // Database specific
+                "db.query",
+                "db.execute",
+                "db.run",
+                "connection.query",
+                "connection.execute",
+                "pool.query",
+                "pool.execute",
+                
+                // ORM raw queries
+                "sequelize.query",
+                "knex.raw",
+                "typeorm.query",
+                "mongoose.aggregate",
+                
+                // MySQL
+                "mysql.query",
+                "mysql2.query",
+                
+                // PostgreSQL
+                "pg.query",
+                "client.query",
+                
+                // SQLite
+                "sqlite3.run",
+                "sqlite3.exec",
+                "sqlite3.prepare"
+            ]),
+            
+            sanitizers: Some([
+                // Parameterized queries
+                "prepare",
+                "prepared",
+                "parameterized",
+                
+                // Escaping functions
+                "escape",
+                "escapeId",
+                "mysql.escape",
+                "pg.escape",
+                
+                // Validation
+                "validateSQL",
+                "sanitizeSQL",
+                "isValidSQL"
+            ]),
+            
+            finding_type: Some("SQL Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            
+            description: Some("User-controlled data flows to SQL queries without parameterization"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*/public/*", "*/static/*", "*/assets/*", "*/dist/*",
+                    "*/build/*", "*/frontend/*", "*/client/*",
+                    "*/node_modules/*", "*/lib/*", "*/vendor/*"
+                ])
+            )),
+            
+            tags: Some(["sql-injection", "cwe-89", "server-side", "backend"])
+        ),
+
+        // ==================== CWE-22: Server-side Path Traversal ====================
+        (
+            id: Some("js-server-path-traversal-001"),
+            name: Some("Server-side Path Traversal"),
+            category: Some("path-traversal"),
+            mode: "taint",
+            
+            sources: Some([
+                // Request parameters
+                "req.query.*",
+                "req.params.*",
+                "req.body.*",
+                "request.query.*",
+                "request.params.*",
+                "request.body.*",
+                "ctx.query.*",
+                "ctx.params.*",
+                
+                // File upload names
+                "req.files.*.name",
+                "req.file.originalname",
+                "req.file.filename",
+                
+                // Headers
+                "req.headers.*",
+                
+                // Function parameters
+                "filename",
+                "filepath",
+                "path",
+                "file",
+                "userInput"
+            ]),
+            
+            sinks: Some([
+                // File system operations
+                "fs.readFile",
+                "fs.readFileSync",
+                "fs.writeFile",
+                "fs.writeFileSync",
+                "fs.createReadStream",
+                "fs.createWriteStream",
+                "fs.open",
+                "fs.openSync",
+                "fs.stat",
+                "fs.statSync",
+                "fs.access",
+                "fs.accessSync",
+                "fs.unlink",
+                "fs.unlinkSync",
+                "fs.rmdir",
+                "fs.rmdirSync",
+                "fs.mkdir",
+                "fs.mkdirSync",
+                
+                // Path operations
+                "path.join",
+                "path.resolve",
+                
+                // Express static serving
+                "express.static",
+                "res.sendFile",
+                "response.sendFile",
+                
+                // Require/import
+                "require",
+                "import"
+            ]),
+            
+            sanitizers: Some([
+                // Path validation
+                "path.normalize",
+                "path.resolve",
+                "validatePath",
+                "sanitizePath",
+                "isValidPath",
+                
+                // Security checks
+                "path.basename",
+                "allowedPaths.includes",
+                "pathWhitelist.includes",
+                
+                // Safe path construction
+                "path.join" // When used properly with validation
+            ]),
+            
+            finding_type: Some("Path Traversal"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            
+            description: Some("User-controlled data flows to file system operations without path validation"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*/public/*", "*/static/*", "*/assets/*", "*/dist/*",
+                    "*/build/*", "*/frontend/*", "*/client/*",
+                    "*/node_modules/*", "*/lib/*", "*/vendor/*"
+                ])
+            )),
+            
+            tags: Some(["path-traversal", "cwe-22", "server-side", "backend"])
+        ),
+
+        // ==================== CWE-94: Server-side Code Injection ====================
+        (
+            id: Some("js-server-code-injection-001"),
+            name: Some("Server-side Code Injection"),
+            category: Some("code-injection"),
+            mode: "taint",
+            
+            sources: Some([
+                // Request parameters
+                "req.query.*",
+                "req.params.*",
+                "req.body.*",
+                "request.query.*",
+                "request.params.*",
+                "request.body.*",
+                "ctx.query.*",
+                "ctx.params.*",
+                
+                // Headers
+                "req.headers.*",
+                
+                // Function parameters
+                "code",
+                "script",
+                "expression",
+                "userInput",
+                "input"
+            ]),
+            
+            sinks: Some([
+                // Direct code execution
+                "eval",
+                "Function",
+                "setTimeout",
+                "setInterval",
+                
+                // VM module
+                "vm.runInThisContext",
+                "vm.runInNewContext",
+                "vm.runInContext",
+                
+                // Dynamic requires
+                "require",
+                "import",
+                
+                // Template engines (unsafe usage)
+                "ejs.render",
+                "handlebars.compile",
+                "mustache.render"
+            ]),
+            
+            sanitizers: Some([
+                // Code validation
+                "validateCode",
+                "sanitizeCode",
+                "isValidCode",
+                
+                // Safe alternatives
+                "JSON.parse", // For data, not code
+                "parseInt",
+                "parseFloat"
+            ]),
+            
+            finding_type: Some("Code Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            
+            description: Some("User-controlled data flows to code execution without validation"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*/public/*", "*/static/*", "*/assets/*", "*/dist/*",
+                    "*/build/*", "*/frontend/*", "*/client/*",
+                    "*/node_modules/*", "*/lib/*", "*/vendor/*"
+                ])
+            )),
+            
+            tags: Some(["code-injection", "cwe-94", "server-side", "backend"])
+        )
+    ]
+) 

--- a/rules/javascript/exclusion_patterns.ron
+++ b/rules/javascript/exclusion_patterns.ron
@@ -1,0 +1,60 @@
+// Centralized exclusion patterns for JavaScript/TypeScript security rules
+// This file defines common exclusion patterns that can be referenced by all rules
+// to ensure consistency and reduce maintenance overhead
+
+(
+    frontend_exclusions: Some([
+        "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+        "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+        "*-min.js", "*-bundle.js", "*-compiled.js",
+        "*.production.js", "*.prod.js",
+        
+        // Third-party library directories
+        "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+        "*/libraries/*", "*/deps/*", "*/dependencies/*",
+        
+        // Common JavaScript libraries by name
+        "*jquery*.js", "*angular*.js", "*react*.js", "*vue*.js",
+        "*lodash*.js", "*underscore*.js", "*bootstrap*.js",
+        "*three.js", "*d3*.js", "*chart*.js", "*moment*.js",
+        "*backbone*.js", "*ember*.js", "*knockout*.js",
+        
+        // Framework test runners and testing frameworks (but not our test files)
+        "*/node_modules/*/test/*", "*/node_modules/*/tests/*",
+        "*karma*", "*jasmine*", "*mocha*", "*jest*",
+        "*/cypress/*", "*/e2e/*",
+        
+        // Build and configuration files
+        "*webpack*", "*rollup*", "*babel*", "*gulp*", "*grunt*",
+        "*.config.js", "*.config.ts", "*build*", "*dist*",
+        "*vite*", "*parcel*", "*esbuild*",
+        
+        // Documentation and metadata
+        "*readme*", "*license*", "*changelog*", "*contributing*",
+        "*docs/*", "*documentation/*"
+    ]),
+    
+    backend_exclusions: Some([
+        // Minified and compiled files
+        "*.min.js", "*.bundle.js", "*.compiled.js",
+        
+        // Third-party dependencies
+        "*/node_modules/*", "*/vendor/*", "*/lib/*",
+        
+        // Framework test directories (but not our test files)
+        "*/node_modules/*/test/*", "*/node_modules/*/tests/*",
+        
+        // Build and configuration
+        "*webpack*", "*babel*", "*.config.js", "*build*", "*dist*",
+        
+        // Documentation
+        "*readme*", "*docs/*"
+    ]),
+    
+    common_exclusions: Some([
+        "*/node_modules/*",
+        "*.min.js", "*.bundle.js",
+        "*build*", "*dist*",
+        "*.config.js", "*.config.ts"
+    ])
+) 

--- a/rules/javascript/frontend_security.ron
+++ b/rules/javascript/frontend_security.ron
@@ -94,7 +94,17 @@
             category: Some("prototype-pollution"),
             mode: "search",
             patterns: Some([
-                "*.__proto__*=*", "*['__proto__']*=*", "*[\"__proto__\"]*=*"
+                // Much more specific patterns to avoid false positives
+                ".__proto__=",
+                "['__proto__']=",
+                "[\"__proto__\"]=",
+                ".__proto__ =",
+                "['__proto__'] =",
+                "[\"__proto__\"] =",
+                // Constructor pollution
+                ".constructor.prototype",
+                // Object.prototype pollution  
+                "Object.prototype"
             ]),
             finding_type: Some("Prototype Pollution"),
             severity: Some("High"),

--- a/rules/javascript/frontend_security.ron
+++ b/rules/javascript/frontend_security.ron
@@ -111,13 +111,7 @@
             confidence: Some("High"),
             description: Some("Direct prototype manipulation can poison objects"),
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    "*node_modules/core-js/*",
-                    "*node_modules/es5-shim/*",
-                    "*vendor/prototypal.js*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["prototype-pollution", "frontend"])
         ),
         (

--- a/rules/javascript/frontend_security.ron
+++ b/rules/javascript/frontend_security.ron
@@ -6,13 +6,41 @@
             category: Some("xss"),
             mode: "search",
             patterns: Some([
+                // More specific patterns targeting actual XSS risks
                 "*.innerHTML*=*location.*",
-                "*.innerHTML*=*decodeURIComponent(*location.*"
+                "*.innerHTML*=*decodeURIComponent(*location.*",
+                "*.innerHTML*=*user*",
+                "*.innerHTML*=*input*",
+                "*.innerHTML*=*data*",
+                "*.innerHTML*=*param*",
+                "*.outerHTML*=*location.*",
+                "*.outerHTML*=*user*",
+                "*.outerHTML*=*input*"
+            ]),
+            unless: Some([
+                // Exclude safe operations that cause false positives
+                "addEventListener",
+                "querySelector",
+                "getElementById", 
+                "textContent",
+                "className",
+                "style\\.",
+                "console\\.",
+                "dataset\\.",
+                "setAttribute\\(",
+                "window\\.location\\.href(?!.*=)",  // Reading location.href is safe
+                "new URL\\(",
+                "URLSearchParams",
+                "history\\.",
+                // Exclude sanitized content
+                "DOMPurify\\.sanitize",
+                "escapeHTML",
+                "encodeHTML"
             ]),
             finding_type: Some("DOM XSS"),
             severity: Some("High"),
             confidence: Some("High"),
-            description: Some("Direct assignment to innerHTML can lead to DOM-XSS"),
+            description: Some("Direct assignment to innerHTML with user input can lead to DOM-XSS"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["xss", "dom", "frontend", "cwe-79"])
         ),
@@ -21,7 +49,28 @@
             name: Some("DOM XSS via document.write"),
             category: Some("xss"),
             mode: "search",
-            patterns: Some(["document.write", "document.writeln"]),
+            patterns: Some([
+                // More specific patterns for document.write XSS
+                "document.write(*user*",
+                "document.write(*input*",
+                "document.write(*data*", 
+                "document.write(*param*",
+                "document.write(*location.*",
+                "document.writeln(*user*",
+                "document.writeln(*input*",
+                "document.writeln(*data*",
+                "document.writeln(*param*",
+                "document.writeln(*location.*"
+            ]),
+            unless: Some([
+                // Exclude safe static content
+                "document\\.write\\(['\"]",  // Static strings
+                "document\\.writeln\\(['\"]",
+                // Exclude sanitized content
+                "DOMPurify\\.sanitize",
+                "escapeHTML",
+                "encodeHTML"
+            ]),
             finding_type: Some("DOM XSS"),
             severity: Some("High"),
             confidence: Some("High"),
@@ -150,16 +199,36 @@
             category: Some("redirect"),
             mode: "search",
             patterns: Some([
-                "*window.location*=*user*","*window.location*=*input*",
+                // Focus on more specific dangerous patterns
+                "*window.location.href*=*user*","*window.location.href*=*input*",
+                "*window.location.href*=*data*","*window.location.href*=*param*",
                 "*location.href*=*user*","*location.href*=*input*",
-                "*location.assign*user*","*location.assign*input*",
-                "*location.replace*user*","*location.replace*input*"
+                "*location.href*=*data*","*location.href*=*param*",
+                "*location.assign(*user*","*location.assign(*input*",
+                "*location.assign(*data*","*location.assign(*param*",
+                "*location.replace(*user*","*location.replace(*input*",
+                "*location.replace(*data*","*location.replace(*param*",
+                "*window.open(*user*","*window.open(*input*",
+                "*window.open(*data*","*window.open(*param*"
             ]),
             finding_type: Some("Open Redirect"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
             description: Some("Dynamic location updates can create open redirects"),
-            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Exclude safe internal operations
+                    "*window.location.search*",
+                    "*location.search*", 
+                    "*location.pathname*",
+                    "*history.pushState*",
+                    "*history.replaceState*",
+                    "*URLSearchParams(window.location.search)*",
+                    "*urlParams.toString()*",
+                    "*encodeURIComponent(*)*"
+                ])
+            )),
             tags: Some(["open-redirect","frontend","cwe-601"])
         ),
         (

--- a/rules/javascript/frontend_security.ron
+++ b/rules/javascript/frontend_security.ron
@@ -1,38 +1,19 @@
 (
     rules: [
-        // ==================== DOM-based XSS (CWE-79) ====================
         (
             id: Some("js-dom-xss-001"),
             name: Some("DOM XSS via innerHTML"),
             category: Some("xss"),
             mode: "search",
             patterns: Some([
-                "*.innerHTML*=*"
+                "*.innerHTML*=*location.*",
+                "*.innerHTML*=*decodeURIComponent(*location.*"
             ]),
             finding_type: Some("DOM XSS"),
             severity: Some("High"),
             confidence: Some("High"),
-            description: Some("Direct assignment to innerHTML with potentially untrusted data can lead to DOM-based XSS"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["xss", "dom", "frontend", "cwe-79"])
-        ),
-        (
-            id: Some("js-dom-xss-002"),
-            name: Some("DOM XSS via outerHTML"),
-            category: Some("xss"),
-            mode: "search",
-            patterns: Some([
-                "*.outerHTML*=*"
-            ]),
-            finding_type: Some("DOM XSS"),
-            severity: Some("High"),
-            confidence: Some("High"),
-            description: Some("Direct assignment to outerHTML with potentially untrusted data can lead to DOM-based XSS"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
+            description: Some("Direct assignment to innerHTML can lead to DOM-XSS"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["xss", "dom", "frontend", "cwe-79"])
         ),
         (
@@ -40,408 +21,110 @@
             name: Some("DOM XSS via document.write"),
             category: Some("xss"),
             mode: "search",
-            patterns: Some([
-                "document.write",
-                "document.writeln"
-            ]),
+            patterns: Some(["document.write", "document.writeln"]),
             finding_type: Some("DOM XSS"),
             severity: Some("High"),
             confidence: Some("High"),
-            description: Some("Using document.write with dynamic content can lead to DOM-based XSS vulnerabilities"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
+            description: Some("Using document.write with dynamic content can lead to DOM-based XSS"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["xss", "dom", "frontend", "cwe-79"])
         ),
-        (
-            id: Some("js-dom-xss-004"),
-            name: Some("DOM XSS via insertAdjacentHTML"),
-            category: Some("xss"),
-            mode: "search",
-            patterns: Some([
-                "*.insertAdjacentHTML"
-            ]),
-            finding_type: Some("DOM XSS"),
-            severity: Some("High"),
-            confidence: Some("High"),
-            description: Some("insertAdjacentHTML with untrusted data can lead to DOM-based XSS"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["xss", "dom", "frontend", "cwe-79"])
-        ),
-        (
-            id: Some("js-dom-xss-005"),
-            name: Some("DOM XSS via outerText"),
-            category: Some("xss"),
-            mode: "search",
-            patterns: Some([
-                "*.outerText*=*"
-            ]),
-            finding_type: Some("DOM XSS"),
-            severity: Some("Medium"),
-            confidence: Some("Medium"),
-            description: Some("Direct assignment to outerText can lead to content injection"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["xss", "dom", "frontend", "cwe-79"])
-        ),
-        (
-            id: Some("js-dom-xss-006"),
-            name: Some("DOM XSS via script manipulation"),
-            category: Some("xss"),
-            mode: "search",
-            patterns: Some([
-                "*script*.src*=*user*",
-                "*script*.text*=*user*",
-                "*script*.innerHTML*=*user*"
-            ]),
-            finding_type: Some("DOM XSS"),
-            severity: Some("Critical"),
-            confidence: Some("High"),
-            description: Some("Dynamic script source or content assignment can lead to code injection"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["xss", "script-injection", "frontend", "cwe-79"])
-        ),
-        (
-            id: Some("js-dom-xss-007"),
-            name: Some("DOM XSS via window.name"),
-            category: Some("xss"),
-            mode: "search",
-            patterns: Some([
-                "window.name*=*user*",
-                "window.name*=*input*"
-            ]),
-            finding_type: Some("DOM XSS"),
-            severity: Some("Medium"),
-            confidence: Some("Medium"),
-            description: Some("Assignment to window.name with user data can lead to XSS in some contexts"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["xss", "window-name", "frontend", "cwe-79"])
-        ),
-        (
-            id: Some("js-dom-xss-008"),
-            name: Some("DOM XSS via document.domain"),
-            category: Some("xss"),
-            mode: "search",
-            patterns: Some([
-                "document.domain*=*user*",
-                "document.domain*=*input*"
-            ]),
-            finding_type: Some("DOM XSS"),
-            severity: Some("High"),
-            confidence: Some("Medium"),
-            description: Some("Dynamic assignment to document.domain can lead to security bypass"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["xss", "domain-manipulation", "frontend", "cwe-79"])
-        ),
-        (
-            id: Some("js-dom-xss-009"),
-            name: Some("DOM XSS via insertAdjacentText"),
-            category: Some("xss"),
-            mode: "search",
-            patterns: Some([
-                "*.insertAdjacentText*user*",
-                "*.insertAdjacentText*input*"
-            ]),
-            finding_type: Some("DOM XSS"),
-            severity: Some("Low"),
-            confidence: Some("Medium"),
-            description: Some("insertAdjacentText with user input can lead to content injection"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["xss", "dom", "frontend", "cwe-79"])
-        ),
-
-        // ==================== Code Injection XSS (CWE-80, CWE-95) ====================
         (
             id: Some("js-code-injection-001"),
-            name: Some("Code injection via eval with variables"),
+            name: Some("Code injection via eval"),
             category: Some("code-injection"),
             mode: "search",
             patterns: Some([
-                "eval(*user*)",
-                "eval(*input*)",
-                "eval(*data*)",
-                "eval(*+*)"
+                "eval(*user*)", "eval(*input*)", "eval(*data*)", "eval(*+*)"
             ]),
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
-            description: Some("Using eval() with dynamic content can lead to code injection and XSS"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
+            description: Some("eval() with dynamic content can lead to code injection"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["code-injection", "frontend", "cwe-80", "cwe-95"])
         ),
         (
             id: Some("js-code-injection-002"),
-            name: Some("Code injection via Function constructor with variables"),
+            name: Some("Code injection via Function constructor"),
             category: Some("code-injection"),
             mode: "search",
             patterns: Some([
-                "*Function(*user*)",
-                "*Function(*input*)",
-                "*Function(*data*)",
-                "*Function(*+*)"
+                "*Function(*user*)", "*Function(*input*)", "*Function(*data*)", "*Function(*+*)"
             ]),
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
-            description: Some("Function constructor with dynamic content can lead to code injection and XSS"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
+            description: Some("Function constructor with dynamic content can lead to code injection"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["code-injection", "frontend", "cwe-80", "cwe-95"])
         ),
         (
-            id: Some("js-code-injection-003"),
-            name: Some("Code injection via setTimeout/setInterval with variables"),
-            category: Some("code-injection"),
+            id: Some("js-postmessage-001"),
+            name: Some("postMessage with wildcard origin"),
+            category: Some("postmessage"),
             mode: "search",
-            patterns: Some([
-                "*setTimeout(*user*)",
-                "*setTimeout(*input*)",
-                "*setTimeout(*data*)",
-                "*setInterval(*user*)",
-                "*setInterval(*input*)",
-                "*setInterval(*data*)"
-            ]),
-            finding_type: Some("Code Injection"),
+            patterns: Some(["*postMessage*'*'*", "*postMessage*\"*\"*"]),
+            finding_type: Some("Insecure postMessage"),
             severity: Some("High"),
-            confidence: Some("Medium"),
-            description: Some("Using setTimeout/setInterval with dynamic string content can lead to code injection"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["code-injection", "frontend", "cwe-95"])
+            confidence: Some("High"),
+            description: Some("Using postMessage with \"*\" origin can leak data to any site"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            tags: Some(["postmessage", "origin-validation", "frontend", "cwe-1173", "cwe-927"])
         ),
-
-        // ==================== Information Exposure (CWE-200, CWE-359) ====================
-        (
-            id: Some("js-info-exposure-001"),
-            name: Some("Console logging sensitive data"),
-            category: Some("information-disclosure"),
-            mode: "search",
-            patterns: Some([
-                "*console.log*password*",
-                "*console.log*token*",
-                "*console.log*secret*",
-                "*console.log*key*",
-                "*console.debug*password*",
-                "*console.debug*token*",
-                "*console.debug*secret*",
-                "*console.debug*key*"
-            ]),
-            finding_type: Some("Information Exposure"),
-            severity: Some("Medium"),
-            confidence: Some("Medium"),
-            description: Some("Logging sensitive information to console can expose credentials or secrets"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["information-disclosure", "logging", "frontend", "cwe-200", "cwe-359"])
-        ),
-
-        // ==================== Insecure Storage (CWE-922) ====================
         (
             id: Some("js-storage-001"),
             name: Some("Sensitive data in localStorage"),
             category: Some("storage"),
             mode: "search",
             patterns: Some([
-                "*localStorage.setItem*password*",
-                "*localStorage.setItem*token*",
-                "*localStorage.setItem*secret*",
-                "*localStorage.setItem*key*",
-                "*sessionStorage.setItem*password*",
-                "*sessionStorage.setItem*token*",
-                "*sessionStorage.setItem*secret*",
-                "*sessionStorage.setItem*key*"
+                "*localStorage.setItem*password*", "*localStorage.setItem*token*", "*localStorage.setItem*secret*", "*localStorage.setItem*key*",
+                "*sessionStorage.setItem*password*", "*sessionStorage.setItem*token*", "*sessionStorage.setItem*secret*", "*sessionStorage.setItem*key*"
             ]),
             finding_type: Some("Insecure Storage"),
             severity: Some("High"),
             confidence: Some("Medium"),
-            description: Some("Storing sensitive information in localStorage/sessionStorage is insecure"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
+            description: Some("Storing secrets in web storage is insecure"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["insecure-storage", "frontend", "cwe-922", "cwe-200"])
         ),
-
-        // ==================== Open Redirect (CWE-601) ====================
-        (
-            id: Some("js-open-redirect-001"),
-            name: Some("Open redirect via location"),
-            category: Some("redirect"),
-            mode: "search",
-            patterns: Some([
-                "*window.location*=*user*",
-                "*window.location*=*input*",
-                "*location.href*=*user*",
-                "*location.href*=*input*",
-                "*location.assign*user*",
-                "*location.assign*input*",
-                "*location.replace*user*",
-                "*location.replace*input*"
-            ]),
-            finding_type: Some("Open Redirect"),
-            severity: Some("Medium"),
-            confidence: Some("Medium"),
-            description: Some("Dynamic URL redirection without validation can lead to open redirect vulnerabilities"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["open-redirect", "frontend", "cwe-601"])
-        ),
-        (
-            id: Some("js-open-redirect-002"),
-            name: Some("Open redirect via location.hash"),
-            category: Some("redirect"),
-            mode: "search",
-            patterns: Some([
-                "*location.hash*=*user*",
-                "*location.hash*=*input*"
-            ]),
-            finding_type: Some("Open Redirect"),
-            severity: Some("Low"),
-            confidence: Some("Low"),
-            description: Some("Dynamic hash manipulation can lead to client-side attacks"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["open-redirect", "hash-manipulation", "frontend", "cwe-601"])
-        ),
-
-        // ==================== Insecure postMessage (CWE-1173, CWE-927) ====================
-        (
-            id: Some("js-postmessage-001"),
-            name: Some("postMessage with wildcard origin"),
-            category: Some("postmessage"),
-            mode: "search",
-            patterns: Some([
-                "*postMessage*'*'*",
-                "*postMessage*\"*\"*"
-            ]),
-            finding_type: Some("Insecure postMessage"),
-            severity: Some("High"),
-            confidence: Some("High"),
-            description: Some("Using postMessage with wildcard origin (*) can allow malicious sites to receive messages"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["postmessage", "origin-validation", "frontend", "cwe-1173", "cwe-927"])
-        ),
-        (
-            id: Some("js-postmessage-002"),
-            name: Some("postMessage with variable origin"),
-            category: Some("postmessage"),
-            mode: "search",
-            patterns: Some([
-                "*postMessage(*,*user*)",
-                "*postMessage(*,*input*)",
-                "*postMessage(*,*origin*)",
-                "*postMessage(*,*+*)"
-            ]),
-            finding_type: Some("Insecure postMessage"),
-            severity: Some("Medium"),
-            confidence: Some("Medium"),
-            description: Some("Using postMessage with dynamic origin can be dangerous if not properly validated"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["postmessage", "origin-validation", "frontend", "cwe-1173", "cwe-927"])
-        ),
-        (
-            id: Some("js-postmessage-003"),
-            name: Some("Message event listener without origin check"),
-            category: Some("postmessage"),
-            mode: "search",
-            patterns: Some([
-                "*addEventListener*'message'*",
-                "*addEventListener*\"message\"*",
-                "*onmessage*=*function*",
-                "window.onmessage*=*"
-            ]),
-            finding_type: Some("Missing Origin Validation"),
-            severity: Some("Medium"),
-            confidence: Some("Low"),
-            description: Some("Message event handlers should validate the origin of incoming messages"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["postmessage", "origin-validation", "frontend", "cwe-927"])
-        ),
-
-        // ==================== Prototype Pollution ====================
         (
             id: Some("js-prototype-pollution-001"),
             name: Some("Direct prototype manipulation"),
             category: Some("prototype-pollution"),
             mode: "search",
             patterns: Some([
-                "*.__proto__*=*",
-                "*['__proto__']*=*",
-                "*[\"__proto__\"]*=*"
+                "*.__proto__*=*", "*['__proto__']*=*", "*[\"__proto__\"]*=*"
             ]),
             finding_type: Some("Prototype Pollution"),
             severity: Some("High"),
             confidence: Some("High"),
-            description: Some("Direct prototype manipulation can lead to prototype pollution vulnerabilities"),
+            description: Some("Direct prototype manipulation can poison objects"),
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    "*node_modules/core-js/*",
+                    "*node_modules/es5-shim/*",
+                    "*vendor/prototypal.js*"
+                ])
             )),
             tags: Some(["prototype-pollution", "frontend"])
         ),
-
-        // ==================== Weak Randomness (CWE-338) ====================
-        (
-            id: Some("js-weak-random-001"),
-            name: Some("Weak randomness with Math.random"),
-            category: Some("cryptography"),
-            mode: "search",
-            patterns: Some([
-                "Math.random"
-            ]),
-            finding_type: Some("Weak Randomness"),
-            severity: Some("Medium"),
-            confidence: Some("Medium"),
-            description: Some("Math.random() is not cryptographically secure - use crypto.getRandomValues() for security purposes"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["weak-randomness", "cryptography", "frontend", "cwe-338"])
-        ),
-
-        // ==================== Clear-text Network Requests (CWE-319) ====================
         (
             id: Some("js-cleartext-001"),
             name: Some("HTTP requests instead of HTTPS"),
             category: Some("network"),
             mode: "search",
             patterns: Some([
-                "*fetch*'http://*",
-                "*fetch*\"http://*",
-                "*axios.get*'http://*",
-                "*axios.get*\"http://*",
-                "*axios.post*'http://*",
-                "*axios.post*\"http://*"
+                "*fetch*'http://*", "*fetch*\"http://*",
+                "*axios.get*'http://*", "*axios.get*\"http://*",
+                "*axios.post*'http://*", "*axios.post*\"http://*"
             ]),
             finding_type: Some("Cleartext Network Request"),
             severity: Some("Medium"),
             confidence: Some("High"),
-            description: Some("HTTP requests transmit data in cleartext - use HTTPS for sensitive operations"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
+            description: Some("HTTP requests send data in cleartext – use HTTPS"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["cleartext", "network", "https", "frontend", "cwe-319"])
         ),
         (
@@ -449,120 +132,92 @@
             name: Some("XMLHttpRequest with HTTP"),
             category: Some("network"),
             mode: "search",
-            patterns: Some([
-                "*xhr.open*'*'*'http://*",
-                "*xhr.open*\"*\"*\"http://*"
-            ]),
+            patterns: Some(["*xhr.open*\"http://*"]),
             finding_type: Some("Cleartext Network Request"),
             severity: Some("Medium"),
             confidence: Some("High"),
-            description: Some("XMLHttpRequest with HTTP URLs transmit data in cleartext"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
+            description: Some("XHR over HTTP transmits data in cleartext"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["cleartext", "network", "xhr", "frontend", "cwe-319"])
         ),
-
-        // ==================== Dynamic Code Loading (CWE-95) ====================
+        (
+            id: Some("js-open-redirect-001"),
+            name: Some("Open redirect via location"),
+            category: Some("redirect"),
+            mode: "search",
+            patterns: Some([
+                "*window.location*=*user*","*window.location*=*input*",
+                "*location.href*=*user*","*location.href*=*input*",
+                "*location.assign*user*","*location.assign*input*",
+                "*location.replace*user*","*location.replace*input*"
+            ]),
+            finding_type: Some("Open Redirect"),
+            severity: Some("Medium"),
+            confidence: Some("Medium"),
+            description: Some("Dynamic location updates can create open redirects"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            tags: Some(["open-redirect","frontend","cwe-601"])
+        ),
+        (
+            id: Some("js-open-redirect-002"),
+            name: Some("Open redirect via location.hash"),
+            category: Some("redirect"),
+            mode: "search",
+            patterns: Some(["*location.hash*=*user*","*location.hash*=*input*"]),
+            finding_type: Some("Open Redirect"),
+            severity: Some("Low"),
+            confidence: Some("Low"),
+            description: Some("Manipulating location.hash can enable client-side attacks"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            tags: Some(["open-redirect","hash-manipulation","frontend","cwe-601"])
+        ),
         (
             id: Some("js-dynamic-import-001"),
             name: Some("Dynamic import with user input"),
             category: Some("code-injection"),
             mode: "search",
             patterns: Some([
-                "*import(*user*)",
-                "*import(*input*)",
-                "*import(*data*)",
-                "*require(*user*)",
-                "*require(*input*)",
-                "*require(*data*)"
+                "*import(*user*)","*import(*input*)","*import(*data*)",
+                "*require(*user*)","*require(*input*)","*require(*data*)"
             ]),
             finding_type: Some("Dynamic Code Loading"),
             severity: Some("High"),
             confidence: Some("Medium"),
-            description: Some("Dynamic imports with user-controlled input can lead to code injection"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["code-injection", "dynamic-import", "frontend", "cwe-95"])
+            description: Some("User-controlled module paths can lead to code injection"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            tags: Some(["code-injection","dynamic-import","frontend","cwe-95"])
         ),
-
-        // ==================== ReDoS (CWE-1333) ====================
         (
             id: Some("js-redos-001"),
             name: Some("Potential ReDoS in regex with variables"),
             category: Some("redos"),
             mode: "search",
             patterns: Some([
-                "*RegExp(*user*)",
-                "*RegExp(*input*)",
-                "*RegExp(*data*)",
-                "*.match(*user*)",
-                "*.match(*input*)",
-                "*.replace(*user*)",
-                "*.replace(*input*)",
-                "*.search(*user*)",
-                "*.search(*input*)",
-                "*.split(*user*)",
-                "*.split(*input*)"
+                "*RegExp(*user*)","*RegExp(*input*)","*RegExp(*data*)",
+                "*.match(*user*)","*.match(*input*)",
+                "*.replace(*user*)","*.replace(*input*)",
+                "*.search(*user*)","*.search(*input*)",
+                "*.split(*user*)","*.split(*input*)"
             ]),
             finding_type: Some("Regular Expression DoS"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
-            description: Some("Dynamic regular expressions with user input can lead to ReDoS attacks"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["redos", "regex", "frontend", "cwe-1333"])
+            description: Some("Dynamic regex patterns can cause ReDoS"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            tags: Some(["redos","regex","frontend","cwe-1333"])
         ),
-
-        // ==================== Template Injection (CWE-1336) ====================
-        (
-            id: Some("js-template-injection-001"),
-            name: Some("Client-side template injection"),
-            category: Some("template-injection"),
-            mode: "search",
-            patterns: Some([
-                "*Handlebars.compile(*user*)",
-                "*Handlebars.compile(*input*)",
-                "*Handlebars.compile(*data*)",
-                "*_.template(*user*)",
-                "*_.template(*input*)",
-                "*_.template(*data*)",
-                "*Mustache.compile(*user*)",
-                "*Mustache.compile(*input*)",
-                "*Vue.compile(*user*)",
-                "*Vue.compile(*input*)"
-            ]),
-            finding_type: Some("Template Injection"),
-            severity: Some("High"),
-            confidence: Some("High"),
-            description: Some("Client-side template compilation with user input can lead to template injection"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["template-injection", "frontend", "cwe-1336"])
-        ),
-
-        // ==================== Dangerous URL Construction (CWE-601) ====================
         (
             id: Some("js-url-construction-001"),
             name: Some("Dangerous URL construction"),
             category: Some("url-manipulation"),
             mode: "search",
-            patterns: Some([
-                "*URL(*user*)",
-                "*URL(*input*)",
-                "*URL(*data*)"
-            ]),
+            patterns: Some(["*URL(*user*)","*URL(*input*)","*URL(*data*)"]),
             finding_type: Some("URL Manipulation"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
-            description: Some("Dynamic URL construction with user input can lead to various attacks"),
-            file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
-            )),
-            tags: Some(["url-manipulation", "frontend", "cwe-601"])
+            description: Some("Building URLs from untrusted data can be risky"),
+            file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            tags: Some(["url-manipulation","frontend","cwe-601"])
         )
     ]
-) 
+)

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -183,7 +183,25 @@
             description: Some("User input flows to output context without proper encoding, enabling XSS attacks"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["xss", "cwe-80", "frontend"])
@@ -197,32 +215,44 @@
             mode: "taint",
             
             sources: Some([
-                // Sensitive data sources
-                "password",
-                "token",
-                "apiKey",
-                "secret",
-                "privateKey",
-                "sessionId",
-                "authToken",
-                "accessToken",
-                "refreshToken",
-                "apiSecret",
-                "credentials",
+                // User input sources (DOM elements)
+                "document.getElementById(*).value",
+                "document.querySelector('input[type=password]').value",
+                "document.querySelector('input[name*=password]').value",
+                "document.querySelector('input[name*=token]').value",
+                "document.querySelector('input[name*=key]').value",
+                "document.querySelector('*[type=password]').value",
+                "document.getElementsByName('password')[0].value",
+                "document.getElementsByName('token')[0].value",
+                "document.forms.*.password.value",
+                "document.forms.*.token.value",
+                
+                // URL/location sources with sensitive data
+                "window.location.search",
+                "window.location.hash",
+                "new URLSearchParams(window.location.search).get('password')",
+                "new URLSearchParams(window.location.search).get('token')",
+                "new URLSearchParams(window.location.search).get('key')",
+                
+                // Storage sources
+                "localStorage.getItem('password')",
+                "localStorage.getItem('token')",
+                "localStorage.getItem('apiKey')",
+                "sessionStorage.getItem('password')",
+                "sessionStorage.getItem('token')",
+                "sessionStorage.getItem('apiKey')",
                 "*.cookie",
-                "localStorage.*",
-                "sessionStorage.*",
                 
-                // Environment/config
-                "process.env",
-                "config.*",
-                "settings.*",
-                
-                // Form inputs that might be sensitive
-                "*[type=password]*",
-                "*[name*=password]*",
-                "*[name*=token]*",
-                "*[name*=key]*"
+                // Environment/config (server-side or Node.js)
+                "process.env.PASSWORD",
+                "process.env.TOKEN",
+                "process.env.API_KEY",
+                "process.env.SECRET",
+                "config.password",
+                "config.token",
+                "config.apiKey",
+                "settings.password",
+                "settings.token"
             ]),
             
             sinks: Some([
@@ -276,7 +306,25 @@
             description: Some("Sensitive information may be exposed through logging, network requests, or URL parameters"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["information-disclosure", "cwe-200", "sensitive-data"])
@@ -354,7 +402,25 @@
             description: Some("User data is output without proper context-specific encoding"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["encoding", "cwe-116", "output-encoding"])
@@ -421,7 +487,25 @@
             description: Some("User input flows to template compilation/rendering without sanitization"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["template-injection", "cwe-1336", "client-side"])
@@ -503,7 +587,25 @@
             description: Some("User-controlled input flows to URL redirection without validation"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["open-redirect", "cwe-601", "redirect"])
@@ -572,7 +674,25 @@
             description: Some("postMessage data is used in dangerous operations without proper validation"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["postmessage", "cwe-1173", "origin-validation"])
@@ -628,7 +748,25 @@
             description: Some("postMessage data is processed without validating the message origin"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             conditions: Some([
@@ -873,7 +1011,25 @@
             description: Some("User-controlled input flows to code evaluation functions"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["code-injection", "cwe-95", "eval"])
@@ -938,7 +1094,25 @@
             description: Some("User input flows to regex operations without validation, potentially causing ReDoS"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["redos", "cwe-1333", "regex", "dos"])
@@ -1005,7 +1179,25 @@
             description: Some("Weak random values are used in security-sensitive contexts"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             tags: Some(["randomness", "cwe-338", "crypto"])
@@ -1077,7 +1269,25 @@
             description: Some("Sensitive data is transmitted over unencrypted connections"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"])
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
             )),
             
             conditions: Some([
@@ -1090,6 +1300,456 @@
             ]),
             
             tags: Some(["network", "cwe-319", "cleartext", "https"])
+        ),
+
+        // ==================== CWE-94: Code Injection via eval ====================
+        (
+            id: Some("js-code-injection-eval-taint-001"),
+            name: Some("Code Injection via eval"),
+            category: Some("code-injection"),
+            mode: "taint",
+            
+            sources: Some([
+                // User input sources
+                "window.location.*",
+                "location.*",
+                "document.URL",
+                "document.referrer",
+                "URLSearchParams",
+                "decodeURIComponent",
+                "decodeURI",
+                
+                // DOM input sources
+                "*.value",
+                "*.textContent",
+                "*.innerText",
+                "*.innerHTML",
+                "*.getAttribute",
+                "*.dataset",
+                
+                // Form and user interaction
+                "FormData",
+                "prompt(",
+                "confirm(",
+                
+                // Network responses
+                "*.responseText",
+                "*.response",
+                "fetch(",
+                "XMLHttpRequest",
+                "axios.*",
+                
+                // Storage (could contain user data)
+                "localStorage.getItem",
+                "sessionStorage.getItem",
+                "*.cookie",
+                
+                // PostMessage
+                "event.data",
+                "e.data",
+                "message.data"
+            ]),
+            
+            sinks: Some([
+                // Direct code execution
+                "eval(",
+                "Function(",
+                "new Function(",
+                
+                // Timed execution with string
+                "setTimeout(",
+                "setInterval(",
+                
+                // Dynamic imports
+                "import(",
+                "require(",
+                
+                // Script creation and execution
+                "document.createElement",
+                "*.src",
+                "*.appendChild"
+            ]),
+            
+            sanitizers: Some([
+                // Input validation
+                "validator.isAlphanumeric",
+                "validator.escape",
+                "sanitize(",
+                "validate(",
+                "clean(",
+                
+                // Safe parsing
+                "JSON.parse",
+                "parseInt(",
+                "parseFloat(",
+                
+                // Whitelist validation
+                "allowedFunctions.includes",
+                "whitelist.includes",
+                "isValidFunction"
+            ]),
+            
+            finding_type: Some("Code Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            
+            description: Some("User-controlled data flows to code execution functions without validation"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
+            )),
+            
+            tags: Some(["code-injection", "cwe-94", "cwe-95", "eval"])
+        ),
+
+        // ==================== CWE-601: Open Redirect ====================
+        (
+            id: Some("js-open-redirect-taint-001"),
+            name: Some("Open Redirect via Location Manipulation"),
+            category: Some("redirect"),
+            mode: "taint",
+            
+            sources: Some([
+                // URL parameters
+                "window.location.search",
+                "location.search",
+                "URLSearchParams",
+                "decodeURIComponent",
+                "decodeURI",
+                
+                // User input
+                "*.value",
+                "*.textContent",
+                "*.innerText",
+                "*.getAttribute",
+                "prompt(",
+                
+                // Form data
+                "FormData",
+                "*.dataset",
+                
+                // Network responses
+                "*.responseText",
+                "*.response",
+                "fetch(",
+                "XMLHttpRequest",
+                
+                // Storage
+                "localStorage.getItem",
+                "sessionStorage.getItem",
+                "*.cookie",
+                
+                // PostMessage
+                "event.data",
+                "e.data"
+            ]),
+            
+            sinks: Some([
+                // Location manipulation
+                "window.location",
+                "window.location.href",
+                "window.location.assign",
+                "window.location.replace",
+                "location.href",
+                "location.assign",
+                "location.replace",
+                "location.hash",
+                
+                // Navigation
+                "history.pushState",
+                "history.replaceState",
+                "*.href",
+                "*.src",
+                
+                // Form actions
+                "*.action",
+                "*.formAction",
+                
+                // Meta refresh
+                "document.createElement(\"meta\")",
+                "*.setAttribute(\"http-equiv\", \"refresh\")"
+            ]),
+            
+            sanitizers: Some([
+                // URL validation
+                "isValidURL",
+                "validateURL",
+                "URL.parse",
+                "new URL(",
+                
+                // Domain validation
+                "isAllowedDomain",
+                "whitelist.includes",
+                "allowedHosts.includes",
+                
+                // Relative URL enforcement
+                "startsWith(\"/\")",
+                "isRelativeURL",
+                "makeRelative"
+            ]),
+            
+            finding_type: Some("Open Redirect"),
+            severity: Some("Medium"),
+            confidence: Some("High"),
+            
+            description: Some("User-controlled data flows to navigation without validation, enabling open redirects"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
+            )),
+            
+            tags: Some(["open-redirect", "cwe-601", "navigation"])
+        ),
+
+        // ==================== CWE-95: Dynamic Code Loading ====================
+        (
+            id: Some("js-dynamic-import-taint-001"),
+            name: Some("Dynamic Code Loading with User Input"),
+            category: Some("code-injection"),
+            mode: "taint",
+            
+            sources: Some([
+                // User input sources
+                "window.location.*",
+                "location.*",
+                "URLSearchParams",
+                "decodeURIComponent",
+                
+                // DOM input
+                "*.value",
+                "*.textContent",
+                "*.getAttribute",
+                "*.dataset",
+                
+                // User interaction
+                "prompt(",
+                "FormData",
+                
+                // Network
+                "*.responseText",
+                "*.response",
+                "fetch(",
+                "XMLHttpRequest",
+                
+                // Storage
+                "localStorage.getItem",
+                "sessionStorage.getItem",
+                
+                // PostMessage
+                "event.data"
+            ]),
+            
+            sinks: Some([
+                // Dynamic imports
+                "import(",
+                "require(",
+                "requirejs(",
+                "System.import",
+                
+                // Module loading
+                "loadModule(",
+                "loadScript(",
+                "getScript(",
+                
+                // Script creation
+                "document.createElement(\"script\")",
+                "*.src",
+                "*.appendChild",
+                
+                // Dynamic loading libraries
+                "$.getScript",
+                "head.js",
+                "LABjs"
+            ]),
+            
+            sanitizers: Some([
+                // Path validation
+                "path.resolve",
+                "path.normalize",
+                "isValidModulePath",
+                "validatePath",
+                
+                // Whitelist validation
+                "allowedModules.includes",
+                "moduleWhitelist.includes",
+                "isAllowedModule",
+                
+                // Safe module resolution
+                "resolve(",
+                "sanitizePath"
+            ]),
+            
+            finding_type: Some("Dynamic Code Loading"),
+            severity: Some("High"),
+            confidence: Some("Medium"),
+            
+            description: Some("User-controlled module paths can lead to arbitrary code execution"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
+            )),
+            
+            tags: Some(["code-injection", "cwe-95", "dynamic-import"])
+        ),
+
+        // ==================== CWE-601: URL Manipulation ====================
+        (
+            id: Some("js-url-manipulation-taint-001"),
+            name: Some("URL Construction with User Input"),
+            category: Some("url-manipulation"),
+            mode: "taint",
+            
+            sources: Some([
+                // User input sources
+                "window.location.*",
+                "location.*",
+                "URLSearchParams",
+                "decodeURIComponent",
+                "decodeURI",
+                
+                // DOM input
+                "*.value",
+                "*.textContent",
+                "*.getAttribute",
+                "prompt(",
+                "FormData",
+                
+                // Network
+                "*.responseText",
+                "*.response",
+                
+                // Storage
+                "localStorage.getItem",
+                "sessionStorage.getItem",
+                
+                // PostMessage
+                "event.data"
+            ]),
+            
+            sinks: Some([
+                // URL construction
+                "new URL(",
+                "URL(",
+                "createObjectURL",
+                
+                // Network requests with URLs
+                "fetch(",
+                "XMLHttpRequest",
+                "axios.get",
+                "axios.post",
+                "$.ajax",
+                "$.get",
+                "$.post",
+                
+                // Navigation
+                "window.open",
+                "*.href",
+                "*.src",
+                "*.action",
+                
+                // Frame sources
+                "*.contentWindow.location"
+            ]),
+            
+            sanitizers: Some([
+                // URL validation
+                "isValidURL",
+                "validateURL",
+                "URL.parse",
+                
+                // Encoding
+                "encodeURIComponent",
+                "encodeURI",
+                
+                // Domain validation
+                "isAllowedDomain",
+                "isSameDomain",
+                "allowedHosts.includes"
+            ]),
+            
+            finding_type: Some("URL Manipulation"),
+            severity: Some("Medium"),
+            confidence: Some("Medium"),
+            
+            description: Some("User input flows to URL construction without validation"),
+            
+            file_types: Some((
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
+                exclude_patterns: Some([
+                    // Minified files
+                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
+                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
+                    "*-min.js", "*-bundle.js", "*-compiled.js",
+                    
+                    // Third-party library directories
+                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
+                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
+                    
+                    // Common library files by name
+                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
+                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
+                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
+                    
+                    // Test files
+                    "*test*", "*spec*", "*mock*"
+                ])
+            )),
+            
+            tags: Some(["url-manipulation", "cwe-601"])
         )
     ]
 ) 

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -50,7 +50,38 @@
                 // Storage (could contain user data)
                 "localStorage.getItem",
                 "sessionStorage.getItem",
-                "*.cookie"
+                "*.cookie",
+                
+                // Function parameters that commonly contain user input
+                "userInput",
+                "user_input", 
+                "input",
+                "data",
+                "content",
+                "htmlContent",
+                "html",
+                "text",
+                "value",
+                "param",
+                "parameter",
+                "args",
+                "arguments",
+                "lyrics",
+                "message",
+                "msg",
+                "comment",
+                "description",
+                "title",
+                "name",
+                
+                // Common variable names for user data
+                "req.body",
+                "req.query",
+                "req.params",
+                "request.*",
+                "params.*",
+                "query.*",
+                "body.*"
             ]),
             
             sinks: Some([
@@ -1346,8 +1377,7 @@
                 
                 // PostMessage
                 "event.data",
-                "e.data",
-                "message.data"
+                "e.data"
             ]),
             
             sinks: Some([
@@ -1455,11 +1485,9 @@
                 // Storage
                 "localStorage.getItem",
                 "sessionStorage.getItem",
-                "*.cookie",
                 
                 // PostMessage
-                "event.data",
-                "e.data"
+                "event.data"
             ]),
             
             sinks: Some([

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -82,8 +82,6 @@
                 // HTML encoding
                 "encodeHTML",
                 "escapeHTML", 
-                "*.textContent",
-                "document.createTextNode",
                 
                 // Validation
                 "DOMPurify.sanitize",
@@ -91,10 +89,6 @@
                 "sanitize(",
                 "validate(",
                 "clean(",
-                
-                // Safe DOM methods
-                "document.createElement",
-                "document.createTextNode"
             ]),
             
             finding_type: Some("DOM-based XSS"),
@@ -179,10 +173,7 @@
                 "validator.escape",
                 "encodeHTML",
                 "escapeHTML",
-                "sanitizeHTML",
-                "*.textContent",
-                "document.createTextNode",
-                "encodeURIComponent"
+                "sanitizeHTML"
             ]),
             
             finding_type: Some("Cross-Site Scripting"),

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -1242,23 +1242,138 @@
             mode: "taint",
             
             sources: Some([
-                // Sensitive data
-                "password",
-                "token",
-                "apiKey",
-                "secret",
-                "privateKey",
-                "sessionId",
-                "authToken",
-                "accessToken",
-                "credentials",
+                // Actual DOM element value access
+                "document.getElementById('password').value",
+                "document.getElementById('token').value",
+                "document.getElementById('apiKey').value",
+                "document.getElementById('secret').value",
+                "document.getElementById('privateKey').value",
+                "document.getElementById('sessionId').value",
+                "document.getElementById('authToken').value",
+                "document.getElementById('accessToken').value",
+                "document.getElementById('credentials').value",
                 
-                // Sensitive form fields
-                "*[type=password]*",
-                "*[name*=password]*",
-                "*[name*=token]*",
-                "*[name*=key]*",
-                "*[name*=secret]*"
+                // Query selector for sensitive form fields
+                "document.querySelector('input[type=password]').value",
+                "document.querySelector('input[name*=password]').value",
+                "document.querySelector('input[name*=token]').value",
+                "document.querySelector('input[name*=key]').value",
+                "document.querySelector('input[name*=secret]').value",
+                "document.querySelector('input[name*=apikey]').value",
+                "document.querySelector('input[name*=sessionid]').value",
+                "document.querySelector('input[name*=authtoken]').value",
+                "document.querySelector('input[name*=accesstoken]').value",
+                "document.querySelector('input[name*=credentials]').value",
+                
+                // getElementsByName for sensitive fields
+                "document.getElementsByName('password')[0].value",
+                "document.getElementsByName('token')[0].value",
+                "document.getElementsByName('apiKey')[0].value",
+                "document.getElementsByName('secret')[0].value",
+                "document.getElementsByName('privateKey')[0].value",
+                "document.getElementsByName('sessionId')[0].value",
+                "document.getElementsByName('authToken')[0].value",
+                "document.getElementsByName('accessToken')[0].value",
+                "document.getElementsByName('credentials')[0].value",
+                
+                // Form access patterns
+                "document.forms.*.password.value",
+                "document.forms.*.token.value",
+                "document.forms.*.apiKey.value",
+                "document.forms.*.secret.value",
+                "document.forms.*.privateKey.value",
+                "document.forms.*.sessionId.value",
+                "document.forms.*.authToken.value",
+                "document.forms.*.accessToken.value",
+                "document.forms.*.credentials.value",
+                
+                // FormData with sensitive field names
+                "FormData().get('password')",
+                "FormData().get('token')",
+                "FormData().get('apiKey')",
+                "FormData().get('secret')",
+                "FormData().get('privateKey')",
+                "FormData().get('sessionId')",
+                "FormData().get('authToken')",
+                "FormData().get('accessToken')",
+                "FormData().get('credentials')",
+                
+                // Local storage of sensitive data
+                "localStorage.getItem('password')",
+                "localStorage.getItem('token')",
+                "localStorage.getItem('apiKey')",
+                "localStorage.getItem('secret')",
+                "localStorage.getItem('privateKey')",
+                "localStorage.getItem('sessionId')",
+                "localStorage.getItem('authToken')",
+                "localStorage.getItem('accessToken')",
+                "localStorage.getItem('credentials')",
+                
+                // Session storage of sensitive data
+                "sessionStorage.getItem('password')",
+                "sessionStorage.getItem('token')",
+                "sessionStorage.getItem('apiKey')",
+                "sessionStorage.getItem('secret')",
+                "sessionStorage.getItem('privateKey')",
+                "sessionStorage.getItem('sessionId')",
+                "sessionStorage.getItem('authToken')",
+                "sessionStorage.getItem('accessToken')",
+                "sessionStorage.getItem('credentials')",
+                
+                // URL parameters containing sensitive data
+                "new URLSearchParams().get('password')",
+                "new URLSearchParams().get('token')",
+                "new URLSearchParams().get('key')",
+                "new URLSearchParams().get('secret')",
+                "new URLSearchParams().get('apiKey')",
+                "new URLSearchParams().get('privateKey')",
+                "new URLSearchParams().get('sessionId')",
+                "new URLSearchParams().get('authToken')",
+                "new URLSearchParams().get('accessToken')",
+                "new URLSearchParams().get('credentials')",
+                
+                // URLSearchParams with window.location
+                "new URLSearchParams(window.location.search).get('password')",
+                "new URLSearchParams(window.location.search).get('token')",
+                "new URLSearchParams(window.location.search).get('key')",
+                "new URLSearchParams(window.location.search).get('secret')",
+                "new URLSearchParams(window.location.search).get('apiKey')",
+                "new URLSearchParams(window.location.search).get('privateKey')",
+                "new URLSearchParams(window.location.search).get('sessionId')",
+                "new URLSearchParams(window.location.search).get('authToken')",
+                "new URLSearchParams(window.location.search).get('accessToken')",
+                "new URLSearchParams(window.location.search).get('credentials')",
+                
+                // Cookie values with sensitive names
+                "document.cookie.match(/password=/)",
+                "document.cookie.match(/token=/)",
+                "document.cookie.match(/session=/)",
+                "document.cookie.match(/apikey=/)",
+                "document.cookie.match(/secret=/)",
+                "document.cookie.match(/privatekey=/)",
+                "document.cookie.match(/authtoken=/)",
+                "document.cookie.match(/accesstoken=/)",
+                "document.cookie.match(/credentials=/)",
+                
+                // Authentication responses
+                "*.responseJSON.token",
+                "*.responseJSON.accessToken",
+                "*.responseJSON.refreshToken",
+                "*.responseJSON.apiKey",
+                "*.responseJSON.sessionId",
+                "*.responseJSON.authToken",
+                "*.responseJSON.privateKey",
+                "*.responseJSON.secret",
+                "*.responseJSON.credentials",
+                "*.response.data.token",
+                "*.response.data.accessToken",
+                "*.response.data.refreshToken",
+                "*.response.data.apiKey",
+                "*.response.data.sessionId",
+                "*.response.data.authToken",
+                "*.response.data.privateKey",
+                "*.response.data.secret",
+                "*.response.data.credentials"
             ]),
             
             sinks: Some([
@@ -1564,6 +1679,7 @@
             
             tags: Some(["open-redirect", "cwe-601", "navigation"])
         ),
+
 
         // ==================== CWE-95: Dynamic Code Loading ====================
         (

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -900,19 +900,19 @@
             ]),
             
             sinks: Some([
-                // Regex operations
+                // Regex operations 
                 "new RegExp(",
                 "RegExp(",
-                "*.match(",
-                "*.replace(",
-                "*.search(",
-                "*.split(",
+                "*.match(*",  // Only match when there's an argument
+                "*.replace(*",  // Only match when there's an argument
+                "*.search(*",  // Only match when there's an argument
+                "*.split(*",  // Only match when there's an argument
                 "*.test(",
                 "*.exec(",
                 
-                // String methods that use regex
-                "*.matchAll(",
-                "*.replaceAll("
+                // String methods that use regex - made more specific
+                "*.matchAll(*",
+                "*.replaceAll(*"
             ]),
             
             sanitizers: Some([

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -8,128 +8,170 @@
             mode: "taint",
             
             sources: Some([
-                // URL and location sources
+                // External/untrusted sources only - be more specific
                 "window.location.hash",
                 "window.location.search", 
-                "window.location.href",
-                "location.hash",
-                "location.search",
-                "location.href",
                 "document.URL",
                 "document.documentURI",
                 "document.baseURI",
                 
-                // URL parameter parsing
-                "URLSearchParams",
-                "new URL",
-                "decodeURIComponent",
-                "decodeURI",
+                // URL parameter parsing - actual user input
+                "URLSearchParams(*window.location*",
+                "new URLSearchParams(*window.location*",
+                "decodeURIComponent(*location.*",
+                "decodeURI(*location.*",
                 
-                // DOM input sources
-                "*.value",
-                "*.textContent", 
-                "*.innerText",
-                "*.innerHTML",
-                "*.getAttribute",
-                "*.dataset",
-                
-                // Form data
-                "FormData",
-                "*.files",
-                "*.selectedOptions",
+                // Form inputs (actual user input)
+                "document.querySelector('input').value",
+                "document.querySelector('textarea').value",
+                "document.getElementById(*).value",
+                "input.value",
+                "textarea.value",
                 
                 // User interaction
                 "prompt(",
                 "confirm(",
                 
-                // PostMessage
+                // PostMessage (external data)
                 "event.data",
                 "e.data",
                 "message.data",
                 
-                // Storage (could contain user data)
+                // Network responses (external data)
+                "*.responseText",
+                "*.response",
+                "fetch(*).then",
+                "XMLHttpRequest.responseText",
+                
+                // External storage (could be manipulated)
                 "localStorage.getItem",
                 "sessionStorage.getItem",
-                "*.cookie",
-                
-                // Function parameters that commonly contain user input
-                "userInput",
-                "user_input", 
-                "input",
-                "data",
-                "content",
-                "htmlContent",
-                "html",
-                "text",
-                "value",
-                "param",
-                "parameter",
-                "args",
-                "arguments",
-                "lyrics",
-                "message",
-                "msg",
-                "comment",
-                "description",
-                "title",
-                "name",
-                
-                // Common variable names for user data
-                "req.body",
-                "req.query",
-                "req.params",
-                "request.*",
-                "params.*",
-                "query.*",
-                "body.*"
+                "document.cookie"
             ]),
             
             sinks: Some([
-                // Direct DOM manipulation
+                // Dangerous HTML manipulation only
                 "*.innerHTML",
                 "*.outerHTML", 
                 "document.write",
                 "document.writeln",
                 "*.insertAdjacentHTML",
                 
-                // Script injection
-                "*.src",
-                "*.href",
-                "document.createElement",
+                // Script injection points - be more specific
+                "script.src",
+                "iframe.src",
                 
-                // Eval-like functions
+                // Code execution
                 "eval(",
                 "Function(",
-                "setTimeout(",
-                "setInterval(",
+                "setTimeout(",  // With string argument
+                "setInterval(",  // With string argument
                 
                 // Dynamic script loading
                 "import(",
-                "*.appendChild",
-                "*.insertBefore"
+                "document.createElement(\"script\").src"
             ]),
             
             sanitizers: Some([
-                // HTML encoding
+                // HTML sanitization
+                "DOMPurify.sanitize",
                 "encodeHTML",
                 "escapeHTML", 
+                "validator.escape",
+                
+                // Safe DOM methods
+                "*.textContent",  // Safe text assignment
+                "document.createTextNode",
+                
+                // Framework auto-escaping
+                "React.createElement",
+                "Vue.createTextVNode",
                 
                 // Validation
-                "DOMPurify.sanitize",
-                "validator.escape",
                 "sanitize(",
                 "validate(",
                 "clean(",
+                "escape("
             ]),
             
             finding_type: Some("DOM-based XSS"),
-            severity: Some("Critical"),
+            severity: Some("High"),
             confidence: Some("High"),
             
-            description: Some("User-controlled data flows to DOM manipulation without proper sanitization, enabling XSS attacks"),
+            description: Some("User input flows to dangerous DOM manipulation without sanitization"),
             
             file_types: Some((
                 extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            
+            conditions: Some([
+                // Exclude safe operations that commonly cause false positives
+                (
+                    field: "pattern",
+                    operator: "not_contains", 
+                    value: "addEventListener",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "querySelector",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "getElementById",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains", 
+                    value: "textContent",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "className",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "style.",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "console.",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "window.location.href",
+                    condition_type: Some("exclude_safe_location_reads")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "history.",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "createTextNode",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "DOMPurify.sanitize",
+                    condition_type: Some("exclude_safe_operations")
+                )
+            ]),
             
             tags: Some(["xss", "dom", "cwe-79", "frontend"])
         ),
@@ -142,77 +184,131 @@
             mode: "taint",
             
             sources: Some([
-                // All DOM-based sources plus additional
-                "window.location.*",
-                "location.*",
+                // External/untrusted sources - be more specific
+                "window.location.hash",
+                "window.location.search",
                 "document.URL",
                 "document.referrer",
-                "*.value",
-                "*.textContent",
-                "*.innerText", 
-                "*.getAttribute",
-                "FormData",
-                "URLSearchParams",
-                "prompt(",
-                "event.data",
-                "localStorage.*",
-                "sessionStorage.*",
-                "*.cookie",
+                "URLSearchParams(*window.location*",
+                "decodeURIComponent(*location.*",
+                "decodeURI(*location.*",
                 
-                // Network sources
-                "fetch(",
-                "XMLHttpRequest",
+                // Form inputs (actual user input)
+                "document.querySelector('input').value",
+                "document.querySelector('textarea').value",
+                "document.getElementById(*).value",
+                "input.value",
+                "textarea.value",
+                
+                // User interaction
+                "prompt(",
+                "confirm(",
+                
+                // PostMessage (external data)
+                "event.data",
+                
+                // Network responses (external data)
                 "*.responseText",
                 "*.response",
-                "axios.*",
-                "$.get",
-                "$.post",
-                "$.ajax"
+                "fetch(*).then",
+                "XMLHttpRequest.responseText",
+                "axios.*.then",
+                "$.get(*).done",
+                "$.post(*).done",
+                "$.ajax(*).done",
+                
+                // External storage
+                "localStorage.getItem",
+                "sessionStorage.getItem",
+                "document.cookie"
             ]),
             
             sinks: Some([
-                // DOM sinks
+                // Dangerous HTML manipulation
                 "*.innerHTML",
                 "*.outerHTML",
                 "document.write",
                 "document.writeln",
                 "*.insertAdjacentHTML",
                 
-                // Attribute sinks
-                "*.src",
-                "*.href", 
+                // Script injection points
+                "*.src",  // For script elements
+                "*.href", // For dangerous contexts
                 "*.action",
                 "*.formAction",
                 "*.setAttribute",
                 
-                // Event handler sinks
+                // Event handlers
                 "*.onclick",
                 "*.onload",
                 "*.onerror",
                 "addEventListener",
                 
-                // Template/rendering
+                // Template/rendering (dangerous)
                 "template.innerHTML",
                 "*.render",
                 "*.compile"
             ]),
             
             sanitizers: Some([
+                // HTML sanitization
                 "DOMPurify.sanitize",
                 "validator.escape",
                 "encodeHTML",
                 "escapeHTML",
-                "sanitizeHTML"
+                "sanitizeHTML",
+                
+                // Safe DOM methods
+                "*.textContent",
+                "document.createTextNode",
+                
+                // Framework auto-escaping
+                "React.createElement",
+                "Vue.createTextVNode"
             ]),
             
             finding_type: Some("Cross-Site Scripting"),
             severity: Some("High"),
             confidence: Some("High"),
             
-            description: Some("User input flows to output context without proper encoding, enabling XSS attacks"),
+            description: Some("User input flows to output context without proper encoding"),
             
             file_types: Some((
                 extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            
+            conditions: Some([
+                // Exclude safe DOM operations
+                (
+                    field: "pattern",
+                    operator: "not_contains", 
+                    value: "textContent",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "className", 
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "querySelector(",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "getElementById(",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "getAttribute(",
+                    condition_type: Some("exclude_safe_operations")
+                )
+            ]),
             
             tags: Some(["xss", "cwe-80", "frontend"])
         ),
@@ -472,65 +568,76 @@
             mode: "taint",
             
             sources: Some([
-                // URL parameters
-                "window.location.search",
-                "location.search",
-                "window.location.hash",
-                "location.hash",
-                "URLSearchParams",
-                "new URL",
+                // External/untrusted sources only
+                "event.data",              // PostMessage from external sources
+                "*.responseText",          // Network responses
+                "*.response",              // Network responses  
+                "prompt(",                 // User prompts
+                "*.value",                 // Form inputs (filtered by conditions)
                 
-                // User input
-                "*.value",
-                "prompt(",
-                "event.data",
+                // URL parameters - but only when accessed for external use
+                "new URLSearchParams(window.location.search).get",  // Specific parameter access
+                "decodeURIComponent",      // Decoded URL components
+                "decodeURI",              // Decoded URLs
                 
-                // Network responses
-                "*.responseText",
-                "*.response",
-                "*.location",
-                
-                // Storage
-                "localStorage.getItem",
-                "sessionStorage.getItem"
+                // External storage (could be manipulated)
+                "localStorage.getItem",    // Only if from external sources
+                "sessionStorage.getItem"   // Only if from external sources
             ]),
             
             sinks: Some([
-                // Direct navigation
-                "window.location",
+                // Direct navigation (high risk)
                 "window.location.href",
+                "window.location.assign", 
+                "window.location.replace",
                 "location.href",
                 "location.assign",
                 "location.replace",
                 "window.open",
                 
-                // Form actions
-                "*.action",
-                "*.formAction",
+                // External redirects
+                "*.href",                  // Link href attributes
+                "*.src",                   // Resource sources
+                "*.action",                // Form actions
+                "*.formAction",            // Form actions
                 
-                // Link modification
-                "*.href",
-                
-                // Meta refresh
-                "*.setAttribute(\"http-equiv\"",
-                "*.content"
+                // Meta refresh (high risk)
+                "*.setAttribute(\"http-equiv\", \"refresh\")"
             ]),
             
             sanitizers: Some([
-                // URL validation
-                "validateURL",
+                // URL validation functions
                 "isValidURL",
-                "sanitizeURL",
+                "validateURL", 
+                "isAllowedURL",
                 "whitelistURL",
+                "sanitizeURL",
                 
-                // Domain checking
-                "checkDomain",
-                "validateDomain",
+                // Domain validation
                 "isAllowedDomain",
+                "validateDomain",
+                "isSameDomain",
+                "allowedHosts.includes",
+                "whitelist.includes",
                 
-                // URL parsing for validation
-                "new URL(",
-                "URL.parse"
+                // URL construction with validation
+                "new URL(",               // URL constructor validates format
+                "URL.parse",
+                
+                // Relative URL enforcement
+                "startsWith(\"/\")",       // Relative URLs
+                "startsWith(\"./\")",      // Relative URLs
+                "isRelativeURL",
+                "makeRelative",
+                
+                // Same-origin checks
+                "location.origin",
+                "window.location.origin",
+                "document.domain",
+                
+                // Encoding (safe when used properly)
+                "encodeURIComponent",
+                "encodeURI"
             ]),
             
             finding_type: Some("Open Redirect"),
@@ -541,6 +648,58 @@
             
             file_types: Some((
                 extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
+            
+            conditions: Some([
+                // Exclude safe internal URL operations
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "window.location.search",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern", 
+                    operator: "not_contains",
+                    value: "location.search",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains", 
+                    value: "location.pathname",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "history.pushState",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "history.replaceState", 
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "URLSearchParams(window.location.search)",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "urlParams.toString()",
+                    condition_type: Some("exclude_safe_operations")
+                ),
+                (
+                    field: "pattern",
+                    operator: "not_contains",
+                    value: "encodeURIComponent(",
+                    condition_type: Some("exclude_safe_operations")
+                )
+            ]),
             
             tags: Some(["open-redirect", "cwe-601", "redirect"])
         ),
@@ -1298,8 +1457,12 @@
                 
                 // Script creation and execution
                 "document.createElement",
-                "*.src",
-                "*.appendChild"
+                "*.appendChild",
+                "*.insertBefore",
+                
+                // WebAssembly
+                "WebAssembly.compile",
+                "WebAssembly.instantiate"
             ]),
             
             sanitizers: Some([

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -129,9 +129,7 @@
             description: Some("User-controlled data flows to DOM manipulation without proper sanitization, enabling XSS attacks"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some(["*test*", "*spec*", "*mock*", "*.min.js"])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["xss", "dom", "cwe-79", "frontend"])
         ),
@@ -214,26 +212,7 @@
             description: Some("User input flows to output context without proper encoding, enabling XSS attacks"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["xss", "cwe-80", "frontend"])
         ),
@@ -337,26 +316,7 @@
             description: Some("Sensitive information may be exposed through logging, network requests, or URL parameters"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["information-disclosure", "cwe-200", "sensitive-data"])
         ),
@@ -433,26 +393,7 @@
             description: Some("User data is output without proper context-specific encoding"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["encoding", "cwe-116", "output-encoding"])
         ),
@@ -518,26 +459,7 @@
             description: Some("User input flows to template compilation/rendering without sanitization"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["template-injection", "cwe-1336", "client-side"])
         ),
@@ -618,26 +540,7 @@
             description: Some("User-controlled input flows to URL redirection without validation"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["open-redirect", "cwe-601", "redirect"])
         ),
@@ -705,26 +608,7 @@
             description: Some("postMessage data is used in dangerous operations without proper validation"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["postmessage", "cwe-1173", "origin-validation"])
         ),
@@ -779,26 +663,7 @@
             description: Some("postMessage data is processed without validating the message origin"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             conditions: Some([
                 (
@@ -950,9 +815,7 @@
             description: Some("Sensitive authentication or cryptographic data is stored in browser storage without proper encryption"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some(["*test*", "*spec*", "*mock*", "*.min.js", "*demo*", "*example*"])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             conditions: Some([
                 (
@@ -1042,26 +905,7 @@
             description: Some("User-controlled input flows to code evaluation functions"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["code-injection", "cwe-95", "eval"])
         ),
@@ -1125,26 +969,7 @@
             description: Some("User input flows to regex operations without validation, potentially causing ReDoS"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["redos", "cwe-1333", "regex", "dos"])
         ),
@@ -1210,26 +1035,7 @@
             description: Some("Weak random values are used in security-sensitive contexts"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["randomness", "cwe-338", "crypto"])
         ),
@@ -1415,26 +1221,7 @@
             description: Some("Sensitive data is transmitted over unencrypted connections"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             conditions: Some([
                 (
@@ -1541,26 +1328,7 @@
             description: Some("User-controlled data flows to code execution functions without validation"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["code-injection", "cwe-94", "cwe-95", "eval"])
         ),
@@ -1656,26 +1424,7 @@
             description: Some("User-controlled data flows to navigation without validation, enabling open redirects"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["open-redirect", "cwe-601", "navigation"])
         ),
@@ -1766,26 +1515,7 @@
             description: Some("User-controlled module paths can lead to arbitrary code execution"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["code-injection", "cwe-95", "dynamic-import"])
         ),
@@ -1872,26 +1602,7 @@
             description: Some("User input flows to URL construction without validation"),
             
             file_types: Some((
-                extensions: Some([".js", ".jsx", ".ts", ".tsx"]),
-                exclude_patterns: Some([
-                    // Minified files
-                    "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-                    "*.bundle.js", "*.chunk.js", "*.vendor.js", 
-                    "*-min.js", "*-bundle.js", "*-compiled.js",
-                    
-                    // Third-party library directories
-                    "*/node_modules/*", "*/assets/*", "*/lib/*", "*/vendor/*",
-                    "*/libraries/*", "*/deps/*", "*/dependencies/*",
-                    
-                    // Common library files by name
-                    "*three.js", "*three.min.js", "*jquery*.js", "*bootstrap*.js",
-                    "*angular*.js", "*react*.js", "*vue*.js", "*lodash*.js",
-                    "*moment*.js", "*d3*.js", "*chart*.js", "*dat.gui*.js",
-                    
-                    // Test files
-                    "*test*", "*spec*", "*mock*"
-                ])
-            )),
+                extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             
             tags: Some(["url-manipulation", "cwe-601"])
         )

--- a/rules/python/exclusion_patterns.ron
+++ b/rules/python/exclusion_patterns.ron
@@ -1,0 +1,39 @@
+// Centralized exclusion patterns for Python security rules
+// This file defines common exclusion patterns that can be referenced by all rules
+// to ensure consistency and reduce maintenance overhead
+
+(
+    frontend_exclusions: Some([
+        // Python frontend frameworks (Django templates, Flask templates)
+        "*/static/*", "*/assets/*", "*/media/*",
+        
+        // Framework test directories (but not our test files)
+        "*/site-packages/*/test/*", "*/site-packages/*/tests/*",
+        
+        "*docs/*", "*documentation/*"
+    ]),
+    
+    backend_exclusions: Some([
+        // Third-party dependencies
+        "*/site-packages/*", "*/dist-packages/*", "*/venv/*", "*/env/*",
+        "*/.venv/*", "*/.env/*", "*/virtualenv/*", "*/__pycache__/*",
+        "*/node_modules/*", "*/vendor/*", "*/lib/*", "*/libraries/*",
+        
+        // Framework test directories (but not our test files)
+        "*/site-packages/*/test/*", "*/site-packages/*/tests/*",
+        
+        // Build and configuration
+        "*build*", "*dist*", "*.egg-info/*", "setup.py", "setup.cfg",
+        "*migrations/*", "*alembic/*",
+        
+        // Documentation and metadata
+        "*readme*", "*license*", "*changelog*", "*contributing*",
+        "*docs/*", "*documentation/*"
+    ]),
+    
+    common_exclusions: Some([
+        "*/__pycache__/*", "*/venv/*", "*/env/*",
+        "*build*", "*dist*", "*.egg-info/*",
+        "*docs/*"
+    ])
+)

--- a/rules/python/sql_injection.ron
+++ b/rules/python/sql_injection.ron
@@ -25,7 +25,7 @@
             )),
             tags: Some(["sql", "dangerous", "injection", "keywords"])
         ),
-        
+
         // === COMPREHENSIVE TAINT RULE (General SQL injection data flows) ===
         (
             id: Some("python-sql-injection-comprehensive-taint"),
@@ -52,7 +52,6 @@
             )),
             tags: Some(["sql", "injection", "taint", "database", "critical", "data-flow"])
         ),
-        
 
     ]
 )

--- a/src/code_type_detector.rs
+++ b/src/code_type_detector.rs
@@ -1,0 +1,451 @@
+use std::collections::{HashMap, HashSet};
+use tree_sitter::{Node, Tree};
+use crate::parser;
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CodeType {
+    Frontend,
+    Backend,
+    Both,
+    Unknown,
+}
+
+impl CodeType {
+    pub fn from_string(s: &str) -> Option<CodeType> {
+        match s.to_lowercase().as_str() {
+            "frontend" => Some(CodeType::Frontend),
+            "backend" => Some(CodeType::Backend),
+            "both" => Some(CodeType::Both),
+            _ => None,
+        }
+    }
+
+    pub fn matches_filter(&self, filter: &CodeType) -> bool {
+        match filter {
+            CodeType::Both => true,
+            CodeType::Unknown => true,
+            _ => self == filter || *self == CodeType::Both,
+        }
+    }
+}
+
+pub struct FrameworkRegistry {
+    frameworks: HashMap<&'static str, FrameworkInfo>,
+}
+
+#[derive(Debug, Clone)]
+struct FrameworkInfo {
+    signatures: Vec<&'static str>,
+    code_type: CodeType,
+}
+
+impl FrameworkRegistry {
+    pub fn new() -> Self {
+        let mut frameworks = HashMap::new();
+
+        // Frontend frameworks
+        let frontend_frameworks = vec![
+            ("React", vec!["react", "react-dom"]),
+            ("Next.js", vec!["next/link", "next/router", "next/head", "@next/"]),
+            ("Angular", vec!["@angular/core"]),
+            ("Vue", vec!["vue", "vue-router"]),
+            ("Nuxt.js", vec!["nuxt", "@nuxtjs", "@nuxt/"]),
+            ("Svelte", vec!["svelte"]),
+            ("SvelteKit", vec!["@sveltejs/kit"]),
+            ("SolidJS", vec!["solid-js"]),
+            ("Qwik", vec!["@builder.io/qwik"]),
+            ("Ember", vec!["@ember"]),
+            ("Remix", vec!["@remix-run"]),
+            ("Astro", vec!["astro", "@astrojs/"]),
+            ("Gatsby", vec!["gatsby"]),
+            ("jQuery", vec!["jquery"]),
+            ("HTMX", vec!["htmx", "hx-"]),
+            ("Alpine.js", vec!["alpinejs", "alpine.js", "x-data"]),
+            ("Stimulus", vec!["@hotwired/stimulus"]),
+            ("TailwindCSS", vec!["tailwindcss"]),
+            ("Styled Components", vec!["styled-components"]),
+            ("Emotion", vec!["@emotion"]),
+            ("Material-UI", vec!["@mui/material", "@material-ui/core"]),
+            ("Ant Design", vec!["antd"]),
+            ("Chakra UI", vec!["@chakra-ui"]),
+            ("Redux", vec!["redux", "@reduxjs/toolkit"]),
+            ("Zustand", vec!["zustand"]),
+            ("Jotai", vec!["jotai"]),
+            ("Recoil", vec!["recoil"]),
+            ("MobX", vec!["mobx"]),
+            ("Pinia", vec!["pinia"]),
+            ("TanStack Query", vec!["@tanstack/react-query", "@tanstack/vue-query"]),
+            ("SWR", vec!["swr"]),
+            ("Vite", vec!["vite", "@vitejs/"]),
+            ("Webpack", vec!["webpack"]),
+            ("Rollup", vec!["rollup"]),
+            ("Parcel", vec!["parcel"]),
+            ("esbuild", vec!["esbuild"]),
+            ("SWC", vec!["@swc/"]),
+            ("Turbopack", vec!["turbopack"]),
+            ("Rspack", vec!["@rspack/"]),
+            ("Jest", vec!["jest"]),
+            ("Vitest", vec!["vitest", "@vitest/"]),
+            ("Cypress", vec!["cypress"]),
+            ("Playwright", vec!["playwright"]),
+            ("Testing Library", vec!["@testing-library/"]),
+            ("Storybook", vec!["@storybook/"]),
+            ("TensorFlow.js", vec!["@tensorflow/tfjs"]),
+            ("ML5.js", vec!["ml5"]),
+            ("Brain.js", vec!["brain.js"]),
+            ("Synaptic", vec!["synaptic"]),
+            ("Web3.js", vec!["web3"]),
+            ("Ethers.js", vec!["ethers"]),
+            ("Wagmi", vec!["wagmi"]),
+            ("RainbowKit", vec!["@rainbow-me/rainbowkit"]),
+            ("Moralis", vec!["moralis"]),
+            ("React Native", vec!["react-native"]),
+            ("Expo", vec!["expo", "@expo/"]),
+            ("Tauri", vec!["@tauri-apps/tauri"]),
+            ("Capacitor", vec!["@capacitor/core"]),
+            ("D3", vec!["d3"]),
+            ("Backbone", vec!["backbone"]),
+            ("Underscore", vec!["underscore"]),
+            ("Tipped", vec!["tipped"]),
+        ];
+
+        for (name, sigs) in frontend_frameworks {
+            frameworks.insert(name, FrameworkInfo {
+                signatures: sigs,
+                code_type: CodeType::Frontend,
+            });
+        }
+
+        // Backend frameworks
+        let backend_frameworks = vec![
+            ("Express", vec!["express"]),
+            ("Koa", vec!["koa"]),
+            ("Fastify", vec!["fastify"]),
+            ("NestJS", vec!["@nestjs/common", "@nestjs/core"]),
+            ("Hapi", vec!["@hapi/hapi"]),
+            ("Hono", vec!["hono"]),
+            ("tRPC", vec!["@trpc/server", "@trpc/client"]),
+            ("Elysia", vec!["elysia"]),
+            ("Prisma", vec!["prisma", "@prisma/client"]),
+            ("Drizzle", vec!["drizzle-orm"]),
+            ("TypeORM", vec!["typeorm"]),
+            ("Sequelize", vec!["sequelize"]),
+            ("Mongoose", vec!["mongoose"]),
+            ("Knex", vec!["knex"]),
+            ("MikroORM", vec!["@mikro-orm/core"]),
+            ("Vercel", vec!["@vercel/node", "@vercel/edge"]),
+            ("Netlify", vec!["@netlify/functions"]),
+            ("Cloudflare Workers", vec!["@cloudflare/workers-types"]),
+            ("AWS Lambda", vec!["aws-lambda"]),
+            ("Auth0", vec!["auth0", "@auth0/nextjs-auth0"]),
+            ("Supabase", vec!["@supabase/supabase-js"]),
+            ("Firebase", vec!["firebase"]),
+            ("Clerk", vec!["@clerk/nextjs"]),
+            ("NextAuth", vec!["next-auth"]),
+            ("Cheerio", vec!["cheerio"]),
+        ];
+
+        for (name, sigs) in backend_frameworks {
+            frameworks.insert(name, FrameworkInfo {
+                signatures: sigs,
+                code_type: CodeType::Backend,
+            });
+        }
+
+        Self { frameworks }
+    }
+
+    pub fn get_frontend_signatures(&self) -> HashSet<String> {
+        self.frameworks
+            .values()
+            .filter(|info| info.code_type == CodeType::Frontend)
+            .flat_map(|info| info.signatures.iter())
+            .map(|s| s.to_lowercase())
+            .collect()
+    }
+
+    pub fn get_backend_signatures(&self) -> HashSet<String> {
+        self.frameworks
+            .values()
+            .filter(|info| info.code_type == CodeType::Backend)
+            .flat_map(|info| info.signatures.iter())
+            .map(|s| s.to_lowercase())
+            .collect()
+    }
+
+    pub fn detect_from_frameworks(&self, imports: &[String]) -> CodeType {
+        let mut frontend_matches = 0;
+        let mut backend_matches = 0;
+
+        for (_, info) in &self.frameworks {
+            let has_match = info.signatures.iter().any(|sig| {
+                imports.iter().any(|imp| imp.to_lowercase().contains(&sig.to_lowercase()))
+            });
+
+            if has_match {
+                match info.code_type {
+                    CodeType::Frontend => frontend_matches += 1,
+                    CodeType::Backend => backend_matches += 1,
+                    _ => {}
+                }
+            }
+        }
+
+        if frontend_matches > 0 && backend_matches == 0 {
+            CodeType::Frontend
+        } else if backend_matches > 0 && frontend_matches == 0 {
+            CodeType::Backend
+        } else if frontend_matches > 0 && backend_matches > 0 {
+            CodeType::Both
+        } else {
+            CodeType::Unknown
+        }
+    }
+}
+
+pub struct CodeTypeDetector {
+    framework_registry: FrameworkRegistry,
+}
+
+impl CodeTypeDetector {
+    pub fn new() -> Self {
+        Self {
+            framework_registry: FrameworkRegistry::new(),
+        }
+    }
+
+    pub fn detect_code_type(&self, file_path: &str, content: &str, language: &str) -> CodeType {
+        // First try framework detection
+        let imports = self.extract_imports(content, language);
+        let framework_result = self.framework_registry.detect_from_frameworks(&imports);
+        
+        if framework_result != CodeType::Unknown {
+            return framework_result;
+        }
+
+        // Then try AST analysis for JavaScript/TypeScript
+        if matches!(language.to_lowercase().as_str(), "javascript" | "typescript" | "tsx") {
+            if let Ok(mut parser) = crate::parser::LanguageParser::new(language) {
+                if let Ok(tree) = parser.parse(content.as_bytes()) {
+                    let ast_result = self.detect_from_ast(&tree, content.as_bytes());
+                    if ast_result != CodeType::Unknown {
+                        return ast_result;
+                    }
+                }
+            }
+        }
+
+        // Import-based detection
+        let import_result = self.detect_from_imports(&imports);
+        if import_result != CodeType::Unknown {
+            return import_result;
+        }
+
+        // Default fallback based on language
+        match language.to_lowercase().as_str() {
+            "javascript" | "typescript" | "tsx" | "jsx" => CodeType::Frontend,
+            "python" | "java" | "rust" | "go" | "php" | "ruby" | "c" | "cpp" | "c#" | "csharp" => CodeType::Backend,
+            _ => CodeType::Unknown,
+        }
+    }
+
+    fn extract_imports(&self, content: &str, language: &str) -> Vec<String> {
+        let mut imports = Vec::new();
+
+        // Extract require() calls
+        let require_patterns = vec![
+            regex::Regex::new(r#"require\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap(),
+            regex::Regex::new(r#"import\s+.*from\s+['"]([^'"]+)['"]"#).unwrap(),
+            regex::Regex::new(r#"import\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap(),
+        ];
+
+        for pattern in require_patterns {
+            for cap in pattern.captures_iter(content) {
+                if let Some(module) = cap.get(1) {
+                    imports.push(module.as_str().to_lowercase());
+                }
+            }
+        }
+
+        imports
+    }
+
+    fn detect_from_ast(&self, tree: &Tree, source: &[u8]) -> CodeType {
+        let mut frontend_score = 0;
+        let mut backend_score = 0;
+
+        // Frontend signals
+        frontend_score += self.score_frontend_signals(tree, source);
+        
+        // Backend signals
+        backend_score += self.score_backend_signals(tree, source);
+
+        if frontend_score > 0 && backend_score == 0 {
+            CodeType::Frontend
+        } else if backend_score > 0 && frontend_score == 0 {
+            CodeType::Backend
+        } else if backend_score > frontend_score {
+            CodeType::Backend
+        } else if frontend_score > backend_score {
+            CodeType::Frontend
+        } else {
+            CodeType::Unknown
+        }
+    }
+
+    fn score_frontend_signals(&self, tree: &Tree, source: &[u8]) -> i32 {
+        let mut score = 0;
+        let root_node = tree.root_node();
+
+        // DOM methods
+        let dom_methods = vec![
+            "getElementById", "getElementsByClassName", "querySelector", "querySelectorAll",
+            "createElement", "appendChild", "addEventListener"
+        ];
+
+        // Browser objects
+        let browser_objects = vec![
+            "document", "window", "navigator", "localStorage", "sessionStorage",
+            "location", "history", "screen"
+        ];
+
+        // React hooks
+        let react_hooks = vec![
+            "useState", "useEffect", "useContext", "useReducer", "useMemo", "useCallback"
+        ];
+
+        // Check for call expressions
+        self.walk_tree(&root_node, &mut |node| {
+            if node.kind() == "call_expression" {
+                let text = parser::get_node_text(&node, source);
+                
+                // Check for DOM methods
+                for method in &dom_methods {
+                    if text.contains(method) {
+                        score += 2;
+                    }
+                }
+
+                // Check for React hooks
+                for hook in &react_hooks {
+                    if text.contains(hook) {
+                        score += 2;
+                    }
+                }
+
+                // Check for jQuery
+                if text.starts_with("$") || text.contains("jQuery") {
+                    score += 2;
+                }
+            }
+
+            // Check for member expressions with browser objects
+            if node.kind() == "member_expression" {
+                let text = parser::get_node_text(&node, source);
+                for obj in &browser_objects {
+                    if text.starts_with(obj) {
+                        score += 1;
+                    }
+                }
+            }
+
+            // Check for JSX
+            if node.kind().starts_with("jsx_") {
+                score += 3;
+            }
+        });
+
+        score
+    }
+
+    fn score_backend_signals(&self, tree: &Tree, source: &[u8]) -> i32 {
+        let mut score = 0;
+        let root_node = tree.root_node();
+
+        // Node.js core modules
+        let core_modules = vec![
+            "fs", "path", "http", "https", "crypto", "os", "util", "events"
+        ];
+
+        // Node.js globals
+        let node_globals = vec!["__dirname", "__filename", "module", "exports", "process"];
+
+        // Server methods
+        let server_methods = vec!["get", "post", "put", "delete", "patch", "use", "listen"];
+
+        self.walk_tree(&root_node, &mut |node| {
+            if node.kind() == "call_expression" {
+                let text = parser::get_node_text(&node, source);
+                
+                // Check for require calls with core modules
+                if text.starts_with("require(") {
+                    for module in &core_modules {
+                        if text.contains(&format!("'{}'", module)) || text.contains(&format!("\"{}\"", module)) {
+                            score += 3;
+                        }
+                    }
+                }
+
+                // Check for server methods
+                for method in &server_methods {
+                    if text.contains(&format!(".{}(", method)) {
+                        score += 2;
+                    }
+                }
+            }
+
+            // Check for Node.js globals
+            if node.kind() == "identifier" {
+                let text = parser::get_node_text(&node, source);
+                for global in &node_globals {
+                    if text == *global {
+                        score += 1;
+                    }
+                }
+            }
+        });
+
+        score
+    }
+
+    fn detect_from_imports(&self, imports: &[String]) -> CodeType {
+        let frontend_sigs = self.framework_registry.get_frontend_signatures();
+        let backend_sigs = self.framework_registry.get_backend_signatures();
+
+        let frontend_matches = imports.iter()
+            .filter(|imp| frontend_sigs.iter().any(|sig| imp.contains(sig)))
+            .count();
+
+        let backend_matches = imports.iter()
+            .filter(|imp| backend_sigs.iter().any(|sig| imp.contains(sig)))
+            .count();
+
+        if frontend_matches > 0 && backend_matches == 0 {
+            CodeType::Frontend
+        } else if backend_matches > 0 && frontend_matches == 0 {
+            CodeType::Backend
+        } else if frontend_matches > 0 && backend_matches > 0 {
+            CodeType::Both
+        } else {
+            CodeType::Unknown
+        }
+    }
+
+    fn walk_tree<F>(&self, node: &Node, callback: &mut F) 
+    where
+        F: FnMut(Node),
+    {
+        callback(*node);
+        
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            self.walk_tree(&child, callback);
+        }
+    }
+}
+
+impl Default for CodeTypeDetector {
+    fn default() -> Self {
+        Self::new()
+    }
+} 

--- a/src/common.rs
+++ b/src/common.rs
@@ -63,6 +63,19 @@ impl CommonUtils {
             return false;
         }
 
+        // Special handling for DOM property patterns like *.innerHTML
+        if pattern.starts_with("*.") {
+            let property = &pattern[2..]; // Remove "*."
+            
+            // Handle TypeScript casting syntax: (element.innerHTML as Type) = value
+            if text.contains(&format!(".{}", property)) {
+                // Check for assignment context
+                if text.contains('=') && !text.contains("==") && !text.contains("!=") {
+                    return true;
+                }
+            }
+        }
+
         Self::matches_unified_pattern(pattern, text)
     }
 
@@ -325,8 +338,25 @@ impl CommonUtils {
             variables.push(var);
         }
 
+        // Assignment variables (both sides)
+        if let Some(var) = Self::extract_variable_from_assignment(expr, false) {
+            variables.push(var);
+        }
+
+        // Extract variables from the right side of assignments
+        if let Some(eq_pos) = expr.find('=') {
+            let right_side = &expr[eq_pos + 1..].trim();
+            // Recursively extract from right side, but avoid infinite recursion
+            if !right_side.contains('=') || right_side.contains("==") {
+                variables.extend(Self::extract_simple_variables(right_side));
+            }
+        }
+
         // F-string variables: f"echo {user_input}"
         variables.extend(Self::extract_f_string_variables(expr));
+
+        // JavaScript/TypeScript template literals: `hello ${user_input}`
+        variables.extend(Self::extract_template_literal_variables(expr));
 
         // Format string variables: "echo {}".format(user_input)
         variables.extend(Self::extract_format_variables(expr));
@@ -337,7 +367,10 @@ impl CommonUtils {
         // Function call arguments: eval(user_input)
         variables.extend(Self::extract_function_arguments(expr).unwrap_or_default());
 
-        variables
+        // Remove duplicates and invalid names
+        variables.sort();
+        variables.dedup();
+        variables.into_iter().filter(|v| Self::is_valid_variable_name(v)).collect()
     }
 
     /// Extract direct variable from simple expressions
@@ -386,6 +419,9 @@ impl CommonUtils {
                                 if Self::is_valid_variable_name(clean_var) {
                                     log::debug!("[F_STRING_EXTRACT] Found variable: {}", clean_var);
                                     variables.push(clean_var.to_string());
+                                } else {
+                                    // For complex expressions, try to extract simple variables
+                                    variables.extend(Self::extract_simple_variables(clean_var));
                                 }
                             }
                         }
@@ -394,6 +430,58 @@ impl CommonUtils {
                 _ => {}
             }
             i += 1;
+        }
+
+        variables
+    }
+
+    /// Extract variables from JavaScript/TypeScript template literals
+    pub fn extract_template_literal_variables(expr: &str) -> Vec<String> {
+        log::debug!("[TEMPLATE_LITERAL_EXTRACT] Processing: '{}'", expr);
+        
+        let mut variables = Vec::new();
+        let mut dollar_brace_depth = 0usize;
+        let mut current_start: Option<usize> = None;
+        let chars: Vec<char> = expr.chars().collect();
+
+        let mut i = 0;
+        while i < chars.len() {
+            // Look for ${...} patterns
+            if i + 1 < chars.len() && chars[i] == '$' && chars[i + 1] == '{' {
+                dollar_brace_depth += 1;
+                if dollar_brace_depth == 1 {
+                    current_start = Some(i + 2); // Skip ${
+                }
+                i += 2;
+                continue;
+            }
+
+            if chars[i] == '{' && dollar_brace_depth > 0 {
+                dollar_brace_depth += 1;
+            } else if chars[i] == '}' && dollar_brace_depth > 0 {
+                dollar_brace_depth -= 1;
+                if dollar_brace_depth == 0 {
+                    if let Some(start) = current_start.take() {
+                        // Extract the expression inside ${}
+                        let raw_expr: String = chars[start..i].iter().collect();
+                        let raw_expr = raw_expr.trim();
+                        
+                        log::debug!("[TEMPLATE_LITERAL_EXTRACT] Found expression: '{}'", raw_expr);
+                        
+                        // Extract variables from the expression
+                        variables.extend(Self::extract_all_variables(raw_expr));
+                    }
+                }
+            }
+            
+            i += 1;
+        }
+
+        // Also extract assignment target if this is an assignment with template literal
+        if expr.contains('=') && expr.contains('`') {
+            if let Some(var) = Self::extract_variable_from_assignment(expr, false) {
+                variables.push(var);
+            }
         }
 
         variables

--- a/src/common.rs
+++ b/src/common.rs
@@ -286,6 +286,15 @@ impl CommonUtils {
             return expr.split('[').next().map(|s| s.trim().to_string());
         }
 
+        // Handle JavaScript declarations: const/let/var variable_name
+        let tokens: Vec<&str> = expr.split_whitespace().collect();
+        if tokens.len() >= 2 && matches!(tokens[0], "const" | "let" | "var") {
+            // Return the variable name after the declaration keyword
+            if Self::is_valid_variable_name(tokens[1]) {
+                return Some(tokens[1].to_string());
+            }
+        }
+
         // Extract final identifier from whitespace-separated expression
         expr.split_whitespace()
             .last()

--- a/src/language.rs
+++ b/src/language.rs
@@ -18,7 +18,7 @@ pub fn get_language_support(language_name: &str) -> Result<Box<dyn LanguageSuppo
         #[cfg(feature = "java")]
         "java" => Ok(Box::new(JavaLanguage)),
         #[cfg(feature = "javascript")]
-        "javascript" | "js" => Ok(Box::new(JavaScriptLanguage)),
+        "javascript" | "js" | "jsx" => Ok(Box::new(JavaScriptLanguage)),
         #[cfg(feature = "tsx")]
         "tsx" | "typescript-jsx" => Ok(Box::new(TSXLanguage)),
         #[cfg(feature = "html")]
@@ -141,7 +141,7 @@ pub struct TSXLanguage;
 #[cfg(feature = "tsx")]
 impl LanguageSupport for TSXLanguage {
     fn name(&self) -> &'static str { "tsx" }
-    fn file_extension(&self) -> &'static str { ".tsx" }
+    fn file_extension(&self) -> &'static str { ".tsx" } // Primary extension, but handles both .ts and .tsx
     fn tree_sitter_language(&self) -> Language { tree_sitter_typescript::LANGUAGE_TSX.into() }
     fn call_node_types(&self) -> &[&'static str] {
         &["call_expression", "new_expression", "jsx_expression", "jsx_attribute"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod models;
 pub mod parser;
 pub mod rules;
 pub mod scanner;
+pub mod code_type_detector;
 
 // Re-export the main types and functions that main.rs needs
 pub use scanner::{
@@ -18,6 +19,8 @@ pub use common::CommonUtils;
 pub use config::ScanDefaults;
 pub use rules::{Rules, match_pattern, check_for_injection_pattern};
 
+// Re-export code type detection
+pub use code_type_detector::{CodeTypeDetector, CodeType};
 
 // Re-export commonly used items from models
 pub use models::{

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,16 +9,8 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Initialize logger (respect RUST_LOG or --verbose flag)
-    if cli.verbose {
-        env_logger::Builder::from_default_env()
-            .filter_level(LevelFilter::Debug)
-            .init();
-    } else {
-        let _ = env_logger::Builder::from_default_env()
-            .filter_level(LevelFilter::Info)
-            .try_init();
-    }
-
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(if cli.verbose { "debug" } else { "info" }))
+        .init();
     // Configure threading if specified
     if let Some(threads) = cli.threads {
         rayon::ThreadPoolBuilder::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,12 @@ fn main() -> Result<()> {
 
     let start_time = std::time::Instant::now();
     
+    // Determine if we should show progress (suppress for structured output formats)
+    let show_progress = !matches!(cli.output_format.as_str(), "json" | "csv");
+    
     // Handle all vulnerability scanning modes with unified flow
     let findings = if cli.taint_analysis {
-        run_taint_analysis(&cli)?
+        run_taint_analysis(&cli, show_progress)?
     } else {
         // Validate CLI parameters using CommonUtils
         CommonUtils::validate_cli_params(&cli.language, &cli.rules_path)
@@ -36,17 +39,21 @@ fn main() -> Result<()> {
             ))?;
 
         match (&cli.language, &cli.rules_path) {
-            (Some(_), Some(_)) => run_explicit_scan(&cli)?,
-            (None, None) => run_auto_detection_scan(&cli)?,
+            (Some(_), Some(_)) => run_explicit_scan(&cli, show_progress)?,
+            (None, None) => run_auto_detection_scan(&cli, show_progress)?,
             _ => unreachable!(), // Validation above ensures this won't happen
         }
     };
 
     // Output results
     let duration = start_time.elapsed();
-    println!();
-    println!("⏱️  Scan completed in {:.2?}", duration);
-    println!();
+    
+    // Only show completion message for text output
+    if show_progress {
+        println!();
+        println!("⏱️  Scan completed in {:.2?}", duration);
+        println!();
+    }
 
     match cli.output_format.as_str() {
         "json" => print_findings_json(&findings),

--- a/src/models.rs
+++ b/src/models.rs
@@ -321,6 +321,14 @@ pub struct Cli {
     /// Skip minified JavaScript files (default: true)
     #[arg(long, help = "Skip minified JavaScript files during scanning")]
     pub skip_minified: Option<bool>,
+
+    /// Filter by code type (frontend, backend, or both)
+    #[arg(long, help = "Filter by code type: frontend, backend, or both (default: both)")]
+    pub code_type: Option<String>,
+
+    /// Filter by programming language
+    #[arg(long, help = "Filter by programming language: javascript, typescript, python, java, etc.")]
+    pub language_filter: Option<String>,
 }
 
 // Helper function for default search mode

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -3,13 +3,58 @@ use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
+
 use crate::language::LanguageSupport;
 use crate::common::CommonUtils;
 
 // Re-export for backward compatibility
 pub use crate::models::{UnifiedRule, FileTypes, Condition};
 
+// Structure for centralized exclusion patterns
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct ExclusionPatterns {
+    pub frontend_exclusions: Option<Vec<String>>,
+    pub backend_exclusions: Option<Vec<String>>,
+    pub common_exclusions: Option<Vec<String>>,
+}
 
+impl ExclusionPatterns {
+    pub fn load_from_file(file_path: &str) -> Result<Self> {
+        let content = fs::read_to_string(file_path)
+            .context(format!("Failed to read exclusion patterns file: {}", file_path))?;
+        
+        ron::from_str(&content).context("Failed to parse exclusion patterns RON")
+    }
+    
+    pub fn get_patterns(&self, pattern_type: &str) -> Vec<String> {
+        match pattern_type {
+            "frontend" => {
+                let mut patterns = Vec::new();
+                if let Some(common) = &self.common_exclusions {
+                    patterns.extend(common.clone());
+                }
+                if let Some(frontend) = &self.frontend_exclusions {
+                    patterns.extend(frontend.clone());
+                }
+                patterns
+            }
+            "backend" => {
+                let mut patterns = Vec::new();
+                if let Some(common) = &self.common_exclusions {
+                    patterns.extend(common.clone());
+                }
+                if let Some(backend) = &self.backend_exclusions {
+                    patterns.extend(backend.clone());
+                }
+                patterns
+            }
+            "common" => {
+                self.common_exclusions.clone().unwrap_or_default()
+            }
+            _ => Vec::new()
+        }
+    }
+}
 
 // Simple injection pattern checking for basic patterns
 pub fn check_for_injection_pattern(text: &str, _language_support: &dyn LanguageSupport) -> bool {
@@ -155,6 +200,59 @@ impl Rules {
         self.rules.iter().filter(|rule| {
             rule.category.as_ref().map(|c| c == category).unwrap_or(false)
         }).collect()
+    }
+
+    /// Apply centralized exclusion patterns to all rules
+    pub fn apply_centralized_exclusions(&mut self, exclusion_patterns: &ExclusionPatterns, pattern_type: &str) {
+        let patterns = exclusion_patterns.get_patterns(pattern_type);
+        
+        for rule in &mut self.rules {
+            if let Some(file_types) = &mut rule.file_types {
+                // If rule doesn't have exclusion patterns, add the centralized ones
+                if file_types.exclude_patterns.is_none() {
+                    file_types.exclude_patterns = Some(patterns.clone());
+                } else {
+                    // If rule has exclusion patterns, merge with centralized ones
+                    if let Some(existing_patterns) = &mut file_types.exclude_patterns {
+                        let mut merged_patterns = patterns.clone();
+                        merged_patterns.extend(existing_patterns.clone());
+                        *existing_patterns = merged_patterns;
+                    }
+                }
+            } else {
+                // If rule doesn't have file_types, create one with centralized exclusions
+                rule.file_types = Some(FileTypes {
+                    python: None,
+                    java: None,
+                    javascript: None,
+                    tsx: None,
+                    html: None,
+                    extensions: Some(vec![".js".to_string(), ".jsx".to_string(), ".ts".to_string(), ".tsx".to_string()]),
+                    include_patterns: None,
+                    exclude_patterns: Some(patterns.clone()),
+                });
+            }
+        }
+    }
+
+    /// Load rules from directory with centralized exclusions applied
+    pub fn load_from_directory_with_exclusions(rules_dir: &str, pattern_type: &str) -> Result<Self> {
+        let mut rules = Self::load_from_directory(rules_dir)?;
+        
+        // Try to load exclusion patterns from the same directory
+        let exclusion_file = format!("{}/exclusion_patterns.ron", rules_dir);
+        if Path::new(&exclusion_file).exists() {
+            match ExclusionPatterns::load_from_file(&exclusion_file) {
+                Ok(exclusion_patterns) => {
+                    rules.apply_centralized_exclusions(&exclusion_patterns, pattern_type);
+                }
+                Err(e) => {
+                    eprintln!("Warning: Failed to load exclusion patterns from {}: {}", exclusion_file, e);
+                }
+            }
+        }
+        
+        Ok(rules)
     }
 }
 

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -764,7 +764,8 @@ impl ScanningLogic {
     fn collect_all_relevant_nodes<'a>(node: tree_sitter::Node<'a>, nodes: &mut Vec<tree_sitter::Node<'a>>, source: Option<&[u8]>) {
         // Include assignment and call nodes
         match node.kind() {
-            "assignment" | "call" | "expression_statement" | "assignment_expression" => {
+            "assignment" | "call" | "expression_statement" | "assignment_expression" |
+            "variable_declaration" | "lexical_declaration" | "variable_declarator" => {
                 // Apply source filtering if provided
                 if let Some(source_bytes) = source {
                     let node_text = crate::parser::get_node_text(&node, source_bytes);

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -598,8 +598,19 @@ impl ScanningLogic {
     ) -> Vec<crate::models::Finding> {
         let mut findings = Vec::new();
 
+        // Filter out rules that don't apply to this file (same as search rules)
+        let applicable_rules: Vec<&crate::rules::UnifiedRule> = taint_rules.iter()
+            .filter(|rule| crate::scanner::utils::rule_applies_to_file(rule.file_types.as_ref(), filepath))
+            .copied()
+            .collect();
+
+        // If no rules apply to this file, return empty findings
+        if applicable_rules.is_empty() {
+            return findings;
+        }
+
         // Create rule deduplicator to prevent cartesian product problems
-        let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
+        let rule_deduplicator = TaintRuleDeduplicator::new(&applicable_rules);
 
         // Create variable flow tracker for legitimate flows only
         let mut flow_tracker = VariableFlowTracker::new();
@@ -1440,13 +1451,17 @@ impl VulnerabilityScanner {
 
         // Phase 2: Multi-file taint analysis (NEW functionality)
         let mut cross_file_findings = Vec::new();
-        if has_taint_rules && filtered_files.len() > 1 {
+        // FIXED: Skip cross-file analysis for frontend scans as it's primarily designed for Backend projects
+        // and causes major performance issues with JavaScript/TypeScript projects
+        let should_skip_cross_file = code_type_filter == Some("frontend");
+        
+        if has_taint_rules && filtered_files.len() > 1 && !should_skip_cross_file {
             if show_progress {
                 log::info!("Performing cross-file taint analysis...");
             }
 
             let mut multi_file_analyzer = MultiFileTaintAnalyzer::new();
-            match multi_file_analyzer.analyze_cross_file_flows(&files_by_language, &taint_rules) {
+            match multi_file_analyzer.analyze_cross_file_flows(&files_by_language, &taint_rules, language_filter) {
                 Ok(findings) => {
                     cross_file_findings = findings;
                     if show_progress && !cross_file_findings.is_empty() {
@@ -1459,6 +1474,8 @@ impl VulnerabilityScanner {
                     }
                 }
             }
+        } else if should_skip_cross_file && show_progress {
+            log::info!("Skipping cross-file taint analysis for frontend scan (performance optimization)");
         }
 
         // Stop progress tracking (reuse existing infrastructure)
@@ -1515,6 +1532,17 @@ impl ScanningLogic {
     ) -> Vec<crate::models::Finding> {
         let mut findings = Vec::new();
         let mut processed_lines = std::collections::HashSet::new();
+
+        // Filter search rules that don't apply to this file (same as taint rules)
+        let applicable_search_rules: Vec<&crate::rules::UnifiedRule> = search_rules.iter()
+            .filter(|rule| crate::scanner::utils::rule_applies_to_file(rule.file_types.as_ref(), filepath))
+            .copied()
+            .collect();
+
+        // If no search rules apply to this file, return empty findings
+        if applicable_search_rules.is_empty() {
+            return findings;
+        }
 
         // Create taint rule deduplicator to leverage taint context
         let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
@@ -1584,7 +1612,7 @@ impl ScanningLogic {
 
         for node in call_nodes.iter() {
             if let Some(func_name) = language_support.get_function_name(node, source) {
-                let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> = search_rules.iter().enumerate()
+                let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> = applicable_search_rules.iter().enumerate()
                     .filter(|(_, rule)| ScanningLogic::rule_might_match_function(*rule, &func_name))
                     .map(|(idx, rule)| (idx, *rule))
                     .collect();
@@ -2269,21 +2297,51 @@ impl MultiFileTaintAnalyzer {
         &mut self,
         files_by_language: &std::collections::HashMap<String, Vec<std::path::PathBuf>>,
         taint_rules: &[&crate::rules::UnifiedRule],
+        language_filter: Option<&str>,
     ) -> Result<Vec<crate::models::Finding>> {
         log::debug!("[CROSS_FILE_NEW] Starting enhanced cross-file taint analysis");
 
-        // Get all Python files for analysis
-        let python_files = files_by_language.get("python").cloned().unwrap_or_default();
+        // UPDATED: Check language_filter first, then fall back to original logic
+        let mut target_files = Vec::new();
+        let mut target_language = None;
         
-        // Initialize the new DataFlowTracer
+        // If language_filter is specified, use that language exclusively
+        if let Some(filter_lang) = language_filter {
+            if let Some(filtered_files) = files_by_language.get(filter_lang) {
+                if !filtered_files.is_empty() {
+                    target_files.extend(filtered_files.clone());
+                    target_language = Some(filter_lang);
+                    log::debug!("[CROSS_FILE_NEW] Using language_filter: {} ({} files)", filter_lang, filtered_files.len());
+                }
+            }
+        } else {
+            
+            if let Some(python_files) = files_by_language.get("python") {
+                if !python_files.is_empty() {
+                    target_files.extend(python_files.clone());
+                    target_language = Some("python");
+                }
+            }
+        }
+        // If still no files, skip cross-file analysis
+        if target_files.is_empty() {
+            log::debug!("[CROSS_FILE_NEW] No suitable files found for cross-file analysis");
+            return Ok(Vec::new());
+        }
+        
+        let language = target_language.unwrap();
+        log::debug!("[CROSS_FILE_NEW] Analyzing {} {} files for cross-file taint flows", 
+            target_files.len(), language);
+        
+        // Initialize the new DataFlowTracer with the appropriate language files
         let mut data_flow_tracer = DataFlowTracer::new();
-        data_flow_tracer.initialize(&python_files, taint_rules)?;
+        data_flow_tracer.initialize(&target_files, taint_rules)?;
 
         let mut findings = Vec::new();
         let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
 
         // Build legacy import/export maps for sink discovery (temporary)
-        self.build_import_export_maps(files_by_language, taint_rules)?;
+        self.build_import_export_maps(files_by_language, taint_rules, language_filter)?;
 
         log::debug!("[CROSS_FILE_NEW] Analyzing {} files with sinks", self.file_imports.len());
 
@@ -2380,18 +2438,21 @@ impl MultiFileTaintAnalyzer {
         &mut self,
         files_by_language: &std::collections::HashMap<String, Vec<std::path::PathBuf>>,
         taint_rules: &[&crate::rules::UnifiedRule],
+        language_filter: Option<&str>,
     ) -> Result<()> {
         let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
 
-        for (language, files) in files_by_language {
-            if language == "python" {
+        // UPDATED: Use same logic as analyze_cross_file_flows
+        if let Some(filter_lang) = language_filter {
+            // If language_filter is specified, use that language exclusively
+            if let Some(files) = files_by_language.get(filter_lang) {
                 for file_path in files {
                     let filepath = file_path.to_string_lossy();
                     let source = std::fs::read(file_path)?;
 
-                    crate::scanner::core::with_local_parser(language, |parser| {
+                    crate::scanner::core::with_local_parser(filter_lang, |parser| {
                         let tree = parser.parse(&source)?;
-                        let language_support = crate::language::get_language_support(language)?;
+                        let language_support = crate::language::get_language_support(filter_lang)?;
 
                         self.analyze_file_imports_exports(
                             &filepath,
@@ -2403,6 +2464,31 @@ impl MultiFileTaintAnalyzer {
 
                         Ok(())
                     })?;
+                }
+            }
+        } else {
+            // Original fallback logic: process JavaScript and Python files
+            for (language, files) in files_by_language {
+                if language == "javascript" || language == "python" {
+                    for file_path in files {
+                        let filepath = file_path.to_string_lossy();
+                        let source = std::fs::read(file_path)?;
+
+                        crate::scanner::core::with_local_parser(language, |parser| {
+                            let tree = parser.parse(&source)?;
+                            let language_support = crate::language::get_language_support(language)?;
+
+                            self.analyze_file_imports_exports(
+                                &filepath,
+                                &source,
+                                &tree,
+                                &rule_deduplicator,
+                                language_support.as_ref(),
+                            );
+
+                            Ok(())
+                        })?;
+                    }
                 }
             }
         }
@@ -3597,7 +3683,20 @@ impl DataFlowTracer {
         let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
         for file_path in files {
             if let Ok(source) = std::fs::read(file_path) {
-                with_local_parser("python", |parser| {
+                // FIXED: Determine language from file extension instead of hardcoding Python
+                let language = if file_path.extension().and_then(|ext| ext.to_str()) == Some("py") {
+                    "python"
+                } else if let Some(ext) = file_path.extension().and_then(|ext| ext.to_str()) {
+                    if ext == "js" || ext == "jsx" || ext == "ts" || ext == "tsx" {
+                        "javascript"
+                    } else {
+                        continue; // Skip unsupported file types
+                    }
+                } else {
+                    continue; // Skip files without extensions
+                };
+
+                with_local_parser(language, |parser| {
                     let tree = parser.parse(&source)?;
                     self.function_analyzer.analyze_file_functions(
                         &file_path.to_string_lossy(),

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -250,7 +250,7 @@ impl ScanningLogic {
             }
         }
 
-        if language_support.name() == "javascript" || language_support.name() == "typescript" {
+        if language_support.name() == "javascript" || language_support.name() == "typescript" || language_support.name() == "tsx" {
             Self::scan_assignments(tree.root_node(), source, filepath, rules, language_support, &mut findings, &mut processed_lines);
         }
 
@@ -285,11 +285,13 @@ impl ScanningLogic {
         findings: &mut Vec<crate::models::Finding>,
         processed_lines: &mut std::collections::HashSet<(usize, String, String)>,
     ) {
-        if matches!(node.kind(), "assignment_expression" | "expression_statement") {
+        if matches!(node.kind(), "assignment_expression" | "expression_statement" | "member_expression") {
             let node_text = crate::parser::get_node_text(&node, source);
 
-            if CommonUtils::is_valid_assignment_text(&node_text) {
-                let assignment_target = CommonUtils::extract_variable_from_assignment(&node_text, true).unwrap_or_default();
+            // Check for direct assignment patterns (e.g., element.innerHTML = value)
+            if CommonUtils::is_valid_assignment_text(&node_text) || Self::is_dom_assignment(&node_text) {
+                let assignment_target = CommonUtils::extract_variable_from_assignment(&node_text, true)
+                    .unwrap_or_else(|| Self::extract_assignment_target(&node_text));
 
                 for rule in assignment_rules {
                     if Self::rule_might_match_assignment(rule, &node_text) {
@@ -321,26 +323,32 @@ impl ScanningLogic {
     fn rule_has_assignment_patterns(rule: &crate::rules::UnifiedRule) -> bool {
         const ASSIGNMENT_INDICATORS: &[&str] = &[
             "innerHTML", "outerHTML", "location", "localStorage", 
-            "sessionStorage", "__proto__", "=", "prototype"
+            "sessionStorage", "__proto__", "=", "prototype",
+            "src", "href", "textContent", "setAttribute",
+            "document.write", "insertAdjacentHTML"
         ];
 
         let check_pattern = |pattern: &str| {
             ASSIGNMENT_INDICATORS.iter().any(|indicator| pattern.contains(indicator))
         };
 
+        // Also check if this is a taint rule with sinks
+        let has_taint_sinks = rule.sinks.as_ref().map_or(false, |sinks| !sinks.is_empty());
+        
         if let Some(patterns) = &rule.patterns {
-            patterns.iter().any(|p| check_pattern(p))
+            patterns.iter().any(|p| check_pattern(p)) || has_taint_sinks
         } else if let Some(pattern) = &rule.pattern {
-            check_pattern(pattern)
+            check_pattern(pattern) || has_taint_sinks
         } else {
-            false
+            has_taint_sinks
         }
     }
 
     fn rule_might_match_assignment(rule: &crate::rules::UnifiedRule, node_text: &str) -> bool {
         const ASSIGNMENT_INDICATORS: &[&str] = &[
             "innerHTML", "outerHTML", "location", "localStorage", 
-            "sessionStorage", "__proto__", "="
+            "sessionStorage", "__proto__", "=", "src", "href", 
+            "textContent", "setAttribute"
         ];
 
         let check_and_match = |pattern: &str| {
@@ -348,12 +356,50 @@ impl ScanningLogic {
             CommonUtils::matches_rule_pattern(pattern, node_text)
         };
 
+        // Check if this is a taint rule with sinks that match the assignment
+        if let Some(sinks) = &rule.sinks {
+            for sink in sinks {
+                if CommonUtils::matches_rule_pattern(sink, node_text) {
+                    return true;
+                }
+            }
+        }
+
         if let Some(patterns) = &rule.patterns {
             patterns.iter().any(|p| check_and_match(p))
         } else if let Some(pattern) = &rule.pattern {
             check_and_match(pattern)
         } else {
             false
+        }
+    }
+
+    /// Check if the text represents a DOM assignment (innerHTML, outerHTML, etc.)
+    fn is_dom_assignment(text: &str) -> bool {
+        const DOM_ASSIGNMENT_PATTERNS: &[&str] = &[
+            ".innerHTML", ".outerHTML", ".textContent", ".innerText",
+            ".src", ".href", ".setAttribute", ".insertAdjacentHTML"
+        ];
+        
+        // Check for direct assignment or TypeScript casting assignment
+        let has_assignment = text.contains('=') && !text.contains("==") && !text.contains("!=");
+        let has_dom_property = DOM_ASSIGNMENT_PATTERNS.iter().any(|pattern| text.contains(pattern));
+        
+        has_assignment && has_dom_property
+    }
+
+    /// Extract assignment target from complex assignment expressions
+    fn extract_assignment_target(text: &str) -> String {
+        if let Some(eq_pos) = text.find('=') {
+            let left_side = text[..eq_pos].trim();
+            // For expressions like "element.innerHTML", extract "element"
+            if let Some(dot_pos) = left_side.rfind('.') {
+                left_side[..dot_pos].trim().to_string()
+            } else {
+                left_side.to_string()
+            }
+        } else {
+            text.trim().to_string()
         }
     }
 
@@ -570,6 +616,38 @@ impl ScanningLogic {
             let line = node.start_position().row + 1;
             let func_name = crate::scanner::utils::AstUtils::get_function_context(node, source);
 
+            // Check for function definitions and mark parameters as potential taint sources
+            log::debug!("[FUNCTION_CHECK] Checking node kind '{}' for function definitions", node.kind());
+            if matches!(node.kind(), 
+                "function_definition" | "function_declaration" | "method_definition" |
+                "arrow_function" | "function_expression" | "generator_function" |
+                "async_function" | "constructor_definition") {
+                log::debug!("[FUNCTION_PARAM_ANALYSIS] Found function definition: {}", node.kind());
+                if let Some(params) = Self::extract_function_parameters(node, source) {
+                    log::debug!("[FUNCTION_PARAM_ANALYSIS] Extracted parameters: {:?}", params);
+                    for param in params {
+                        // Check if parameter name matches any taint source pattern
+                        log::debug!("[FUNCTION_PARAM_ANALYSIS] Checking parameter '{}' against source patterns", param);
+                        if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(&param) {
+                            log::debug!("[FUNCTION_PARAM_ANALYSIS] Function parameter '{}' matches source pattern '{}'", param, source_pattern);
+                            flow_tracker.record_tainted_variable(
+                                param.clone(),
+                                TaintVariableInfo {
+                                    source_line: line,
+                                    source_pattern,
+                                    source_function: func_name.clone(),
+                                    assignment_code: format!("function parameter: {}", param),
+                                }
+                            );
+                        } else {
+                            log::debug!("[FUNCTION_PARAM_ANALYSIS] Function parameter '{}' does not match any source pattern", param);
+                        }
+                    }
+                } else {
+                    log::debug!("[FUNCTION_PARAM_ANALYSIS] No parameters extracted from function");
+                }
+            }
+
             // Look for assignment patterns: var = source_call()
             if CommonUtils::is_valid_assignment_text(&node_text) {
                 if let Some(var_name) = CommonUtils::extract_variable_from_assignment(&node_text, false) {
@@ -690,10 +768,17 @@ impl ScanningLogic {
                 // Check if right side has F-string propagation
                 if right_side.contains('{') && right_side.contains('}') {
                     log::debug!("   Right side contains f-string braces");
-                    let dependent_vars = CommonUtils::extract_f_string_variables(right_side);
-                    log::debug!("   Extracted dependent_vars from f-string: {:?}", dependent_vars);
+                    let mut dependent_vars = CommonUtils::extract_f_string_variables(right_side);
+                    
+                    // Also check for JavaScript/TypeScript template literals
+                    if right_side.contains("${") {
+                        log::debug!("   Right side contains template literal interpolation");
+                        dependent_vars.extend(CommonUtils::extract_template_literal_variables(right_side));
+                    }
+                    
+                    log::debug!("   Extracted dependent_vars from interpolation: {:?}", dependent_vars);
                     if !dependent_vars.is_empty() && CommonUtils::is_valid_variable_name(left_side) {
-                        log::debug!("[PROPAGATION_CHECK] F-string assignment propagation detected: '{}' depends on {:?}", left_side, dependent_vars);
+                        log::debug!("[PROPAGATION_CHECK] Template/F-string assignment propagation detected: '{}' depends on {:?}", left_side, dependent_vars);
                         return Some((left_side.to_string(), dependent_vars));
                     }
                 }
@@ -753,6 +838,102 @@ impl ScanningLogic {
         None
     }
 
+    /// Extract function parameters from function definition node
+    fn extract_function_parameters(func_node: &tree_sitter::Node, source: &[u8]) -> Option<Vec<String>> {
+        let mut parameters = Vec::new();
+        let mut cursor = func_node.walk();
+        
+        // Look for parameter list in function definition
+        if cursor.goto_first_child() {
+            loop {
+                let node = cursor.node();
+                
+                // Check for formal_parameters, parameter_list, or arguments
+                if node.kind() == "formal_parameters" || node.kind() == "parameter_list" || node.kind() == "arguments" {
+                    let mut param_cursor = node.walk();
+                    if param_cursor.goto_first_child() {
+                        loop {
+                            let param_node = param_cursor.node();
+                            
+                            // Skip punctuation like parentheses and commas
+                            if param_node.kind() != "(" && param_node.kind() != ")" && param_node.kind() != "," {
+                                // Handle different parameter node types
+                                let param_text = match param_node.kind() {
+                                    "identifier" => {
+                                        // Simple parameter: function(param)
+                                        crate::parser::get_node_text(&param_node, source)
+                                    }
+                                    "parameter" => {
+                                        // TypeScript parameter: function(param: type)
+                                        Self::extract_parameter_name(&param_node, source)
+                                    }
+                                    "required_parameter" | "optional_parameter" => {
+                                        // TypeScript parameter variants
+                                        Self::extract_parameter_name(&param_node, source)
+                                    }
+                                    _ => {
+                                        // Try to extract identifier from complex parameter
+                                        Self::extract_parameter_name(&param_node, source)
+                                    }
+                                };
+                                
+                                if !param_text.is_empty() && CommonUtils::is_valid_variable_name(&param_text) {
+                                    parameters.push(param_text);
+                                }
+                            }
+                            
+                            if !param_cursor.goto_next_sibling() {
+                                break;
+                            }
+                        }
+                    }
+                    break;
+                }
+                
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+        
+        if parameters.is_empty() {
+            None
+        } else {
+            Some(parameters)
+        }
+    }
+
+    /// Extract parameter name from complex parameter node
+    fn extract_parameter_name(param_node: &tree_sitter::Node, source: &[u8]) -> String {
+        let mut cursor = param_node.walk();
+        
+        // Look for identifier child node
+        if cursor.goto_first_child() {
+            loop {
+                let node = cursor.node();
+                if node.kind() == "identifier" {
+                    return crate::parser::get_node_text(&node, source);
+                }
+                
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+        
+        // Fallback: use the whole node text and try to extract identifier
+        let full_text = crate::parser::get_node_text(param_node, source);
+        if let Some(colon_pos) = full_text.find(':') {
+            // TypeScript parameter with type annotation: "param: string"
+            full_text[..colon_pos].trim().to_string()
+        } else if let Some(equals_pos) = full_text.find('=') {
+            // Parameter with default value: "param = default"
+            full_text[..equals_pos].trim().to_string()
+        } else {
+            full_text.trim().to_string()
+        }
+    }
+
 
 
 
@@ -765,7 +946,11 @@ impl ScanningLogic {
         // Include assignment and call nodes
         match node.kind() {
             "assignment" | "call" | "expression_statement" | "assignment_expression" |
-            "variable_declaration" | "lexical_declaration" | "variable_declarator" => {
+            "variable_declaration" | "lexical_declaration" | "variable_declarator" |
+            "function_definition" | "function_declaration" | "method_definition" |
+            "arrow_function" | "function_expression" | "generator_function" |
+            "async_function" | "constructor_definition" | "template_literal" | 
+            "template_string" | "template_substitution" => {
                 // Apply source filtering if provided
                 if let Some(source_bytes) = source {
                     let node_text = crate::parser::get_node_text(&node, source_bytes);
@@ -779,8 +964,8 @@ impl ScanningLogic {
                     nodes.push(node);
                 }
             }
-            "import_statement" | "import_from_statement" | "function_definition" |
-            "return_statement" | "binary_expression" | "identifier" => {
+            "import_statement" | "import_from_statement" | "return_statement" | 
+            "binary_expression" | "identifier" => {
                 if source.is_some() {
                     // Only collect these additional types when doing source filtering
                     let node_text = crate::parser::get_node_text(&node, source.unwrap());
@@ -945,7 +1130,28 @@ impl VulnerabilityScanner {
             let path = entry.path();
             if path.is_file() {
                 if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                    if format!(".{}", ext) == target_extension {
+                    let file_extension = format!(".{}", ext);
+                    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    
+                    // Enhanced extension matching for each language
+                    let should_include = match self.language.as_str() {
+                        "python" => matches!(ext, "py" | "pyw" | "pyi" | "pyx") ||
+                                   (file_name.ends_with("file") && (file_name.contains("requirements") || file_name.contains("Pipfile"))),
+                        "java" => matches!(ext, "java" | "jav"),
+                        "javascript" => matches!(ext, "js" | "mjs" | "cjs" | "jsx") ||
+                                       matches!(ext, "vue" | "svelte") ||
+                                       (file_name.contains("webpack") || file_name.contains("rollup") || file_name.contains("vite")) &&
+                                       (file_name.ends_with(".config.js") || file_name.ends_with(".config.mjs") || file_name.ends_with(".config.cjs")),
+                        "tsx" => matches!(ext, "ts" | "tsx" | "mts" | "cts") ||
+                                file_name.ends_with(".d.ts") || file_name.ends_with(".d.mts") || file_name.ends_with(".d.cts") ||
+                                ((file_name.contains("webpack") || file_name.contains("rollup") || file_name.contains("vite")) &&
+                                 (file_name.ends_with(".config.ts"))),
+                        "html" => matches!(ext, "html" | "htm" | "xhtml" | "shtml" | "dhtml" | "hbs" | "handlebars" | "mustache" | "twig" | "njk" | "nunjucks" | "ejs" | "pug" | "jade"),
+                        "django" => matches!(ext, "html" | "htm"),
+                        _ => file_extension == target_extension,
+                    };
+                    
+                    if should_include {
                         files.push(path.to_path_buf());
                     }
                 }
@@ -3459,6 +3665,36 @@ impl DataFlowTracer {
             
             VariableSource::FunctionParameter { parameter_index } => {
                 log::debug!("[DATA_FLOW_TRACER] Variable from function parameter {}", parameter_index);
+                
+                // Check if the parameter name matches any taint source patterns
+                if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(sink_variable) {
+                    log::debug!("[DATA_FLOW_TRACER] Function parameter '{}' matches source pattern '{}'", sink_variable, source_pattern);
+                    
+                    // Treat function parameters that match source patterns as taint sources
+                    let flow = VerifiedTaintFlow {
+                        source_file: sink_file.to_string(),
+                        source_function: sink_function.to_string(),
+                        source_pattern: source_pattern.clone(),
+                        source_line: 1, // Function definition line (approximate)
+                        
+                        sink_file: sink_file.to_string(),
+                        sink_function: sink_function.to_string(),
+                        sink_pattern: sink_pattern.to_string(),
+                        sink_line,
+                        sink_variable: sink_variable.to_string(),
+                        
+                        call_chain: Vec::new(),
+                        data_flow_evidence: DataFlowEvidence {
+                            variable_assignments: vec![(sink_variable.to_string(), format!("function parameter {}", parameter_index), 1)],
+                            function_calls: Vec::new(),
+                            return_statements: Vec::new(),
+                        },
+                    };
+
+                    self.verified_flows.push(flow.clone());
+                    return AnalysisResult::DefinitelyTainted { flow };
+                }
+                
                 AnalysisResult::Unknown { 
                     reason: format!("Function parameter {} - requires caller analysis", parameter_index) 
                 }

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -727,6 +727,23 @@ impl ScanningLogic {
                     if let Some(taint_info) = flow_tracker.is_variable_tainted(&used_variable, &func_name).cloned() {
                         // Check if we have a legitimate rule for this source-sink combination
                         if let Some(rule) = rule_deduplicator.get_rule_for_combination(&taint_info.source_pattern, &sink_pattern) {
+                            // Check if the sink expression contains sanitizers before creating finding
+                            if let Some(sanitizers) = &rule.sanitizers {
+                                let mut is_sanitized = false;
+                                for sanitizer in sanitizers {
+                                    if node_text.contains(sanitizer) {
+                                        log::debug!("[SANITIZER_CHECK] Found sanitizer '{}' in sink: '{}'", sanitizer, node_text);
+                                        is_sanitized = true;
+                                        break;
+                                    }
+                                }
+                                
+                                if is_sanitized {
+                                    log::debug!("[SANITIZER_CHECK] Skipping finding due to sanitization: '{}'", node_text);
+                                    continue; // Skip this finding as it's sanitized
+                                }
+                            }
+                            
                             // Ensure we haven't already processed this exact flow
                             if !flow_tracker.is_flow_processed(line, &taint_info.source_pattern, &sink_pattern) {
                                 flow_tracker.mark_flow_processed(line, &taint_info.source_pattern, &sink_pattern);

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -471,10 +471,6 @@ impl ScanningLogic {
         }
     }
 
-
-
-
-
     // Public utility methods for rule access
     pub fn has_matching_rules(rules: &crate::rules::Rules, func_name: &str) -> bool {
         rules.get_search_rules().iter().any(|rule| crate::rules::rule_matches_pattern_unified(rule, func_name))
@@ -634,7 +630,6 @@ impl ScanningLogic {
             // Check if this node matches any sink pattern
             if let Some(sink_pattern) = rule_deduplicator.matches_sink_pattern(&node_text) {
                 log::debug!("[SINK_ANALYSIS] Found sink '{}' with pattern '{}' at line {}", node_text, sink_pattern, line);
-                
                 // Extract ALL variables used in this sink (enhanced extraction)
                 let used_variables = CommonUtils::extract_all_variables(&node_text);
                 log::debug!("[SINK_ANALYSIS] Extracted variables from sink: {:?}", used_variables);

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -1272,9 +1272,11 @@ impl VulnerabilityScanner {
         code_type_filter: Option<&str>,
         language_filter: Option<&str>
     ) -> Result<Vec<Finding>> {
-        println!("running find_vulnerabilities_unified");
+        if show_progress {
+            println!("running find_vulnerabilities_unified");
+        }
         let files_by_language = if self.language.is_empty() {
-            crate::scanner::utils::discover_files_by_language(root_dir, true)?
+            crate::scanner::utils::discover_files_by_language_with_progress(root_dir, true, show_progress)?
         } else {
             let files = self.discover_files(root_dir)?;
             let mut result = std::collections::HashMap::new();

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -581,7 +581,6 @@ impl ScanningLogic {
                         // Check if the assignment value matches any taint source
                         if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(assignment_value) {
                             log::debug!("[ASSIGNMENT_ANALYSIS] Assignment value '{}' matches source pattern '{}'", assignment_value, source_pattern);
-                            
                                                     flow_tracker.record_tainted_variable(
                             var_name,
                             TaintVariableInfo {
@@ -830,6 +829,7 @@ impl ScanningLogic {
         _tree: &tree_sitter::Tree,
         _source_bytes: &[u8],
     ) -> crate::models::Finding {
+
         crate::models::Finding {
             file: sink.file.clone(),
             line: sink.line,
@@ -1054,6 +1054,18 @@ impl VulnerabilityScanner {
     }
 
     pub fn find_vulnerabilities_unified(&self, root_dir: &str, language_name: &str, show_progress: bool) -> Result<Vec<Finding>> {
+        self.find_vulnerabilities_unified_with_filters(root_dir, language_name, show_progress, None, None)
+    }
+
+    pub fn find_vulnerabilities_unified_with_filters(
+        &self, 
+        root_dir: &str, 
+        language_name: &str, 
+        show_progress: bool,
+        code_type_filter: Option<&str>,
+        language_filter: Option<&str>
+    ) -> Result<Vec<Finding>> {
+        println!("running find_vulnerabilities_unified");
         let files_by_language = if self.language.is_empty() {
             crate::scanner::utils::discover_files_by_language(root_dir, true)?
         } else {
@@ -1084,10 +1096,48 @@ impl VulnerabilityScanner {
         let prefilter = crate::scanner::prefilter::PreFilter::with_options(
             &self.rules, language_name, self.skip_minified, Vec::new()
         );
-        let (filtered_files, filter_stats) = prefilter.filter_files(all_files);
+        let (mut filtered_files, filter_stats) = prefilter.filter_files(all_files);
 
         if show_progress {
             println!("{}", filter_stats);
+        }
+
+        // Apply additional filters if specified
+        if code_type_filter.is_some() || language_filter.is_some() {
+            let code_type_detector = crate::code_type_detector::CodeTypeDetector::new();
+            let target_code_type = code_type_filter.and_then(|ct| crate::code_type_detector::CodeType::from_string(ct));
+            let original_count = filtered_files.len();
+            
+            filtered_files = filtered_files.into_iter().filter(|path| {
+                let path_str = path.to_string_lossy();
+                
+                // Language filter
+                if let Some(lang_filter) = language_filter {
+                    if let Some(detected_lang) = crate::scanner::utils::detect_language_from_path(path) {
+                        if !detected_lang.to_lowercase().contains(&lang_filter.to_lowercase()) {
+                            return false;
+                        }
+                    }
+                }
+                
+                // Code type filter
+                if let Some(target_type) = &target_code_type {
+                    if let Ok(content) = std::fs::read_to_string(path) {
+                        if let Some(detected_lang) = crate::scanner::utils::detect_language_from_path(path) {
+                            let detected_type = code_type_detector.detect_code_type(&path_str, &content, &detected_lang);
+                            if !detected_type.matches_filter(target_type) {
+                                return false;
+                            }
+                        }
+                    }
+                }
+                
+                true
+            }).collect();
+            
+            if show_progress && filtered_files.len() != original_count {
+                println!("Additional filtering reduced files from {} to {}", original_count, filtered_files.len());
+            }
         }
 
         if filtered_files.is_empty() {
@@ -1102,14 +1152,12 @@ impl VulnerabilityScanner {
 
         let has_search_rules = !search_rules.is_empty();
         let has_taint_rules = !taint_rules.is_empty();
-
         if !has_search_rules && !has_taint_rules {
             if show_progress {
                 println!("No applicable rules found");
             }
             return Ok(Vec::new());
         }
-
         let mut progress_manager = if show_progress {
             Some(ProgressManager::new(filtered_files.len()))
         } else {
@@ -1143,11 +1191,11 @@ impl VulnerabilityScanner {
                                             let tree = parser.parse(source)?;
 
                                             let mut file_findings = Vec::new();
-
-                                            // Search mode findings (existing functionality)
+                                            // Enhanced search mode with taint context (ALWAYS enabled for search rules)
                                             if has_search_rules {
-                                                file_findings.extend(ScanningLogic::scan_file_with_rules(
-                                                    &filepath_str, source, &tree, &search_rules, parser.language_support()
+                                                // Use enhanced search mode that leverages taint context
+                                                file_findings.extend(ScanningLogic::scan_file_with_rules_and_taint_context(
+                                                    &filepath_str, source, &tree, &search_rules, &taint_rules, parser.language_support()
                                                 ));
                                             }
 
@@ -1238,6 +1286,222 @@ impl VulnerabilityScanner {
         }
 
         Ok(all_findings)
+    }
+}
+
+// ============================================================================
+// OUTPUT & REPORTING - Progress tracking and result formatting
+// ============================================================================
+
+impl ScanningLogic {
+    /// Enhanced search mode that leverages taint context for sophisticated analysis
+    /// This function allows search mode rules to benefit from the same contextual analysis as taint mode
+    pub fn scan_file_with_rules_and_taint_context(
+        filepath: &str,
+        source: &[u8],
+        tree: &tree_sitter::Tree,
+        search_rules: &[&crate::rules::UnifiedRule],
+        taint_rules: &[&crate::rules::UnifiedRule],
+        language_support: &dyn crate::language::LanguageSupport,
+    ) -> Vec<crate::models::Finding> {
+        let mut findings = Vec::new();
+        let mut processed_lines = std::collections::HashSet::new();
+
+        // Create taint rule deduplicator to leverage taint context
+        let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
+
+        // Create variable flow tracker for sophisticated analysis
+        let mut flow_tracker = VariableFlowTracker::new();
+
+        // Use broader traversal to include assignment statements (like taint mode)
+        let mut all_nodes = Vec::new();
+        Self::collect_all_relevant_nodes(tree.root_node(), &mut all_nodes, None);
+
+        // Phase 1: Build taint context by tracking variable assignments from taint sources (only if taint rules exist)
+        let has_taint_rules = !taint_rules.is_empty();
+        
+        if has_taint_rules {
+            for node in all_nodes.iter() {
+                let node_text = crate::parser::get_node_text(node, source);
+                let line = node.start_position().row + 1;
+                let func_name = crate::scanner::utils::AstUtils::get_function_context(node, source);
+
+                // Look for assignment patterns: var = source_call()
+                if CommonUtils::is_valid_assignment_text(&node_text) {
+                    if let Some(var_name) = CommonUtils::extract_variable_from_assignment(&node_text, false) {
+                        // Extract the right side of assignment for source matching
+                        if let Some(eq_pos) = node_text.find('=') {
+                            let assignment_value = &node_text[eq_pos + 1..].trim();
+                            
+                            // Check if the assignment value matches any taint source
+                            if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(assignment_value) {
+                                flow_tracker.record_tainted_variable(
+                                    var_name,
+                                    TaintVariableInfo {
+                                        source_line: line,
+                                        source_pattern,
+                                        source_function: func_name.clone(),
+                                        assignment_code: node_text.clone(),
+                                    }
+                                );
+                            }
+                        }
+                    }
+                }
+
+                // Check for taint propagation through operations
+                if let Some((target_var, dependent_vars)) = ScanningLogic::detect_taint_propagation(&node_text) {
+                    flow_tracker.record_taint_propagation(&target_var, &dependent_vars);
+                    
+                    // Check if any dependent variables are tainted and propagate to target
+                    for dep_var in &dependent_vars {
+                        if let Some(taint_info) = flow_tracker.is_variable_tainted(dep_var, &func_name).cloned() {
+                            // Mark target variable as tainted (inheriting from the dependent variable)
+                            flow_tracker.record_tainted_variable(target_var.to_string(), TaintVariableInfo {
+                                source_line: taint_info.source_line,
+                                source_pattern: taint_info.source_pattern.clone(),
+                                source_function: taint_info.source_function.clone(),
+                                assignment_code: format!("Propagated from {} via: {}", dep_var, node_text),
+                            });
+                            break; // Only need one tainted dependency to taint the target
+                        }
+                    }
+                }
+            }
+        }
+
+        // Phase 2: Apply search rules with enhanced context awareness
+        let call_nodes: Vec<tree_sitter::Node> = crate::parser::traverse_calls_only(tree.root_node(), language_support).collect();
+
+        for node in call_nodes.iter() {
+            if let Some(func_name) = language_support.get_function_name(node, source) {
+                let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> = search_rules.iter().enumerate()
+                    .filter(|(_, rule)| ScanningLogic::rule_might_match_function(*rule, &func_name))
+                    .map(|(idx, rule)| (idx, *rule))
+                    .collect();
+
+                for (_, rule) in relevant_rules {
+                    // Enhanced rule checking with taint context
+                    if let Some(mut finding) = ScanningLogic::check_rule_against_node_with_taint_context(
+                        rule,
+                        node,
+                        source,
+                        filepath,
+                        &func_name,
+                        language_support,
+                        &flow_tracker,
+                        &rule_deduplicator,
+                    ) {
+                        let line_key = (finding.line, finding.function.clone(), finding.finding_type.clone());
+                        if !processed_lines.contains(&line_key) {
+                            processed_lines.insert(line_key);
+                            
+                            // Add taint context tags to distinguish from basic search findings
+                            if finding.tags.is_none() {
+                                finding.tags = Some(Vec::new());
+                            }
+                            if let Some(ref mut tags) = finding.tags {
+                                tags.push("enhanced_search".to_string());
+                                if has_taint_rules {
+                                    tags.push("taint_context_available".to_string());
+                                } else {
+                                    tags.push("taint_context_unavailable".to_string());
+                                }
+                            }
+                            
+                            findings.push(finding);
+                        }
+                    }
+                }
+            }
+        }
+
+        findings
+    }
+
+    /// Enhanced rule checking that leverages taint context for more accurate analysis
+    fn check_rule_against_node_with_taint_context(
+        rule: &crate::rules::UnifiedRule,
+        node: &tree_sitter::Node,
+        source: &[u8],
+        filepath: &str,
+        func_name: &str,
+        language_support: &dyn crate::language::LanguageSupport,
+        flow_tracker: &VariableFlowTracker,
+        rule_deduplicator: &TaintRuleDeduplicator,
+    ) -> Option<crate::models::Finding> {
+        let node_text = crate::parser::get_node_text(node, source);
+        
+        // First check if the rule pattern matches
+        let pattern_matches = if let Some(patterns) = &rule.patterns {
+            patterns.iter().any(|pattern| CommonUtils::matches_rule_pattern(pattern, &node_text))
+        } else if let Some(pattern) = &rule.pattern {
+            CommonUtils::matches_rule_pattern(pattern, &node_text)
+        } else {
+            false
+        };
+
+        if !pattern_matches {
+            return None;
+        }
+
+        // Extract variables used in this node
+        let used_variables = CommonUtils::extract_all_variables(&node_text);
+        let line = node.start_position().row + 1;
+        let function_context = crate::scanner::utils::AstUtils::get_function_context(node, source);
+
+        // Check if any used variables are tainted (enhanced context)
+        let mut taint_context_info = None;
+        for var in &used_variables {
+            if let Some(taint_info) = flow_tracker.is_variable_tainted(var, &function_context) {
+                taint_context_info = Some((var.clone(), taint_info));
+                break;
+            }
+        }
+
+        // Create enhanced finding with taint context
+        let mut finding = crate::models::Finding {
+            file: filepath.to_string(),
+            line,
+            column: node.start_position().column,
+            end_line: node.end_position().row + 1,
+            end_column: node.end_position().column,
+            function: func_name.to_string(),
+            finding_type: rule.get_finding_type().to_string(),
+            snippet: node_text.clone(),
+            severity: rule.get_severity().to_string(),
+            confidence: rule.get_confidence().to_string(),
+            description: rule.description.clone(),
+            source_info: None,
+            sink_info: None,
+            traces: None,
+            tags: rule.tags.clone(),
+        };
+
+        // Add enhanced source and sink information if taint context is available
+        if let Some((tainted_var, taint_info)) = taint_context_info {
+            finding.source_info = Some(crate::models::SourceInfo {
+                source_type: format!("{} (Taint Context)", taint_info.source_pattern),
+                location: format!("Line {} ({})", taint_info.source_line, taint_info.source_function),
+                context: taint_info.assignment_code.clone(),
+            });
+
+            finding.sink_info = Some(crate::models::SinkInfo {
+                sink_type: rule.get_finding_type().to_string(),
+                function_name: func_name.to_string(),
+                location: format!("Line {}", line),
+                variable: Some(tainted_var),
+            });
+
+            // Increase confidence when we have taint context
+            finding.confidence = "High".to_string();
+        } else {
+            // Regular source/sink detection for non-taint context
+            finding.source_info = ScanningLogic::detect_source_pattern(node, source, language_support);
+            finding.sink_info = ScanningLogic::detect_sink_pattern(node, source, func_name, &rule.get_finding_type());
+        }
+
+        Some(finding)
     }
 }
 

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -118,7 +118,7 @@ pub fn run_explicit_scan(cli: &Cli) -> Result<Vec<Finding>> {
     
     let rules = Rules::load_from_path(rules_path)?;
     let total_rules = ScanningLogic::count_total_rules(&rules);
-    
+    println!("🔢 Total number of rules: {}", total_rules);
     // Configure minified file skipping
     let skip_minified = cli.skip_minified.unwrap_or(true);
     let scanner = VulnerabilityScanner::with_skip_minified(
@@ -153,7 +153,18 @@ pub fn run_explicit_scan(cli: &Cli) -> Result<Vec<Finding>> {
     println!("🔍 Running scan with {} rules", total_rules);
     println!();
 
-    scanner.find_vulnerabilities_parallel(&cli.root_dir, language, true)
+    // Use the new filtering method if filters are specified
+    if cli.code_type.is_some() || cli.language_filter.is_some() {
+        scanner.find_vulnerabilities_unified_with_filters(
+            &cli.root_dir, 
+            language, 
+            true,
+            cli.code_type.as_deref(),
+            cli.language_filter.as_deref()
+        )
+    } else {
+        scanner.find_vulnerabilities_parallel(&cli.root_dir, language, true)
+    }
 }
 
 /// Run auto-detection scan mode (automatically detect languages and load rules)
@@ -214,7 +225,19 @@ pub fn run_auto_detection_scan(cli: &Cli) -> Result<Vec<Finding>> {
                     context.skip_minified
                 ).expect("scanner");
                 
-                match scanner.find_vulnerabilities_parallel(&cli.root_dir, &language, false) {
+                let findings_result = if cli.code_type.is_some() || cli.language_filter.is_some() {
+                    scanner.find_vulnerabilities_unified_with_filters(
+                        &cli.root_dir, 
+                        &language, 
+                        false,
+                        cli.code_type.as_deref(),
+                        cli.language_filter.as_deref()
+                    )
+                } else {
+                    scanner.find_vulnerabilities_parallel(&cli.root_dir, &language, false)
+                };
+                
+                match findings_result {
                     Ok(fnds) => {
                         processed_files.fetch_add(files.len(), Ordering::Relaxed);
                         if !fnds.is_empty() {
@@ -263,14 +286,12 @@ pub fn run_taint_analysis(cli: &Cli) -> Result<Vec<Finding>> {
     if taint_rules_count == 0 {
         return Err(anyhow::anyhow!("No taint flow rules found. Please ensure your rules contain rules with mode='taint'."));
     }
-    
     println!("🔍 Starting Optimized Taint Analysis Mode");
     println!("📂 Target directory: {}", cli.root_dir);
     println!("🔧 Loaded {} taint flow rules", taint_rules_count);
     println!("📁 Total files to analyze: {}", context.total_files);
     println!("⚡ Using parallel processing for maximum performance");
     println!();
-    
     // Use the unified VulnerabilityScanner infrastructure for massive speedup!
     // This reuses ALL existing optimizations: parallel processing, prefiltering, 
     // memory mapping, thread-local parsers, progress tracking, etc.
@@ -282,8 +303,17 @@ pub fn run_taint_analysis(cli: &Cli) -> Result<Vec<Finding>> {
         context.skip_minified
     )?;
     
-    // Use unified scanner that processes both search and taint rules efficiently
-    let all_findings = scanner.find_vulnerabilities_unified(&cli.root_dir, language, true)?;
+    let all_findings = if cli.code_type.is_some() || cli.language_filter.is_some() {
+        scanner.find_vulnerabilities_unified_with_filters(
+            &cli.root_dir, 
+            language, 
+            true,
+            cli.code_type.as_deref(),
+            cli.language_filter.as_deref()
+        )?
+    } else {
+        scanner.find_vulnerabilities_unified(&cli.root_dir, language, true)?
+    };
         
     // Filter to only taint analysis findings 
     let taint_findings: Vec<Finding> = all_findings.into_iter()

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -195,7 +195,10 @@ pub fn run_auto_detection_scan(cli: &Cli) -> Result<Vec<Finding>> {
     
     // Process languages sequentially to avoid nested parallelism deadlocks
     for (language, files) in lang_jobs {
-        let rules_dir = format!("rules/{}", language);
+        let rules_dir = match language.as_str() {
+            "tsx" => "rules/javascript".to_string(),
+            _ => format!("rules/{}", language),
+        };
         match Rules::load_from_directory(&rules_dir) {
             Ok(rules) => {
                 let rule_count = ScanningLogic::count_total_rules(&rules);

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -93,7 +93,10 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
             let mut all_rules = Vec::new();
             
             for language in &context.detected_languages {
-                let rules_dir = format!("rules/{}", language);
+                let rules_dir = match language.as_str() {
+                    "tsx" => "rules/javascript".to_string(),
+                    _ => format!("rules/{}", language),
+                };
                 if let Ok(rules) = Rules::load_from_directory(&rules_dir) {
                     all_rules.push(rules);
                 }

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -23,30 +23,36 @@ struct ScanContext {
 
 impl ScanContext {
     /// Initialize scan context with file discovery
-    fn new(cli: &Cli) -> Result<Self> {
+    fn new(cli: &Cli, show_progress: bool) -> Result<Self> {
         let discovery_start = std::time::Instant::now();
         
         let parallel = !cli.single_threaded;
-        if parallel {
-            println!("🚀 Using parallel file discovery for maximum performance...");
-        } else {
-            println!("🔍 Using sequential file discovery...");
+        if show_progress {
+            if parallel {
+                println!("🚀 Using parallel file discovery for maximum performance...");
+            } else {
+                println!("🔍 Using sequential file discovery...");
+            }
         }
         
-        let files_by_language = discover_files_by_language(&cli.root_dir, parallel)?;
+        let files_by_language = crate::scanner::utils::discover_files_by_language_with_progress(&cli.root_dir, parallel, show_progress)?;
         let discovery_time = discovery_start.elapsed();
         
         if files_by_language.is_empty() {
-            println!("❌ No supported files found in {}", cli.root_dir);
-            println!("   Supported file types: .py, .java, .js, .tsx, .html");
+            if show_progress {
+                println!("❌ No supported files found in {}", cli.root_dir);
+                println!("   Supported file types: .py, .java, .js, .tsx, .html");
+            }
             return Err(anyhow::anyhow!("No supported files found"));
         }
         
         let detected_languages: Vec<String> = files_by_language.keys().cloned().collect();
         let total_files: usize = files_by_language.values().map(|files| files.len()).sum();
         
-        println!("🔍 Detected languages: {} (in {:.2?})", 
-                detected_languages.join(", "), discovery_time);
+        if show_progress {
+            println!("🔍 Detected languages: {} (in {:.2?})", 
+                    detected_languages.join(", "), discovery_time);
+        }
         
         Ok(Self {
             root_dir: cli.root_dir.clone(),
@@ -100,6 +106,18 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
                 if let Ok(rules) = Rules::load_from_directory(&rules_dir) {
                     all_rules.push(rules);
                 }
+                
+                // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
+                if matches!(language.as_str(), "javascript" | "tsx") {
+                    if let Some(code_type) = &cli.code_type {
+                        if code_type != "frontend" {
+                            let backend_rules_file = "rules/backend_javascript/backend_security.ron";
+                            if let Ok(backend_rules) = Rules::load_from_file(backend_rules_file) {
+                                all_rules.push(backend_rules);
+                            }
+                        }
+                    }
+                }
             }
             
             if all_rules.is_empty() {
@@ -113,15 +131,35 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
 }
 
 /// Run explicit scan mode (language and rules specified)
-pub fn run_explicit_scan(cli: &Cli) -> Result<Vec<Finding>> {
+pub fn run_explicit_scan(cli: &Cli, show_progress: bool) -> Result<Vec<Finding>> {
     let language = cli.language.as_ref()
         .ok_or_else(|| anyhow::anyhow!("Language required for explicit scan"))?;
     let rules_path = cli.rules_path.as_ref()
         .ok_or_else(|| anyhow::anyhow!("Rules path required for explicit scan"))?;
     
-    let rules = Rules::load_from_path(rules_path)?;
+    let mut all_rules = vec![Rules::load_from_path(rules_path)?];
+    
+    // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
+    if matches!(language.as_str(), "javascript" | "tsx") {
+        if let Some(code_type) = &cli.code_type {
+            if code_type == "backend" || code_type == "both" {
+                let backend_rules_file = "rules/javascript/backend_security.ron";
+                if let Ok(backend_rules) = Rules::load_from_file(backend_rules_file) {
+                    all_rules.push(backend_rules);
+                }
+            }
+        }
+    }
+    
+    let rules = if all_rules.len() == 1 {
+        all_rules.into_iter().next().unwrap()
+    } else {
+        Rules::merge_rules(all_rules)?
+    };
     let total_rules = ScanningLogic::count_total_rules(&rules);
-    println!("🔢 Total number of rules: {}", total_rules);
+    if show_progress {
+        println!("🔢 Total number of rules: {}", total_rules);
+    }
     // Configure minified file skipping
     let skip_minified = cli.skip_minified.unwrap_or(true);
     let scanner = VulnerabilityScanner::with_skip_minified(
@@ -130,70 +168,76 @@ pub fn run_explicit_scan(cli: &Cli) -> Result<Vec<Finding>> {
         skip_minified
     )?;
     
-    if !skip_minified {
+    if !skip_minified && show_progress {
         println!("⚠️  Minified file skipping disabled - this may increase scan time and false positives");
     }
 
-    // Use unified configuration for display
-    let mode = if cli.single_threaded { "single-threaded" } else { "parallel" };
-    let thread_info = if let Some(threads) = cli.threads {
-        format!(" with {} threads", threads)
-    } else {
-        String::new()
-    };
-    
-    println!("🚀 Starting Explicit Scan ({} mode{})!", mode, thread_info);
-    println!("📂 Target directory: {}", cli.root_dir);
-    println!("🔧 Language: {}", language);
-    
-    let path = std::path::Path::new(rules_path);
-    if path.is_dir() {
-        println!("📋 Rules directory: {}", rules_path);
-    } else {
-        println!("📋 Rules file: {}", rules_path);
+    if show_progress {
+        // Use unified configuration for display
+        let mode = if cli.single_threaded { "single-threaded" } else { "parallel" };
+        let thread_info = if let Some(threads) = cli.threads {
+            format!(" with {} threads", threads)
+        } else {
+            String::new()
+        };
+        
+        println!("🚀 Starting Explicit Scan ({} mode{})!", mode, thread_info);
+        println!("📂 Target directory: {}", cli.root_dir);
+        println!("🔧 Language: {}", language);
+        
+        let path = std::path::Path::new(rules_path);
+        if path.is_dir() {
+            println!("📋 Rules directory: {}", rules_path);
+        } else {
+            println!("📋 Rules file: {}", rules_path);
+        }
+        
+        println!("🔍 Running scan with {} rules", total_rules);
+        println!();
     }
-    
-    println!("🔍 Running scan with {} rules", total_rules);
-    println!();
 
     // Use the new filtering method if filters are specified
     if cli.code_type.is_some() || cli.language_filter.is_some() {
         scanner.find_vulnerabilities_unified_with_filters(
             &cli.root_dir, 
             language, 
-            true,
+            show_progress,
             cli.code_type.as_deref(),
             cli.language_filter.as_deref()
         )
     } else {
-        scanner.find_vulnerabilities_parallel(&cli.root_dir, language, true)
+        scanner.find_vulnerabilities_parallel(&cli.root_dir, language, show_progress)
     }
 }
 
 /// Run auto-detection scan mode (automatically detect languages and load rules)
-pub fn run_auto_detection_scan(cli: &Cli) -> Result<Vec<Finding>> {
+pub fn run_auto_detection_scan(cli: &Cli, show_progress: bool) -> Result<Vec<Finding>> {
     let scan_start = std::time::Instant::now();
     
     // Initialize unified scan context
-    let context = ScanContext::new(cli)?;
+    let context = ScanContext::new(cli, show_progress)?;
     let (mode, thread_info) = context.get_mode_info(cli.threads);
     
-    println!("🚀 Starting Auto-Detection Scan ({} mode{})!", mode, thread_info);
-    println!("📂 Target directory: {}", cli.root_dir);
+    if show_progress {
+        println!("🚀 Starting Auto-Detection Scan ({} mode{})!", mode, thread_info);
+        println!("📂 Target directory: {}", cli.root_dir);
+    }
     
     // Rediscover files by language for actual processing (context only used for validation)
     let files_by_language = if cli.single_threaded {
-        discover_files_by_language_sequential(&cli.root_dir)?
+        crate::scanner::utils::discover_files_by_language_sequential_with_progress(&cli.root_dir, false)?
     } else {
-        discover_files_by_language_parallel(&cli.root_dir)?
+        crate::scanner::utils::discover_files_by_language_parallel_with_progress(&cli.root_dir, false)?
     };
     
     let total_findings = Arc::new(AtomicUsize::new(0));
-    let mut progress_manager = if !cli.single_threaded {
+    let mut progress_manager = if !cli.single_threaded && show_progress {
         Some(context.create_progress_manager())
     } else { None };
     
-    println!();
+    if show_progress {
+        println!();
+    }
     
     // Convert to Vec to own data
     let lang_jobs: Vec<(String, Vec<PathBuf>)> = files_by_language.into_iter().collect();
@@ -213,8 +257,36 @@ pub fn run_auto_detection_scan(cli: &Cli) -> Result<Vec<Finding>> {
             "tsx" => "rules/javascript".to_string(),
             _ => format!("rules/{}", language),
         };
-        match Rules::load_from_directory(&rules_dir) {
-            Ok(rules) => {
+        
+        // Load base rules for the language
+        let mut all_rules = Vec::new();
+        if let Ok(base_rules) = Rules::load_from_directory(&rules_dir) {
+            all_rules.push(base_rules);
+        }
+        
+        // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
+        if matches!(language.as_str(), "javascript" | "tsx") {
+            if let Some(code_type) = &cli.code_type {
+                if code_type == "backend" || code_type == "both" {
+                    let backend_rules_dir = "rules/javascript/backend_security.ron";
+                    if let Ok(backend_rules) = Rules::load_from_file(backend_rules_dir) {
+                        all_rules.push(backend_rules);
+                    }
+                }
+            }
+        }
+        
+        if all_rules.is_empty() {
+            continue; // Skip if no rules found
+        }
+        
+        let rules = if all_rules.len() == 1 {
+            all_rules.into_iter().next().unwrap()
+        } else {
+            Rules::merge_rules(all_rules)?
+        };
+        
+        {
                 let rule_count = ScanningLogic::count_total_rules(&rules);
                 total_rules_loaded.fetch_add(rule_count, Ordering::Relaxed);
                 
@@ -232,7 +304,7 @@ pub fn run_auto_detection_scan(cli: &Cli) -> Result<Vec<Finding>> {
                     scanner.find_vulnerabilities_unified_with_filters(
                         &cli.root_dir, 
                         &language, 
-                        false,
+                        false, // Never show progress for individual languages in auto-detection
                         cli.code_type.as_deref(),
                         cli.language_filter.as_deref()
                     )
@@ -253,10 +325,6 @@ pub fn run_auto_detection_scan(cli: &Cli) -> Result<Vec<Finding>> {
                     }
                 }
             }
-            Err(e) => {
-                eprintln!("⚠️  Failed to load rules for {}: {}", language, e);
-            }
-        }
     }
 
     // Stop progress tracking
@@ -266,19 +334,23 @@ pub fn run_auto_detection_scan(cli: &Cli) -> Result<Vec<Finding>> {
     
     // Use unified performance reporting
     let scan_duration = scan_start.elapsed();
-    context.print_performance_summary(total_rules_loaded.load(Ordering::Relaxed), scan_duration);
+    if show_progress {
+        context.print_performance_summary(total_rules_loaded.load(Ordering::Relaxed), scan_duration);
+    }
     
     Ok(all_findings)
 }
 
 /// Run taint analysis mode
-pub fn run_taint_analysis(cli: &Cli) -> Result<Vec<Finding>> {
-    println!("🔍 Taint analysis enabled - tracking data flows from sources to sinks");
+pub fn run_taint_analysis(cli: &Cli, show_progress: bool) -> Result<Vec<Finding>> {
+    if show_progress {
+        println!("🔍 Taint analysis enabled - tracking data flows from sources to sinks");
+    }
     
     let scan_start = std::time::Instant::now();
     
     // Initialize unified scan context (reuse existing infrastructure)
-    let context = ScanContext::new(cli)?;
+    let context = ScanContext::new(cli, show_progress)?;
     
     // Load rules using unified pattern (reuse existing infrastructure)
     let rules = load_rules(cli, &context)?;
@@ -289,12 +361,14 @@ pub fn run_taint_analysis(cli: &Cli) -> Result<Vec<Finding>> {
     if taint_rules_count == 0 {
         return Err(anyhow::anyhow!("No taint flow rules found. Please ensure your rules contain rules with mode='taint'."));
     }
-    println!("🔍 Starting Optimized Taint Analysis Mode");
-    println!("📂 Target directory: {}", cli.root_dir);
-    println!("🔧 Loaded {} taint flow rules", taint_rules_count);
-    println!("📁 Total files to analyze: {}", context.total_files);
-    println!("⚡ Using parallel processing for maximum performance");
-    println!();
+    if show_progress {
+        println!("🔍 Starting Optimized Taint Analysis Mode");
+        println!("📂 Target directory: {}", cli.root_dir);
+        println!("🔧 Loaded {} taint flow rules", taint_rules_count);
+        println!("📁 Total files to analyze: {}", context.total_files);
+        println!("⚡ Using parallel processing for maximum performance");
+        println!();
+    }
     // Use the unified VulnerabilityScanner infrastructure for massive speedup!
     // This reuses ALL existing optimizations: parallel processing, prefiltering, 
     // memory mapping, thread-local parsers, progress tracking, etc.
@@ -310,12 +384,12 @@ pub fn run_taint_analysis(cli: &Cli) -> Result<Vec<Finding>> {
         scanner.find_vulnerabilities_unified_with_filters(
             &cli.root_dir, 
             language, 
-            true,
+            show_progress,
             cli.code_type.as_deref(),
             cli.language_filter.as_deref()
         )?
     } else {
-        scanner.find_vulnerabilities_unified(&cli.root_dir, language, true)?
+        scanner.find_vulnerabilities_unified(&cli.root_dir, language, show_progress)?
     };
         
     // Filter to only taint analysis findings 
@@ -329,18 +403,20 @@ pub fn run_taint_analysis(cli: &Cli) -> Result<Vec<Finding>> {
     
     let scan_duration = scan_start.elapsed();
     
-    // Use unified performance reporting (reuse existing infrastructure)
-    context.print_performance_summary(taint_rules_count, scan_duration);
-    println!("⏱️  Optimized taint analysis completed in {:.2?}", scan_duration);
-    
-    if !taint_findings.is_empty() {
-        let same_file_count = taint_findings.iter()
-            .filter(|f| f.tags.as_ref().map_or(false, |tags| tags.contains(&"same_file".to_string())))
-            .count();
-        let cross_file_count = taint_findings.len() - same_file_count;
+    if show_progress {
+        // Use unified performance reporting (reuse existing infrastructure)
+        context.print_performance_summary(taint_rules_count, scan_duration);
+        println!("⏱️  Optimized taint analysis completed in {:.2?}", scan_duration);
         
-        println!("🎯 Found {} taint flows ({} same-file, {} cross-file)", 
-                taint_findings.len(), same_file_count, cross_file_count);
+        if !taint_findings.is_empty() {
+            let same_file_count = taint_findings.iter()
+                .filter(|f| f.tags.as_ref().map_or(false, |tags| tags.contains(&"same_file".to_string())))
+                .count();
+            let cross_file_count = taint_findings.len() - same_file_count;
+            
+            println!("🎯 Found {} taint flows ({} same-file, {} cross-file)", 
+                    taint_findings.len(), same_file_count, cross_file_count);
+        }
     }
     
     Ok(taint_findings)

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -98,12 +98,25 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
             // Auto-detect and merge rules from all languages
             let mut all_rules = Vec::new();
             
+            // Determine exclusion pattern type based on code_type
+            let pattern_type = if let Some(code_type) = &cli.code_type {
+                if code_type == "backend" {
+                    "backend"
+                } else if code_type == "frontend" {
+                    "frontend"
+                } else {
+                    "frontend" // default for "both" or other values
+                }
+            } else {
+                "frontend" // default when no code_type specified
+            };
+            
             for language in &context.detected_languages {
                 let rules_dir = match language.as_str() {
                     "tsx" => "rules/javascript".to_string(),
                     _ => format!("rules/{}", language),
                 };
-                if let Ok(rules) = Rules::load_from_directory(&rules_dir) {
+                if let Ok(rules) = Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type) {
                     all_rules.push(rules);
                 }
                 
@@ -142,7 +155,7 @@ pub fn run_explicit_scan(cli: &Cli, show_progress: bool) -> Result<Vec<Finding>>
     // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
     if matches!(language.as_str(), "javascript" | "tsx") {
         if let Some(code_type) = &cli.code_type {
-            if code_type == "backend" || code_type == "both" {
+            if code_type != "frontend"{
                 let backend_rules_file = "rules/javascript/backend_security.ron";
                 if let Ok(backend_rules) = Rules::load_from_file(backend_rules_file) {
                     all_rules.push(backend_rules);
@@ -258,16 +271,30 @@ pub fn run_auto_detection_scan(cli: &Cli, show_progress: bool) -> Result<Vec<Fin
             _ => format!("rules/{}", language),
         };
         
-        // Load base rules for the language
+        // Load base rules for the language with centralized exclusions
         let mut all_rules = Vec::new();
-        if let Ok(base_rules) = Rules::load_from_directory(&rules_dir) {
+        
+        // Determine exclusion pattern type based on code_type
+        let pattern_type = if let Some(code_type) = &cli.code_type {
+            if code_type == "backend" {
+                "backend"
+            } else if code_type == "frontend" {
+                "frontend"
+            } else {
+                "frontend" // default for "both" or other values
+            }
+        } else {
+            "frontend" // default when no code_type specified
+        };
+        
+        if let Ok(base_rules) = Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type) {
             all_rules.push(base_rules);
         }
         
         // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
         if matches!(language.as_str(), "javascript" | "tsx") {
             if let Some(code_type) = &cli.code_type {
-                if code_type == "backend" || code_type == "both" {
+                if code_type != "frontend" {
                     let backend_rules_dir = "rules/javascript/backend_security.ron";
                     if let Ok(backend_rules) = Rules::load_from_file(backend_rules_dir) {
                         all_rules.push(backend_rules);

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -70,6 +70,9 @@ pub fn rule_applies_to_file_path(file_types: Option<&FileTypes>, file_path: &Pat
 
 /// Detect programming language from file path
 pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
+    let file_name = file_path.file_name()?.to_str()?;
+    
+    // Handle standard extensions
     match file_path.extension()?.to_str()? {
         // Python extensions
         "py" | "pyw" | "pyi" | "pyx" => Some("python"),
@@ -81,17 +84,10 @@ pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
         "js" | "mjs" | "cjs" | "jsx" => Some("javascript"),
         
         // TypeScript extensions (including all variants)
-        "ts" | "tsx" | "mts" | "cts" | "d.ts" => Some("tsx"),
+        "ts" | "tsx" | "mts" | "cts" => Some("tsx"),
         
         // HTML and template extensions
-        "html" | "htm" | "xhtml" | "shtml" | "dhtml" => {
-            let path_str = file_path.to_string_lossy().to_lowercase();
-            if path_str.contains("template") || path_str.contains("django") {
-                Some("html")
-            } else {
-                Some("html")
-            }
-        },
+        "html" | "htm" | "xhtml" | "shtml" | "dhtml" => Some("html"),
         
         // Template file extensions that should be treated as HTML
         "hbs" | "handlebars" | "mustache" | "twig" | "njk" | "nunjucks" | "ejs" | "pug" | "jade" => Some("html"),
@@ -102,20 +98,15 @@ pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
         // Svelte components 
         "svelte" => Some("javascript"),
         
-        // React/JSX files that might not have .jsx extension
+        // Handle config files and other special cases
         _ => {
-            let file_name = file_path.file_name()?.to_str()?;
-            
-            // Check for special TypeScript declaration files
-            if file_name.ends_with(".d.ts") || file_name.ends_with(".d.mts") || file_name.ends_with(".d.cts") {
-                return Some("tsx");
-            }
-            
-            // Check for JavaScript files with unusual extensions but clear JS content indicators
+            // Check for JavaScript/TypeScript config files
             if file_name.contains("webpack") || file_name.contains("rollup") || file_name.contains("vite") {
-                if file_name.ends_with(".config.js") || file_name.ends_with(".config.ts") || 
-                   file_name.ends_with(".config.mjs") || file_name.ends_with(".config.cjs") {
-                    return if file_name.contains(".ts") { Some("tsx") } else { Some("javascript") };
+                if file_name.ends_with(".config.js") || file_name.ends_with(".config.mjs") || file_name.ends_with(".config.cjs") {
+                    return Some("javascript");
+                }
+                if file_name.ends_with(".config.ts") || file_name.ends_with(".config.mts") || file_name.ends_with(".config.cts") {
+                    return Some("tsx");
                 }
             }
             

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -333,19 +333,22 @@ impl AstUtils {
     /// Domain-specific sanitization pattern checking
     pub fn check_for_sanitization(code: &str, language: &str) -> bool {
         match language {
-            "javascript" | "typescript" => Self::check_javascript_sanitization(code),
+            "javascript" | "typescript" => Self::check_html_sanitization(code),
             "python" => Self::check_python_sanitization(code),
             "java" => Self::check_java_sanitization(code),
             _ => Self::check_generic_sanitization(code),
         }
     }
 
-    fn check_javascript_sanitization(code: &str) -> bool {
-        let js_sanitizers = [
-            "DOMPurify.sanitize", "sanitize(", ".textContent", ".innerText",
-            "encodeURIComponent", "encodeURI", "escape(", "validator.escape", "xss(",
+    fn check_html_sanitization(code: &str) -> bool {
+        let html_sanitizers = [
+            "DOMPurify.sanitize(",
+            "validator.escape(",
+            "xss(",
+            "escapeHtml(",
+            "encodeHTML(",
         ];
-        js_sanitizers.iter().any(|pattern| code.contains(pattern))
+        html_sanitizers.iter().any(|pat| code.contains(pat))
     }
 
     fn check_python_sanitization(code: &str) -> bool {

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -71,11 +71,20 @@ pub fn rule_applies_to_file_path(file_types: Option<&FileTypes>, file_path: &Pat
 /// Detect programming language from file path
 pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
     match file_path.extension()?.to_str()? {
-        "py" => Some("python"),
-        "java" => Some("java"),
-        "js" | "mjs" => Some("javascript"),
-        "tsx" => Some("tsx"),
-        "html" => {
+        // Python extensions
+        "py" | "pyw" | "pyi" | "pyx" => Some("python"),
+        
+        // Java extensions  
+        "java" | "jav" => Some("java"),
+        
+        // JavaScript extensions (including modern variants)
+        "js" | "mjs" | "cjs" | "jsx" => Some("javascript"),
+        
+        // TypeScript extensions (including all variants)
+        "ts" | "tsx" | "mts" | "cts" | "d.ts" => Some("tsx"),
+        
+        // HTML and template extensions
+        "html" | "htm" | "xhtml" | "shtml" | "dhtml" => {
             let path_str = file_path.to_string_lossy().to_lowercase();
             if path_str.contains("template") || path_str.contains("django") {
                 Some("html")
@@ -83,7 +92,40 @@ pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
                 Some("html")
             }
         },
-        _ => None,
+        
+        // Template file extensions that should be treated as HTML
+        "hbs" | "handlebars" | "mustache" | "twig" | "njk" | "nunjucks" | "ejs" | "pug" | "jade" => Some("html"),
+        
+        // Vue.js single file components (contain HTML, JS, and CSS)
+        "vue" => Some("javascript"),
+        
+        // Svelte components 
+        "svelte" => Some("javascript"),
+        
+        // React/JSX files that might not have .jsx extension
+        _ => {
+            let file_name = file_path.file_name()?.to_str()?;
+            
+            // Check for special TypeScript declaration files
+            if file_name.ends_with(".d.ts") || file_name.ends_with(".d.mts") || file_name.ends_with(".d.cts") {
+                return Some("tsx");
+            }
+            
+            // Check for JavaScript files with unusual extensions but clear JS content indicators
+            if file_name.contains("webpack") || file_name.contains("rollup") || file_name.contains("vite") {
+                if file_name.ends_with(".config.js") || file_name.ends_with(".config.ts") || 
+                   file_name.ends_with(".config.mjs") || file_name.ends_with(".config.cjs") {
+                    return if file_name.contains(".ts") { Some("tsx") } else { Some("javascript") };
+                }
+            }
+            
+            // Check for Python files with unusual extensions
+            if file_name.ends_with("file") && (file_name.contains("requirements") || file_name.contains("Pipfile")) {
+                return Some("python");
+            }
+            
+            None
+        }
     }
 }
 

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -131,17 +131,21 @@ pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
 
 /// Discover files by language with configurable parallelism
 pub fn discover_files_by_language(root_dir: &str, parallel: bool) -> Result<HashMap<String, Vec<PathBuf>>> {
+    discover_files_by_language_with_progress(root_dir, parallel, true)
+}
+
+pub fn discover_files_by_language_with_progress(root_dir: &str, parallel: bool, show_progress: bool) -> Result<HashMap<String, Vec<PathBuf>>> {
     let estimated_languages = crate::config::ScanDefaults::ESTIMATED_LANGUAGES;
 
     if parallel {
-        discover_files_parallel(root_dir, estimated_languages)
+        discover_files_parallel(root_dir, estimated_languages, show_progress)
     } else {
-        discover_files_sequential(root_dir, estimated_languages)
+        discover_files_sequential(root_dir, estimated_languages, show_progress)
     }
 }
 
 /// Internal parallel file discovery implementation
-fn discover_files_parallel(root_dir: &str, estimated_languages: usize) -> Result<HashMap<String, Vec<PathBuf>>> {
+fn discover_files_parallel(root_dir: &str, estimated_languages: usize, show_progress: bool) -> Result<HashMap<String, Vec<PathBuf>>> {
     let all_paths: Vec<PathBuf> = WalkDir::new(root_dir)
         .follow_links(false)
         .into_iter()
@@ -169,8 +173,10 @@ fn discover_files_parallel(root_dir: &str, estimated_languages: usize) -> Result
         (all_paths.len() / estimated_languages).max(crate::config::ScanDefaults::ESTIMATED_FILES_PER_LANG)
     };
 
-    println!("📂 Discovered {} files total, estimating {} files per language",
-             all_paths.len(), estimated_files_per_lang);
+    if show_progress {
+        println!("📂 Discovered {} files total, estimating {} files per language",
+                 all_paths.len(), estimated_files_per_lang);
+    }
 
     let files_by_language = Arc::new(Mutex::new(
         HashMap::<String, Vec<PathBuf>>::with_capacity(estimated_languages)
@@ -192,7 +198,7 @@ fn discover_files_parallel(root_dir: &str, estimated_languages: usize) -> Result
 }
 
 /// Internal sequential file discovery implementation
-fn discover_files_sequential(root_dir: &str, estimated_languages: usize) -> Result<HashMap<String, Vec<PathBuf>>> {
+fn discover_files_sequential(root_dir: &str, estimated_languages: usize, _show_progress: bool) -> Result<HashMap<String, Vec<PathBuf>>> {
     let mut files_by_language = HashMap::with_capacity(estimated_languages);
 
     for entry in WalkDir::new(root_dir)
@@ -229,6 +235,16 @@ pub fn discover_files_by_language_parallel(root_dir: &str) -> Result<HashMap<Str
 /// Sequential file discovery (replaces legacy wrapper)
 pub fn discover_files_by_language_sequential(root_dir: &str) -> Result<HashMap<String, Vec<PathBuf>>> {
     discover_files_by_language(root_dir, false)
+}
+
+/// Parallel file discovery with progress control
+pub fn discover_files_by_language_parallel_with_progress(root_dir: &str, show_progress: bool) -> Result<HashMap<String, Vec<PathBuf>>> {
+    discover_files_by_language_with_progress(root_dir, true, show_progress)
+}
+
+/// Sequential file discovery with progress control
+pub fn discover_files_by_language_sequential_with_progress(root_dir: &str, show_progress: bool) -> Result<HashMap<String, Vec<PathBuf>>> {
+    discover_files_by_language_with_progress(root_dir, false, show_progress)
 }
 
 // =========================================================================

--- a/test_files/false_positives/README.md
+++ b/test_files/false_positives/README.md
@@ -1,0 +1,87 @@
+# False Positive Regression Tests
+
+This directory contains test files designed to prevent regression of false positive issues that have been previously identified and fixed in the vulnerability scanner.
+
+## Purpose
+
+False positives are a critical issue in security scanners because they:
+- Reduce trust in the tool
+- Create noise that masks real vulnerabilities
+- Waste developer time investigating non-issues
+- Can lead to the scanner being disabled or ignored
+
+These tests ensure that once a false positive issue is fixed, it doesn't reappear in future updates.
+
+## Test Files
+
+### `cleartext_transmission_false_positives.js`
+
+**Issue**: Clear-text Transmission rule was generating false positives due to overly broad taint source patterns.
+
+**Problem**: Patterns like `"password"`, `"*[type=password]*"`, `"*[name*=token]*"` were matching any variable name containing these keywords, not just actual user input sources.
+
+**Impact**: 
+- THREE.js library: 20 false positives from constants like `DDPF_ALPHAPIXELS`
+- Any library with variables containing "password", "token", "key", etc.
+- Function parameters with these names were incorrectly flagged
+
+**Expected Results**:
+- 3 TRUE POSITIVES (legitimate vulnerabilities)
+- 0 FALSE POSITIVES (library code, constants, function parameters)
+
+**Test Command**:
+```bash
+./target/debug/find_vulns test_files/false_positives/cleartext_transmission_false_positives.js --code-type frontend --taint-analysis
+```
+
+**Fixed Rule**: `js-cleartext-network-taint-001`
+
+## Running Tests
+
+To run all false positive tests:
+
+```bash
+# Run individual test
+./target/debug/find_vulns test_files/false_positives/cleartext_transmission_false_positives.js --code-type frontend --taint-analysis
+
+# Count results to validate
+./target/debug/find_vulns test_files/false_positives/cleartext_transmission_false_positives.js --code-type frontend --taint-analysis --output-format json | grep -c "Clear-text Transmission"
+```
+
+## Adding New Tests
+
+When adding new false positive regression tests:
+
+1. Create a descriptive filename: `{rule_category}_{issue_description}_false_positives.{ext}`
+2. Include comprehensive documentation in the file header:
+   - Issue description
+   - Problem patterns that were fixed
+   - Real-world impact
+   - Expected behavior
+   - Test commands
+3. Include both TRUE POSITIVES and FALSE POSITIVES sections
+4. Add validation instructions
+5. Update this README
+
+## Validation
+
+Each test file should:
+- Produce a known number of legitimate vulnerabilities (TRUE POSITIVES)
+- Produce zero false positives from the problematic patterns
+- Include clear documentation of expected results
+- Be runnable with a simple command
+
+## Maintenance
+
+- Run these tests before each release
+- Update tests when rules are modified
+- Add new tests when false positives are reported and fixed
+- Keep expected result counts updated in documentation
+
+## Integration
+
+These tests should be integrated into:
+- CI/CD pipelines
+- Pre-release validation
+- Automated testing suites
+- Developer workflow checks 

--- a/test_files/false_positives/cleartext_transmission_false_positives.js
+++ b/test_files/false_positives/cleartext_transmission_false_positives.js
@@ -1,0 +1,223 @@
+/**
+ * FALSE POSITIVE REGRESSION TEST: Clear-text Transmission
+ * 
+ * ISSUE DESCRIPTION:
+ * The Clear-text Transmission rule (js-cleartext-network-taint-001) was generating
+ * false positives due to overly broad taint source patterns that matched any variable
+ * name containing sensitive keywords, rather than actual user input sources.
+ * 
+ * PROBLEM PATTERNS (Fixed):
+ * - "password" - matched any variable named "password"
+ * - "*[type=password]*" - matched any identifier containing "type=password"
+ * - "*[name*=token]*" - matched any identifier containing "name*=token"
+ * - "*[name*=key]*" - matched any identifier containing "name*=key"
+ * 
+ * REAL WORLD IMPACT:
+ * - THREE.js library: 20 false positives from constants like DDPF_ALPHAPIXELS
+ * - Any library with variables containing "password", "token", "key", etc.
+ * - Function parameters with these names were incorrectly flagged
+ * 
+ * EXPECTED BEHAVIOR:
+ * - This file should produce 3 TRUE POSITIVES (legitimate vulnerabilities)
+ * - This file should produce 0 FALSE POSITIVES (library code, constants, etc.)
+ * 
+ * FIXED RULE DATE: 2024-01-XX
+ * RULE ID: js-cleartext-network-taint-001
+ * 
+ * TEST COMMAND:
+ * ./target/debug/find_vulns test_files/false_positives/cleartext_transmission_false_positives.js --code-type frontend --taint-analysis
+ * 
+ * EXPECTED RESULTS:
+ * - 3 Clear-text Transmission vulnerabilities (lines 43, 52, 61)
+ * - 0 false positives from library code section
+ */
+
+// ========================================================================
+// TRUE POSITIVES: These SHOULD be detected as vulnerabilities
+// ========================================================================
+
+// 1. Real password field access transmitted over HTTP
+function submitLoginForm() {
+    var password = document.getElementById('password').value;
+    var xhr = new XMLHttpRequest();
+    xhr.open('POST', 'http://example.com/login'); // HTTP not HTTPS
+    xhr.send(JSON.stringify({ password: password }));
+}
+
+// 2. Real form data with sensitive token transmitted over HTTP
+function submitTokenForm() {
+    var userToken = document.querySelector('input[name=token]').value;
+    fetch('http://api.example.com/data', { // HTTP not HTTPS
+        method: 'POST',
+        body: JSON.stringify({ token: userToken })
+    });
+}
+
+// 3. Real localStorage sensitive data transmitted over HTTP
+function sendStoredApiKey() {
+    var apiKey = localStorage.getItem('apiKey');
+    var request = new XMLHttpRequest();
+    request.open('GET', 'http://api.example.com/data?key=' + apiKey); // HTTP not HTTPS
+    request.send();
+}
+
+// ========================================================================
+// FALSE POSITIVES: These should NOT be detected (library code patterns)
+// ========================================================================
+
+// THREE.js-style constants (should NOT be flagged)
+var DDPF_ALPHAPIXELS = 0x1;
+var DDPF_ALPHA = 0x2;
+var DDPF_FOURCC = 0x4;
+var DDPF_RGB = 0x40;
+var DDPF_YUV = 0x200;
+var DDPF_LUMINANCE = 0x20000;
+
+// THREE.js-style texture loading (should NOT be flagged)
+function loadTexture(url, mapping, onLoad, onError) {
+    var loader = new ImageLoader();
+    loader.crossOrigin = this.crossOrigin;
+    
+    var texture = new Texture(undefined, mapping);
+    var request = new XMLHttpRequest();
+    
+    request.onload = function() {
+        var buffer = request.response;
+        texture.needsUpdate = true;
+        if (onLoad) onLoad(texture);
+    };
+    
+    request.onerror = onError;
+    request.open('GET', url, true);
+    request.responseType = "arraybuffer";
+    request.send(null);
+    
+    return texture;
+}
+
+// Generic library code with "sensitive" variable names (should NOT be flagged)
+function processConfig() {
+    var password = "hardcoded_config_value";
+    var token = "Bearer " + "static_token";
+    var key = "encryption_key_constant";
+    var secret = "app_secret_constant";
+    var apiKey = "public_api_key";
+    
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://api.example.com/config'); // HTTPS is OK
+    xhr.send();
+}
+
+// Function parameters with sensitive names (should NOT be flagged)
+function authenticateUser(username, password, token, apiKey) {
+    var request = new XMLHttpRequest();
+    request.open('POST', 'https://secure.example.com/auth'); // HTTPS is OK
+    request.send(JSON.stringify({
+        username: username,
+        // These are parameters, not DOM inputs
+        password: password,
+        token: token,
+        apiKey: apiKey
+    }));
+}
+
+// Graphics library patterns (should NOT be flagged)
+var ImageUtils = {
+    crossOrigin: undefined,
+    
+    loadCompressedTexture: function(url, mapping, onLoad, onError) {
+        var texture = new CompressedTexture();
+        texture.mapping = mapping;
+        
+        var request = new XMLHttpRequest();
+        
+        request.onload = function() {
+            var buffer = request.response;
+            texture.needsUpdate = true;
+            if (onLoad) onLoad(texture);
+        };
+        
+        request.onerror = onError;
+        request.open('GET', url, true);
+        request.responseType = "arraybuffer";
+        request.send(null);
+        
+        return texture;
+    }
+};
+
+// Crypto library constants (should NOT be flagged)
+var CRYPTO_CONSTANTS = {
+    DES_KEY_SIZE: 8,
+    AES_KEY_SIZE: 32,
+    RSA_KEY_SIZE: 2048,
+    HMAC_SECRET_SIZE: 64
+};
+
+function initializeCrypto() {
+    var key = CRYPTO_CONSTANTS.AES_KEY_SIZE;
+    var secret = CRYPTO_CONSTANTS.HMAC_SECRET_SIZE;
+    
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://crypto.example.com/init'); // HTTPS is OK
+    xhr.send();
+}
+
+// Database connection strings (should NOT be flagged - these are config, not user input)
+var DB_CONFIG = {
+    password: "db_password_from_env",
+    token: "db_access_token",
+    key: "db_encryption_key"
+};
+
+function connectToDatabase() {
+    var request = new XMLHttpRequest();
+    request.open('POST', 'https://database.example.com/connect'); // HTTPS is OK
+    request.send(JSON.stringify(DB_CONFIG));
+}
+
+// ========================================================================
+// EDGE CASES: These should NOT be flagged
+// ========================================================================
+
+// Variable names that contain sensitive substrings but aren't actual sensitive data
+var passwordValidator = "regex_pattern";
+var tokenParser = "parsing_function";
+var keyGenerator = "key_generation_algorithm";
+var secretManager = "secret_management_service";
+
+function utilityFunction() {
+    var request = new XMLHttpRequest();
+    request.open('GET', 'https://utils.example.com/tools'); // HTTPS is OK
+    request.send();
+}
+
+// Comments and strings containing sensitive words (should NOT be flagged)
+function documentedFunction() {
+    // This function handles password validation
+    // It also manages token refresh
+    // API key rotation is handled separately
+    
+    var message = "Enter your password to continue";
+    var instruction = "Your token will expire in 1 hour";
+    
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://docs.example.com/help'); // HTTPS is OK
+    xhr.send();
+}
+
+/**
+ * REGRESSION TEST VALIDATION:
+ * 
+ * To validate this test file:
+ * 1. Run: ./target/debug/find_vulns test_files/false_positives/cleartext_transmission_false_positives.js --code-type frontend --taint-analysis
+ * 2. Expected: Exactly 3 Clear-text Transmission vulnerabilities
+ * 3. Expected: 0 false positives from library code sections
+ * 4. If more than 3 vulnerabilities are found, the rule has regressed
+ * 5. If fewer than 3 vulnerabilities are found, the rule is too restrictive
+ * 
+ * MAINTENANCE:
+ * - Update this file when adding new sensitive data patterns
+ * - Add new false positive cases when encountered in real projects
+ * - Keep the expected results count updated in comments
+ */ 

--- a/test_files/javascript/dom_xss_test.js
+++ b/test_files/javascript/dom_xss_test.js
@@ -27,4 +27,26 @@ function testSafeInnerHTML(userInput) {
 function testSafeTextContent(userInput) {
     const div = document.createElement('div');
     div.textContent = userInput; // Should not trigger
+}
+
+// Case 6: Function call chain DOM XSS (like in test fixtures)
+function waitForElementsInnerHtmlToBe(selector, htmlContent) {
+    const element = document.querySelector(selector);
+    if (element) {
+        element.innerHTML = htmlContent; // Should trigger DOM XSS
+    }
+}
+
+// Case 7: Test fixture pattern with function call
+function testFixturePattern() {
+    const testFixture = {
+        text: 'Hit enter again.',
+        fixture: '.fill-remaining-space',
+        unskippable: true,
+        resolved: waitForElementsInnerHtmlToBe('#searchValue', '<h1>owasp</h1>') // Should be flagged
+    };
+    
+    // More obvious XSS case with user input
+    const userInput = window.location.search;
+    waitForElementsInnerHtmlToBe('#searchValue', userInput); // Should definitely be caught
 } 

--- a/test_files/javascript/tsx_xss_test.tsx
+++ b/test_files/javascript/tsx_xss_test.tsx
@@ -1,0 +1,28 @@
+export const onRendererLoad = ({
+  ipc: { invoke, on },
+}: RendererContext<LyricsGeniusPluginConfig>) => {
+  const setLyrics = (lyricsContainer: Element, lyrics: string | null) => {
+    const targetHtml = `
+      <div id="contents" class="style-scope ytmusic-section-list-renderer description ytmusic-description-shelf-renderer genius-lyrics">
+        ${
+          lyrics?.replaceAll(/\r\n|\r|\n/g, '<br/>') ??
+          'Could not retrieve lyrics from genius'
+        }
+      </div>
+      <yt-formatted-string class="footer style-scope ytmusic-description-shelf-renderer" style="align-self: baseline">
+      </yt-formatted-string>
+    `;
+    (lyricsContainer.innerHTML as string | TrustedHTML) =
+      defaultTrustedTypePolicy
+        ? defaultTrustedTypePolicy.createHTML(targetHtml)
+        : targetHtml;
+
+    if (lyrics) {
+      const footer = lyricsContainer.querySelector('.footer');
+
+      if (footer) {
+        footer.textContent = 'Source: Genius';
+      }
+    }
+  };
+}; 

--- a/test_files/test_backend_rules.js
+++ b/test_files/test_backend_rules.js
@@ -1,0 +1,25 @@
+// Test backend security rules
+
+// Server-side Open Redirect
+const redirectUrl = req.query.url;
+res.setHeader('Location', redirectUrl);
+
+// Express style redirect  
+app.get('/redirect', (req, res) => {
+    const target = req.query.target;
+    res.redirect(target);
+});
+
+// Command Injection
+const userCmd = req.body.command;
+child_process.exec(userCmd);
+
+// SQL Injection
+const searchTerm = req.params.search;
+db.query("SELECT * FROM users WHERE name = '" + searchTerm + "'");
+
+// Path Traversal
+const filename = req.query.file;
+fs.readFile(filename, (err, data) => {
+    res.send(data);
+}); 

--- a/tests/integration/integration_tests.rs
+++ b/tests/integration/integration_tests.rs
@@ -66,7 +66,7 @@ def paste_data():
         // Load and validate rules
         let rules = Rules::load_from_file(rules_file.path().to_str().unwrap())
             .expect("Failed to load rules");
-        
+
         let malware_rules = rules.malware_detection.unwrap();
         assert_eq!(malware_rules.len(), 2);
 
@@ -94,13 +94,13 @@ def test_clipboard_operations():
     # Various clipboard access patterns
     pyperclip.copy("data")
     data = pyperclip.paste()
-    
+
     df = pd.DataFrame({"col": [1, 2, 3]})
     df.to_clipboard()
-    
+
     root = tk.Tk()
     root.clipboard_append("text")
-    
+
     # Non-matching function
     print("safe operation")
 "#;


### PR DESCRIPTION
Modified frontend_security.ron so that it has high accuracy of findings. 
- Dropping some function from sanitizers as they don't really sanitize it and still raises risks. 

- Added logic for tsx file to look at javascript rules. 

- Added code type detection (frontend /backend) and language filter

- fixed taint system for javascript. some declaration were missing and also not supporting js style declaration like `const/let/var variable = value`


- Updated rule for Prototype Pollution

<img width="884" alt="image" src="https://github.com/user-attachments/assets/236c1966-6ff0-43a1-87f3-7b2c12a92893" />
