### PR TITLE
Add CWE as response, export linux compatible binary, etc for fusion integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,6 +330,7 @@ dependencies = [
  "env_logger",
  "glob",
  "indicatif",
+ "lazy_static",
  "log",
  "memmap2",
  "num_cpus",
@@ -463,6 +464,12 @@ dependencies = [
  "once_cell",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ syntect = "5.1"
 memmap2 = "0.9"
 log = "0.4"
 env_logger = "0.10"
+lazy_static = "1.4"
 dbg_breakpoint="0.1.1"
 [dev-dependencies]
 tempfile = "3.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,6 @@ repository = "https://github.com/corgea/greppy_prototype"
 name = "find_vulns"
 path = "src/main.rs"
 
-[lib]
-name = "find_vulns"
-path = "src/lib.rs"
-
 [features]
 default = ["python", "java", "javascript", "tsx", "html", "django"]
 python = ["tree-sitter-python"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Multi-stage Dockerfile for building find_vulns binary
+# Stage 1: Build the binary
+FROM rust:1.80-slim AS builder
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set working directory
+WORKDIR /app
+
+# Copy source code
+COPY . .
+
+# Remove Cargo.lock to avoid version conflicts in container
+RUN rm -f Cargo.lock
+
+# Build the release binary
+RUN cargo build --release
+
+# Export stage - minimal image with just the binary and required files
+FROM scratch AS export
+COPY --from=builder /app/target/release/find_vulns /find_vulns
+COPY --from=builder /app/rules /rules

--- a/README.md
+++ b/README.md
@@ -43,12 +43,19 @@ A high-performance vulnerability scanner for source code using tree-sitter parsi
 
 ### Build from Source
 ```bash
-git clone https://github.com/corgea/greppy_prototype.git
-cd greppy_prototype
+git clone https://github.com/corgea/Sighthound.git
+cd Sighthound
 cargo build --release
 ```
 
 The binary will be available at `target/release/find_vulns`.
+
+In order to build linux container compatible binary,
+```bash
+docker build --target export -t find-vulns-export:latest .
+docker run --rm -v $(pwd):/output find-vulns-export sh -c "cp /find_vulns /output/
+```
+Then binary `find_vulns` would be exported at the current folder.
 
 ### Development Setup
 ```bash

--- a/rules/backend_javascript/backend_security.ron
+++ b/rules/backend_javascript/backend_security.ron
@@ -111,6 +111,7 @@
             finding_type: Some("Open Redirect"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-601"),
             
             description: Some("User-controlled data flows to HTTP redirect headers without validation"),
             
@@ -215,6 +216,7 @@
             finding_type: Some("Command Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-78"),
             
             description: Some("User-controlled data flows to command execution without sanitization"),
             
@@ -319,6 +321,7 @@
             finding_type: Some("SQL Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-89"),
             
             description: Some("User-controlled data flows to SQL queries without parameterization"),
             
@@ -424,6 +427,7 @@
             finding_type: Some("Path Traversal"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-22"),
             
             description: Some("User-controlled data flows to file system operations without path validation"),
             
@@ -506,6 +510,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             
             description: Some("User-controlled data flows to code execution without validation"),
             

--- a/rules/javascript/frontend_security.ron
+++ b/rules/javascript/frontend_security.ron
@@ -40,6 +40,7 @@
             finding_type: Some("DOM XSS"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
             description: Some("Direct assignment to innerHTML with user input can lead to DOM-XSS"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["xss", "dom", "frontend", "cwe-79"])
@@ -74,6 +75,7 @@
             finding_type: Some("DOM XSS"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
             description: Some("Using document.write with dynamic content can lead to DOM-based XSS"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["xss", "dom", "frontend", "cwe-79"])
@@ -89,6 +91,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             description: Some("eval() with dynamic content can lead to code injection"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["code-injection", "frontend", "cwe-80", "cwe-95"])
@@ -104,6 +107,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             description: Some("Function constructor with dynamic content can lead to code injection"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["code-injection", "frontend", "cwe-80", "cwe-95"])
@@ -117,6 +121,7 @@
             finding_type: Some("Insecure postMessage"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-346"),
             description: Some("Using postMessage with \"*\" origin can leak data to any site"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["postmessage", "origin-validation", "frontend", "cwe-1173", "cwe-927"])
@@ -133,6 +138,7 @@
             finding_type: Some("Insecure Storage"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-922"),
             description: Some("Storing secrets in web storage is insecure"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["insecure-storage", "frontend", "cwe-922", "cwe-200"])
@@ -158,10 +164,11 @@
             finding_type: Some("Prototype Pollution"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-1321"),
             description: Some("Direct prototype manipulation can poison objects"),
             file_types: Some((
                 extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
-            tags: Some(["prototype-pollution", "frontend"])
+            tags: Some(["prototype-pollution", "frontend", "cwe-1321"])
         ),
         (
             id: Some("js-cleartext-001"),
@@ -176,6 +183,7 @@
             finding_type: Some("Cleartext Network Request"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-319"),
             description: Some("HTTP requests send data in cleartext – use HTTPS"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["cleartext", "network", "https", "frontend", "cwe-319"])
@@ -189,6 +197,7 @@
             finding_type: Some("Cleartext Network Request"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-319"),
             description: Some("XHR over HTTP transmits data in cleartext"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["cleartext", "network", "xhr", "frontend", "cwe-319"])
@@ -229,6 +238,7 @@
                     "*encodeURIComponent(*)*"
                 ])
             )),
+            cwe_id: Some("cwe-601"),
             tags: Some(["open-redirect","frontend","cwe-601"])
         ),
         (
@@ -240,6 +250,7 @@
             finding_type: Some("Open Redirect"),
             severity: Some("Low"),
             confidence: Some("Low"),
+            cwe_id: Some("cwe-601"),
             description: Some("Manipulating location.hash can enable client-side attacks"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["open-redirect","hash-manipulation","frontend","cwe-601"])
@@ -256,6 +267,7 @@
             finding_type: Some("Dynamic Code Loading"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-95"),
             description: Some("User-controlled module paths can lead to code injection"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["code-injection","dynamic-import","frontend","cwe-95"])
@@ -275,6 +287,7 @@
             finding_type: Some("Regular Expression DoS"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-1333"),
             description: Some("Dynamic regex patterns can cause ReDoS"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["redos","regex","frontend","cwe-1333"])
@@ -288,6 +301,7 @@
             finding_type: Some("URL Manipulation"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-601"),
             description: Some("Building URLs from untrusted data can be risky"),
             file_types: Some((extensions: Some([".js", ".jsx", ".ts", ".tsx"]))),
             tags: Some(["url-manipulation","frontend","cwe-601"])

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -97,6 +97,7 @@
             finding_type: Some("DOM-based XSS"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
             
             description: Some("User input flows to dangerous DOM manipulation without sanitization"),
             
@@ -270,6 +271,7 @@
             finding_type: Some("Cross-Site Scripting"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
             
             description: Some("User input flows to output context without proper encoding"),
             
@@ -408,6 +410,7 @@
             finding_type: Some("Information Disclosure"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-200"),
             
             description: Some("Sensitive information may be exposed through logging, network requests, or URL parameters"),
             
@@ -485,6 +488,7 @@
             finding_type: Some("Improper Output Encoding"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-116"),
             
             description: Some("User data is output without proper context-specific encoding"),
             
@@ -551,6 +555,7 @@
             finding_type: Some("Template Injection"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-1336"),
             
             description: Some("User input flows to template compilation/rendering without sanitization"),
             
@@ -643,6 +648,7 @@
             finding_type: Some("Open Redirect"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-601"),
             
             description: Some("User-controlled input flows to URL redirection without validation"),
             
@@ -763,6 +769,7 @@
             finding_type: Some("Insecure postMessage"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-346"),
             
             description: Some("postMessage data is used in dangerous operations without proper validation"),
             
@@ -818,6 +825,7 @@
             finding_type: Some("Missing Origin Validation"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-346"),
             
             description: Some("postMessage data is processed without validating the message origin"),
             
@@ -970,7 +978,7 @@
             finding_type: Some("Insecure Storage"),
             severity: Some("Medium"),
             confidence: Some("High"),
-            
+            cwe_id: Some("cwe-922"),
             description: Some("Sensitive authentication or cryptographic data is stored in browser storage without proper encryption"),
             
             file_types: Some((
@@ -1060,7 +1068,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
-            
+            cwe_id: Some("cwe-95"),
             description: Some("User-controlled input flows to code evaluation functions"),
             
             file_types: Some((
@@ -1124,6 +1132,7 @@
             finding_type: Some("ReDoS"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-1333"),
             
             description: Some("User input flows to regex operations without validation, potentially causing ReDoS"),
             
@@ -1190,6 +1199,7 @@
             finding_type: Some("Weak Randomness"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
             
             description: Some("Weak random values are used in security-sensitive contexts"),
             
@@ -1376,6 +1386,7 @@
             finding_type: Some("Clear-text Transmission"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-319"),
             
             description: Some("Sensitive data is transmitted over unencrypted connections"),
             
@@ -1487,7 +1498,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
-            
+            cwe_id: Some("cwe-95"),
             description: Some("User-controlled data flows to code execution functions without validation"),
             
             file_types: Some((
@@ -1583,6 +1594,7 @@
             finding_type: Some("Open Redirect"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-601"),
             
             description: Some("User-controlled data flows to navigation without validation, enabling open redirects"),
             
@@ -1674,6 +1686,7 @@
             finding_type: Some("Dynamic Code Loading"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-95"),
             
             description: Some("User-controlled module paths can lead to arbitrary code execution"),
             
@@ -1761,7 +1774,7 @@
             finding_type: Some("URL Manipulation"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
-            
+            cwe_id: Some("cwe-601"),
             description: Some("User input flows to URL construction without validation"),
             
             file_types: Some((
@@ -1770,4 +1783,4 @@
             tags: Some(["url-manipulation", "cwe-601"])
         )
     ]
-) 
+)

--- a/rules/python/command_injection.ron
+++ b/rules/python/command_injection.ron
@@ -19,6 +19,7 @@
             finding_type: Some("Command Injection"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-78"),
             description: Some("Command execution detected - verify input is properly sanitized"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -43,6 +44,7 @@
             finding_type: Some("Command Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-78"),
             description: Some("Command constructed using string formatting, highly vulnerable to injection"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -64,6 +66,7 @@
             finding_type: Some("Command Injection"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-78"),
             description: Some("Command constructed using string concatenation, vulnerable to injection"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -111,6 +114,7 @@
             finding_type: Some("Command Injection via Taint Flow"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-78"),
             description: Some("User input flows directly to command execution without proper sanitization"),
             file_types: Some((
                 extensions: Some([".py"])

--- a/rules/python/cryptography.ron
+++ b/rules/python/cryptography.ron
@@ -15,6 +15,7 @@
             finding_type: Some("Weak Cryptography"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-327"),
             description: Some("MD5 is cryptographically broken and should not be used for security purposes"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -35,6 +36,7 @@
             finding_type: Some("Weak Cryptography"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-327"),
             description: Some("SHA1 is cryptographically weak and should be replaced with SHA-256 or higher"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -54,6 +56,7 @@
             finding_type: Some("Weak Cryptography"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-327"),
             description: Some("DES encryption is obsolete and easily broken"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -73,6 +76,7 @@
             finding_type: Some("Weak Cryptography"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-327"),
             description: Some("RC4 stream cipher has known vulnerabilities and should not be used"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -93,6 +97,7 @@
             finding_type: Some("Hardcoded Cryptographic Material"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-798"),
             description: Some("Hardcoded cryptographic keys or secrets detected"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -113,6 +118,7 @@
             finding_type: Some("Weak Random Number Generation"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-338"),
             description: Some("Standard random module is not cryptographically secure, use secrets module instead"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -132,6 +138,7 @@
             finding_type: Some("Weak Cryptography"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-327"),
             description: Some("ECB mode encryption is insecure and reveals patterns in plaintext"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -162,6 +169,7 @@
             finding_type: Some("Hardcoded Cryptographic Material in Data Flow"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-798"),
             description: Some("Hardcoded string flows to cryptographic operations"),
             file_types: Some((
                 extensions: Some([".py"])

--- a/rules/python/file_system.ron
+++ b/rules/python/file_system.ron
@@ -15,6 +15,7 @@
             finding_type: Some("Path Traversal"),
             severity: Some("High"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-22"),
             description: Some("Potential path traversal vulnerability detected"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -36,6 +37,7 @@
             finding_type: Some("Path Traversal"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-22"),
             description: Some("File path constructed dynamically, verify input validation"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -59,6 +61,7 @@
             finding_type: Some("Insecure File Permissions"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-732"),
             description: Some("File permissions set to world-writable or overly permissive"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -79,6 +82,7 @@
             finding_type: Some("Insecure Temporary File"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-377"),
             description: Some("Insecure temporary file usage detected"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -100,6 +104,7 @@
             finding_type: Some("File Upload Vulnerability"),
             severity: Some("Medium"),
             confidence: Some("Low"),
+            cwe_id: Some("cwe-434"),
             description: Some("File upload detected - verify file type validation and restrictions"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -147,6 +152,7 @@
             finding_type: Some("Path Traversal via Taint Flow"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-22"),
             description: Some("User input flows to file system operations without proper path validation"),
             file_types: Some((
                 extensions: Some([".py"])

--- a/rules/python/general_security.ron
+++ b/rules/python/general_security.ron
@@ -12,6 +12,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             description: Some("Use of eval() can lead to arbitrary code execution"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -29,6 +30,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             description: Some("Use of exec() can lead to arbitrary code execution"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -47,6 +49,7 @@
             finding_type: Some("Dynamic Import"),
             severity: Some("Medium"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-95"),
             description: Some("Dynamic imports can be dangerous if user input is involved"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -70,6 +73,7 @@
             finding_type: Some("Unsafe Deserialization"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-502"),
             description: Some("Pickle deserialization is unsafe with untrusted data"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -88,6 +92,7 @@
             finding_type: Some("Unsafe Deserialization"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-502"),
             description: Some("YAML load() is unsafe, use safe_load() instead"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -109,6 +114,7 @@
             finding_type: Some("SSL Verification Disabled"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-295"),
             description: Some("SSL certificate verification is disabled"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -128,6 +134,7 @@
             finding_type: Some("Insecure HTTP URL"),
             severity: Some("Low"),
             confidence: Some("Medium"),
+            cwe_id: Some("cwe-319"),
             description: Some("HTTP URLs should be HTTPS in production"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -149,6 +156,7 @@
             finding_type: Some("Debug Mode Enabled"),
             severity: Some("Medium"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-489"),
             description: Some("Debug mode should be disabled in production"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -168,6 +176,7 @@
             finding_type: Some("Information Disclosure"),
             severity: Some("Low"),
             confidence: Some("Low"),
+            cwe_id: Some("cwe-209"),
             description: Some("Exception handling may disclose sensitive information"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -208,6 +217,7 @@
             finding_type: Some("Code Injection via Taint Flow"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             description: Some("User input flows to code execution functions without proper validation"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -241,6 +251,7 @@
             finding_type: Some("Unsafe Deserialization via Taint Flow"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-502"),
             description: Some("User input flows to unsafe deserialization functions"),
             file_types: Some((
                 extensions: Some([".py"])

--- a/rules/python/simple_test.ron
+++ b/rules/python/simple_test.ron
@@ -6,6 +6,7 @@
             finding_type: Some("Code Injection"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             file_types: Some((
                 extensions: Some([".py"]),
                 include_patterns: None,

--- a/rules/python/sql_injection.ron
+++ b/rules/python/sql_injection.ron
@@ -19,6 +19,7 @@
             finding_type: Some("Dangerous SQL Keywords"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-89"),
             description: Some("Dangerous SQL keywords detected that could indicate SQL injection attempts or malicious queries"),
             file_types: Some((
                 extensions: Some([".py"])
@@ -46,6 +47,7 @@
             finding_type: Some("SQL Injection Data Flow"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-89"),
             description: Some("User input flows to SQL execution without proper sanitization, creating SQL injection vulnerability"),
             file_types: Some((
                 extensions: Some([".py"])

--- a/rules/python/working.ron
+++ b/rules/python/working.ron
@@ -7,6 +7,7 @@
             finding_type: Some("Dangerous Function"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             file_types: Some((
                 extensions: Some([".py"]),
                 include_patterns: None,
@@ -31,6 +32,7 @@
             finding_type: Some("Code Execution"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
             file_types: Some((
                 extensions: Some([".py"]),
                 include_patterns: None,
@@ -55,6 +57,7 @@
             finding_type: Some("Command Execution"),
             severity: Some("High"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-78"),
             file_types: Some((
                 extensions: Some([".py"]),
                 include_patterns: None,
@@ -79,6 +82,7 @@
             finding_type: Some("Unsafe Deserialization"),
             severity: Some("Critical"),
             confidence: Some("High"),
+            cwe_id: Some("cwe-502"),
             file_types: Some((
                 extensions: Some([".py"]),
                 include_patterns: None,

--- a/src/common.rs
+++ b/src/common.rs
@@ -711,11 +711,26 @@ impl CommonUtils {
     }
 
     /// Validate required CLI parameter combination
-    pub fn validate_cli_params(language: &Option<String>, rules_path: &Option<String>) -> Result<()> {
-        match (language, rules_path) {
-            (Some(_), Some(_)) | (None, None) => Ok(()),
-            _ => Err(anyhow::anyhow!(
-                "Invalid combination. Provide both language and rules path, or use auto-detection"
+    pub fn validate_cli_params(language: &Option<String>, rules_path: &Option<String>, use_embedded_rules: bool, use_file_rules: bool) -> Result<()> {
+        // Resolve the actual embedded rules setting (use_file_rules overrides use_embedded_rules)
+        let should_use_embedded = use_embedded_rules && !use_file_rules;
+        
+        match (language, rules_path, should_use_embedded) {
+            // Explicit mode with embedded rules
+            (Some(_), None, true) => Ok(()),
+            // Explicit mode with file rules
+            (Some(_), Some(_), false) => Ok(()),
+            // Auto-detection mode (embedded or file rules)
+            (None, None, _) => Ok(()),
+            // Invalid combinations
+            (Some(_), Some(_), true) => Err(anyhow::anyhow!(
+                "Cannot specify both --rules-path and embedded rules. Use --use-file-rules to disable embedded rules"
+            )),
+            (Some(_), None, false) => Err(anyhow::anyhow!(
+                "Must specify --rules-path when using explicit mode with --use-file-rules"
+            )),
+            (None, Some(_), _) => Err(anyhow::anyhow!(
+                "Cannot specify --rules-path without language in auto-detection mode"
             )),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,19 +28,26 @@ fn main() -> Result<()> {
     let findings = if cli.taint_analysis {
         run_taint_analysis(&cli, show_progress)?
     } else {
+        // Resolve the actual embedded rules setting (use_file_rules overrides use_embedded_rules)
+        let should_use_embedded = cli.use_embedded_rules && !cli.use_file_rules;
+        
         // Validate CLI parameters using CommonUtils
-        CommonUtils::validate_cli_params(&cli.language, &cli.rules_path)
-            .map_err(|_| anyhow::anyhow!(
-                "❌ Invalid combination. Please provide both language and rules path:\n  \
-                cargo run -- {} <language> <rules_path>\n  \
-                Or use auto-detection (no language/rules args):\n  \
-                cargo run -- {}", 
-                cli.root_dir, cli.root_dir
+        CommonUtils::validate_cli_params(&cli.language, &cli.rules_path, cli.use_embedded_rules, cli.use_file_rules)
+            .map_err(|e| anyhow::anyhow!(
+                "❌ Invalid parameter combination: {}\n\n\
+                Valid usage:\n  \
+                • Explicit mode with embedded rules (default): cargo run -- {} <language>\n  \
+                • Explicit mode with file rules: cargo run -- {} <language> <rules_path> --use-file-rules\n  \
+                • Auto-detection mode with embedded rules (default): cargo run -- {}\n  \
+                • Auto-detection mode with file rules: cargo run -- {} --use-file-rules\n  \
+                • Custom rules directory: cargo run -- {} --rules-dir <custom_rules_dir> --use-file-rules", 
+                e, cli.root_dir, cli.root_dir, cli.root_dir, cli.root_dir, cli.root_dir
             ))?;
 
-        match (&cli.language, &cli.rules_path) {
-            (Some(_), Some(_)) => run_explicit_scan(&cli, show_progress)?,
-            (None, None) => run_auto_detection_scan(&cli, show_progress)?,
+        match (&cli.language, &cli.rules_path, should_use_embedded) {
+            (Some(_), Some(_), false) => run_explicit_scan(&cli, show_progress)?,
+            (Some(_), None, true) => run_explicit_scan(&cli, show_progress)?,
+            (None, None, _) => run_auto_detection_scan(&cli, show_progress)?,
             _ => unreachable!(), // Validation above ensures this won't happen
         }
     };

--- a/src/models.rs
+++ b/src/models.rs
@@ -302,6 +302,18 @@ pub struct Cli {
     #[arg(help = "Path to rules file (.ron) or directory containing multiple .ron rule files")]
     pub rules_path: Option<String>,
     
+    /// Custom rules directory (overrides default 'rules' directory)
+    #[arg(long, help = "Custom rules directory to use instead of default 'rules' directory")]
+    pub rules_dir: Option<String>,
+    
+    /// Use embedded rules instead of loading from files (default: true)
+    #[arg(long, default_value = "true", help = "Use rules embedded in the binary instead of loading from files (default: true)")]
+    pub use_embedded_rules: bool,
+    
+    /// Disable embedded rules and use file-based rules instead
+    #[arg(long, help = "Disable embedded rules and load rules from files (overrides --use-embedded-rules)")]
+    pub use_file_rules: bool,
+    
     /// Output format (text, json, csv)
     #[arg(short, long, default_value = "text", help = "Output format: text, json, or csv")]
     pub output_format: String,

--- a/src/models.rs
+++ b/src/models.rs
@@ -17,6 +17,8 @@ pub struct Finding {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub cwe_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub source_info: Option<SourceInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sink_info: Option<SinkInfo>,
@@ -226,6 +228,10 @@ pub struct UnifiedRule {
     
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
+    pub cwe_id: Option<String>,
+    
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub message: Option<String>,
 }
 
@@ -273,6 +279,8 @@ pub struct Condition {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ancestor_types: Option<Vec<String>>,
 }
+
+
 
 /// CLI configuration structure
 #[derive(clap::Parser)]
@@ -378,6 +386,7 @@ impl Finding {
             severity: "Medium".to_string(),
             confidence: "Medium".to_string(),
             description: None,
+            cwe_id: None,
             source_info: None,
             sink_info: None,
             traces: None,
@@ -395,5 +404,34 @@ impl Finding {
         } else {
             self.traces = Some(vec![trace]);
         }
+    }
+    
+    /// Extract CWE ID from tags field and set the cwe_id field
+    pub fn extract_cwe_id(&mut self) {
+        if let Some(ref tags) = self.tags {
+            // Look for tags that start with "cwe-" and extract the first one
+            for tag in tags {
+                if tag.starts_with("cwe-") {
+                    self.cwe_id = Some(tag.clone());
+                    break;
+                }
+            }
+        }
+    }
+    
+    /// Extract CWE ID from tags if present
+    pub fn extract_cwe_id_from_tags(tags: &Option<Vec<String>>) -> Option<String> {
+        tags.as_ref()
+            .and_then(|tag_list| {
+                tag_list.iter()
+                    .find(|tag| tag.starts_with("cwe-"))
+                    .map(|tag| tag.to_string())
+            })
+    }
+    
+    /// Extract CWE ID from rule tags (kept for backward compatibility)
+    pub fn extract_cwe_id_with_fallback(tags: &[String], _finding_type: &str) -> Option<String> {
+        // Get CWE from rule tags only
+        Finding::extract_cwe_id_from_tags(&Some(tags.to_vec()))
     }
 } 

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -10,6 +10,21 @@ use crate::common::CommonUtils;
 // Re-export for backward compatibility
 pub use crate::models::{UnifiedRule, FileTypes, Condition};
 
+// Embedded rules - include rule files at compile time
+const EMBEDDED_PYTHON_GENERAL_RULES: &str = include_str!("../rules/python/general_security.ron");
+const EMBEDDED_PYTHON_COMMAND_INJECTION_RULES: &str = include_str!("../rules/python/command_injection.ron");
+const EMBEDDED_PYTHON_CRYPTOGRAPHY_RULES: &str = include_str!("../rules/python/cryptography.ron");
+const EMBEDDED_PYTHON_FILE_SYSTEM_RULES: &str = include_str!("../rules/python/file_system.ron");
+const EMBEDDED_PYTHON_SQL_INJECTION_RULES: &str = include_str!("../rules/python/sql_injection.ron");
+const EMBEDDED_PYTHON_WORKING_RULES: &str = include_str!("../rules/python/working.ron");
+const EMBEDDED_JAVASCRIPT_FRONTEND_RULES: &str = include_str!("../rules/javascript/frontend_security.ron");
+const EMBEDDED_JAVASCRIPT_BACKEND_RULES: &str = include_str!("../rules/backend_javascript/backend_security.ron");
+const EMBEDDED_JAVASCRIPT_TAINT_RULES: &str = include_str!("../rules/javascript/frontend_taint_security.ron");
+
+// Add more embedded rules as needed
+// const EMBEDDED_JAVA_RULES: &str = include_str!("../rules/java/security.ron");
+// const EMBEDDED_HTML_RULES: &str = include_str!("../rules/html/security.ron");
+
 // Structure for centralized exclusion patterns
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ExclusionPatterns {
@@ -85,6 +100,91 @@ impl Default for Rules {
 }
 
 impl Rules {
+    /// Load embedded rules for a specific language
+    pub fn load_embedded_rules(language: &str, code_type: Option<&str>) -> Result<Self> {
+        let mut all_rules = Vec::new();
+        
+        match language {
+            "python" => {
+                // Load all Python rule files
+                let general_rules: Rules = ron::from_str(EMBEDDED_PYTHON_GENERAL_RULES)
+                    .context("Failed to parse embedded Python general rules")?;
+                all_rules.push(general_rules);
+                
+                let command_injection_rules: Rules = ron::from_str(EMBEDDED_PYTHON_COMMAND_INJECTION_RULES)
+                    .context("Failed to parse embedded Python command injection rules")?;
+                all_rules.push(command_injection_rules);
+                
+                let cryptography_rules: Rules = ron::from_str(EMBEDDED_PYTHON_CRYPTOGRAPHY_RULES)
+                    .context("Failed to parse embedded Python cryptography rules")?;
+                all_rules.push(cryptography_rules);
+                
+                let file_system_rules: Rules = ron::from_str(EMBEDDED_PYTHON_FILE_SYSTEM_RULES)
+                    .context("Failed to parse embedded Python file system rules")?;
+                all_rules.push(file_system_rules);
+                
+                let sql_injection_rules: Rules = ron::from_str(EMBEDDED_PYTHON_SQL_INJECTION_RULES)
+                    .context("Failed to parse embedded Python SQL injection rules")?;
+                all_rules.push(sql_injection_rules);
+                
+                let working_rules: Rules = ron::from_str(EMBEDDED_PYTHON_WORKING_RULES)
+                    .context("Failed to parse embedded Python working rules")?;
+                all_rules.push(working_rules);
+            }
+            "javascript" | "tsx" => {
+                // Load frontend rules by default
+                let frontend_rules: Rules = ron::from_str(EMBEDDED_JAVASCRIPT_FRONTEND_RULES)
+                    .context("Failed to parse embedded JavaScript frontend rules")?;
+                all_rules.push(frontend_rules);
+                
+                // Load taint rules
+                let taint_rules: Rules = ron::from_str(EMBEDDED_JAVASCRIPT_TAINT_RULES)
+                    .context("Failed to parse embedded JavaScript taint rules")?;
+                all_rules.push(taint_rules);
+                
+                // Load backend rules if requested
+                if let Some(code_type) = code_type {
+                    if code_type != "frontend" {
+                        let backend_rules: Rules = ron::from_str(EMBEDDED_JAVASCRIPT_BACKEND_RULES)
+                            .context("Failed to parse embedded JavaScript backend rules")?;
+                        all_rules.push(backend_rules);
+                    }
+                }
+            }
+            // Add more languages as needed
+            _ => {
+                return Err(anyhow::anyhow!("No embedded rules available for language: {}", language));
+            }
+        }
+        
+        if all_rules.is_empty() {
+            return Ok(Self::default());
+        }
+        
+        Self::merge_rules(all_rules)
+    }
+    
+    /// Load embedded rules for all detected languages
+    pub fn load_all_embedded_rules(languages: &[String], code_type: Option<&str>) -> Result<Self> {
+        let mut all_rules = Vec::new();
+        
+        for language in languages {
+            match Self::load_embedded_rules(language, code_type) {
+                Ok(rules) => all_rules.push(rules),
+                Err(e) => {
+                    // Log warning but continue with other languages
+                    eprintln!("Warning: Failed to load embedded rules for {}: {}", language, e);
+                }
+            }
+        }
+        
+        if all_rules.is_empty() {
+            return Err(anyhow::anyhow!("No embedded rules found for any of the detected languages"));
+        }
+        
+        Self::merge_rules(all_rules)
+    }
+
     pub fn load_from_file(rules_file: &str) -> Result<Self> {
         let content = fs::read_to_string(rules_file)
             .context(format!("Failed to read rules file: {}", rules_file))?;

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -559,6 +559,17 @@ impl ScanningLogic {
         finding.confidence = rule.get_confidence().to_string();
         finding.description = rule.description.clone();
         finding.tags = rule.tags.clone();
+        
+        // Use CWE ID directly from rule, with fallback to tags for backward compatibility
+        finding.cwe_id = rule.cwe_id.clone()
+            .or_else(|| {
+                // Fallback: extract from tags if rule doesn't have cwe_id field
+                if let Some(ref tags) = rule.tags {
+                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+                } else {
+                    None
+                }
+            });
     }
 
     pub fn create_finding(
@@ -581,6 +592,7 @@ impl ScanningLogic {
             confidence: "Medium".to_string(),
             snippet: crate::parser::get_node_text(node, source),
             description: None,
+            cwe_id: None,
             source_info: None,
             sink_info: None,
             traces: None,
@@ -1043,8 +1055,7 @@ impl ScanningLogic {
         _tree: &tree_sitter::Tree,
         _source_bytes: &[u8],
     ) -> crate::models::Finding {
-
-        crate::models::Finding {
+        let mut finding = crate::models::Finding {
             file: sink.file.clone(),
             line: sink.line,
             column: 0,
@@ -1059,6 +1070,7 @@ impl ScanningLogic {
                 "Taint flow detected from {} (line {}) to {} (line {})",
                 source.operation, source.line, sink.operation, sink.line
             ))),
+            cwe_id: None,
             source_info: Some(crate::models::SourceInfo {
                 source_type: source.operation.clone(),
                 location: format!("{}:{}", source.file, source.line),
@@ -1076,7 +1088,20 @@ impl ScanningLogic {
                 "data_flow".to_string(),
                 rule.category.clone().unwrap_or_else(|| "injection".to_string()),
             ]),
-        }
+        };
+
+        // Use CWE ID directly from rule, with fallback to tags for backward compatibility
+        finding.cwe_id = rule.cwe_id.clone()
+            .or_else(|| {
+                // Fallback: extract from tags if rule doesn't have cwe_id field
+                if let Some(ref tags) = rule.tags {
+                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+                } else {
+                    None
+                }
+            });
+
+        finding
     }
 
 
@@ -1726,11 +1751,23 @@ impl ScanningLogic {
             severity: rule.get_severity().to_string(),
             confidence: rule.get_confidence().to_string(),
             description: rule.description.clone(),
+            cwe_id: None,
             source_info: None,
             sink_info: None,
             traces: None,
             tags: rule.tags.clone(),
         };
+
+        // Use CWE ID directly from rule, with fallback to tags for backward compatibility
+        finding.cwe_id = rule.cwe_id.clone()
+            .or_else(|| {
+                // Fallback: extract from tags if rule doesn't have cwe_id field
+                if let Some(ref tags) = rule.tags {
+                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+                } else {
+                    None
+                }
+            });
 
         // Add enhanced source and sink information if taint context is available
         if let Some((tainted_var, taint_info)) = taint_context_info {
@@ -1881,13 +1918,14 @@ pub fn print_findings_json(findings: &[Finding]) {
 
 /// Print findings in CSV format
 pub fn print_findings_csv(findings: &[Finding]) {
-    println!("file,line,function,finding_type,code,severity,confidence,source_type,source_context,sink_type,sink_function,traces");
+    println!("file,line,function,finding_type,code,severity,confidence,cwe_id,source_type,source_context,sink_type,sink_function,traces");
     for finding in findings {
         let code = finding.snippet.replace('"', "\"\"");
         let source_type = finding.source_info.as_ref().map(|s| s.source_type.as_str()).unwrap_or("");
         let source_context = finding.source_info.as_ref().map(|s| s.context.as_str()).unwrap_or("");
         let sink_type = finding.sink_info.as_ref().map(|s| s.sink_type.as_str()).unwrap_or("");
         let sink_function = finding.sink_info.as_ref().map(|s| s.function_name.as_str()).unwrap_or("");
+        let cwe_id = finding.cwe_id.as_deref().unwrap_or("");
 
         let traces = if let Some(traces) = &finding.traces {
             traces.iter()
@@ -1898,9 +1936,9 @@ pub fn print_findings_csv(findings: &[Finding]) {
             String::new()
         };
 
-        println!("{},{},{},{},\"{}\",{},{},{},{},{},{},\"{}\"",
+        println!("{},{},{},{},\"{}\",{},{},{},{},{},{},{},\"{}\"",
                 finding.file, finding.line, finding.function, finding.finding_type,
-                code, finding.severity, finding.confidence, source_type, source_context, sink_type, sink_function, traces);
+                code, finding.severity, finding.confidence, cwe_id, source_type, source_context, sink_type, sink_function, traces);
     }
 }
 
@@ -1957,10 +1995,16 @@ pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: b
             let end_line = (line_num + 3).min(lines.len());
 
             println!("");
-            println!("    {}{}●\x1b[0m {} on line {}",
+            let cwe_info = if let Some(ref cwe_id) = finding.cwe_id {
+                format!(" ({})", cwe_id)
+            } else {
+                String::new()
+            };
+            println!("    {}{}●\x1b[0m {}{} on line {}",
                     severity_color,
                     severity_color,
                     finding.finding_type,
+                    cwe_info,
                     line_num);
 
             // Display source and sink information if available
@@ -2422,7 +2466,7 @@ impl MultiFileTaintAnalyzer {
                 flow.call_chain.len())
         };
 
-        crate::models::Finding {
+        let mut finding = crate::models::Finding {
             file: flow.sink_file.clone(),
             line: flow.sink_line,
             column: 0,
@@ -2434,6 +2478,7 @@ impl MultiFileTaintAnalyzer {
             severity: rule.severity.clone().unwrap_or_else(|| "Medium".to_string()),
             confidence: rule.confidence.clone().unwrap_or_else(|| "High".to_string()),
             description: Some(description),
+            cwe_id: None,
             source_info: Some(crate::models::SourceInfo {
                 source_type: flow.source_pattern.clone(),
                 location: format!("{}:{}", flow.source_file, flow.source_line),
@@ -2447,7 +2492,20 @@ impl MultiFileTaintAnalyzer {
             }),
             traces: None,
             tags: Some(vec!["taint_analysis".to_string(), "cross_file".to_string()]),
-        }
+        };
+
+        // Use CWE ID directly from rule, with fallback to tags for backward compatibility
+        finding.cwe_id = rule.cwe_id.clone()
+            .or_else(|| {
+                // Fallback: extract from tags if rule doesn't have cwe_id field
+                if let Some(ref tags) = rule.tags {
+                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+                } else {
+                    None
+                }
+            });
+
+        finding
     }
 
     /// Build import/export maps for all files
@@ -2869,7 +2927,7 @@ impl MultiFileTaintAnalyzer {
             branch_id: None,
         };
 
-        crate::models::Finding {
+        let mut finding = crate::models::Finding {
             file: flow.sink_file.clone(),
             line: flow.sink_line,
             column: 0,
@@ -2884,6 +2942,7 @@ impl MultiFileTaintAnalyzer {
                 "Cross-file taint flow detected from {} (line {}) to {} (line {})",
                 flow.source_function, flow.source_line, flow.sink_function, flow.sink_line
             ))),
+            cwe_id: None,
             source_info: Some(crate::models::SourceInfo {
                 source_type: "cross_file_import".to_string(),
                 location: format!("{}:{}", flow.source_file, flow.source_line),
@@ -2902,7 +2961,20 @@ impl MultiFileTaintAnalyzer {
                 "data_flow".to_string(),
                 flow.rule.category.clone().unwrap_or_else(|| "injection".to_string()),
             ]),
-        }
+        };
+
+        // Use CWE ID directly from rule, with fallback to tags for backward compatibility
+        finding.cwe_id = flow.rule.cwe_id.clone()
+            .or_else(|| {
+                // Fallback: extract from tags if rule doesn't have cwe_id field
+                if let Some(ref tags) = flow.rule.tags {
+                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+                } else {
+                    None
+                }
+            });
+
+        finding
     }
 
     /// Extract import information from node text - FIXED for multi-line imports and parentheses

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -90,8 +90,18 @@ impl ScanContext {
     }
 }
 
+/// Resolve whether to use embedded rules (use_file_rules overrides use_embedded_rules)
+fn should_use_embedded_rules(cli: &Cli) -> bool {
+    cli.use_embedded_rules && !cli.use_file_rules
+}
+
 /// Load rules based on CLI configuration
 fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
+    // If using embedded rules, load them directly
+    if should_use_embedded_rules(cli) {
+        return Rules::load_all_embedded_rules(&context.detected_languages, cli.code_type.as_deref());
+    }
+    
     match (&cli.language, &cli.rules_path) {
         (Some(_language), Some(rules_path)) => Rules::load_from_path(rules_path),
         (None, None) => {
@@ -112,9 +122,10 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
             };
             
             for language in &context.detected_languages {
+                let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
                 let rules_dir = match language.as_str() {
-                    "tsx" => "rules/javascript".to_string(),
-                    _ => format!("rules/{}", language),
+                    "tsx" => format!("{}/javascript", base_rules_dir),
+                    _ => format!("{}/{}", base_rules_dir, language),
                 };
                 if let Ok(rules) = Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type) {
                     all_rules.push(rules);
@@ -124,8 +135,9 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
                 if matches!(language.as_str(), "javascript" | "tsx") {
                     if let Some(code_type) = &cli.code_type {
                         if code_type != "frontend" {
-                            let backend_rules_file = "rules/backend_javascript/backend_security.ron";
-                            if let Ok(backend_rules) = Rules::load_from_file(backend_rules_file) {
+                            let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
+                            let backend_rules_file = format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
+                            if let Ok(backend_rules) = Rules::load_from_file(&backend_rules_file) {
                                 all_rules.push(backend_rules);
                             }
                         }
@@ -147,17 +159,23 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
 pub fn run_explicit_scan(cli: &Cli, show_progress: bool) -> Result<Vec<Finding>> {
     let language = cli.language.as_ref()
         .ok_or_else(|| anyhow::anyhow!("Language required for explicit scan"))?;
-    let rules_path = cli.rules_path.as_ref()
-        .ok_or_else(|| anyhow::anyhow!("Rules path required for explicit scan"))?;
     
-    let mut all_rules = vec![Rules::load_from_path(rules_path)?];
+    let mut all_rules = if should_use_embedded_rules(cli) {
+        vec![Rules::load_embedded_rules(language, cli.code_type.as_deref())?]
+    } else {
+        let rules_path = cli.rules_path.as_ref()
+            .ok_or_else(|| anyhow::anyhow!("Rules path required for explicit scan when not using embedded rules"))?;
+        vec![Rules::load_from_path(rules_path)?]
+    };
     
     // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
-    if matches!(language.as_str(), "javascript" | "tsx") {
+    // (Note: For embedded rules, backend rules are already loaded in load_embedded_rules)
+    if !should_use_embedded_rules(cli) && matches!(language.as_str(), "javascript" | "tsx") {
         if let Some(code_type) = &cli.code_type {
             if code_type != "frontend"{
-                let backend_rules_file = "rules/javascript/backend_security.ron";
-                if let Ok(backend_rules) = Rules::load_from_file(backend_rules_file) {
+                let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
+                let backend_rules_file = format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
+                if let Ok(backend_rules) = Rules::load_from_file(&backend_rules_file) {
                     all_rules.push(backend_rules);
                 }
             }
@@ -198,11 +216,15 @@ pub fn run_explicit_scan(cli: &Cli, show_progress: bool) -> Result<Vec<Finding>>
         println!("📂 Target directory: {}", cli.root_dir);
         println!("🔧 Language: {}", language);
         
-        let path = std::path::Path::new(rules_path);
-        if path.is_dir() {
-            println!("📋 Rules directory: {}", rules_path);
-        } else {
-            println!("📋 Rules file: {}", rules_path);
+        if should_use_embedded_rules(cli) {
+            println!("📋 Using embedded rules");
+        } else if let Some(rules_path) = &cli.rules_path {
+            let path = std::path::Path::new(rules_path);
+            if path.is_dir() {
+                println!("📋 Rules directory: {}", rules_path);
+            } else {
+                println!("📋 Rules file: {}", rules_path);
+            }
         }
         
         println!("🔍 Running scan with {} rules", total_rules);
@@ -266,38 +288,47 @@ pub fn run_auto_detection_scan(cli: &Cli, show_progress: bool) -> Result<Vec<Fin
     
     // Process languages sequentially to avoid nested parallelism deadlocks
     for (language, files) in lang_jobs {
+        let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
         let rules_dir = match language.as_str() {
-            "tsx" => "rules/javascript".to_string(),
-            _ => format!("rules/{}", language),
+            "tsx" => format!("{}/javascript", base_rules_dir),
+            _ => format!("{}/{}", base_rules_dir, language),
         };
         
-        // Load base rules for the language with centralized exclusions
+        // Load rules - either embedded or from files
         let mut all_rules = Vec::new();
         
-        // Determine exclusion pattern type based on code_type
-        let pattern_type = if let Some(code_type) = &cli.code_type {
-            if code_type == "backend" {
-                "backend"
-            } else if code_type == "frontend" {
-                "frontend"
-            } else {
-                "frontend" // default for "both" or other values
+        if should_use_embedded_rules(cli) {
+            // Use embedded rules
+            if let Ok(embedded_rules) = Rules::load_embedded_rules(&language, cli.code_type.as_deref()) {
+                all_rules.push(embedded_rules);
             }
         } else {
-            "frontend" // default when no code_type specified
-        };
-        
-        if let Ok(base_rules) = Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type) {
-            all_rules.push(base_rules);
-        }
-        
-        // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
-        if matches!(language.as_str(), "javascript" | "tsx") {
-            if let Some(code_type) = &cli.code_type {
-                if code_type != "frontend" {
-                    let backend_rules_dir = "rules/javascript/backend_security.ron";
-                    if let Ok(backend_rules) = Rules::load_from_file(backend_rules_dir) {
-                        all_rules.push(backend_rules);
+            // Load base rules for the language with centralized exclusions
+            // Determine exclusion pattern type based on code_type
+            let pattern_type = if let Some(code_type) = &cli.code_type {
+                if code_type == "backend" {
+                    "backend"
+                } else if code_type == "frontend" {
+                    "frontend"
+                } else {
+                    "frontend" // default for "both" or other values
+                }
+            } else {
+                "frontend" // default when no code_type specified
+            };
+            
+            if let Ok(base_rules) = Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type) {
+                all_rules.push(base_rules);
+            }
+            
+            // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
+            if matches!(language.as_str(), "javascript" | "tsx") {
+                if let Some(code_type) = &cli.code_type {
+                    if code_type != "frontend" {
+                        let backend_rules_dir = format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
+                        if let Ok(backend_rules) = Rules::load_from_file(&backend_rules_dir) {
+                            all_rules.push(backend_rules);
+                        }
                     }
                 }
             }

--- a/test_files/accuracy_tests/cross_file/module_a.py
+++ b/test_files/accuracy_tests/cross_file/module_a.py
@@ -6,72 +6,84 @@ CROSS-FILE TEST MODULE A: Source module with various taint sources
 import os
 import sys
 
+
 class TaintedDataProvider:
     """Class with tainted methods"""
-    
+
     def get_env_data(self):
         """Tainted: Environment data"""
-        return os.environ.get('CLASS_ENV', '')
-    
+        return os.environ.get("CLASS_ENV", "")
+
     def get_argv_data(self):
-        """Tainted: Command line data"""  
+        """Tainted: Command line data"""
         return sys.argv[1] if len(sys.argv) > 1 else ""
+
 
 # CF1: Direct function exports
 def get_database_config():
     """Tainted: Database configuration from environment"""
-    return os.environ.get('DATABASE_CONFIG', '')
+    return os.environ.get("DATABASE_CONFIG", "")
+
 
 def get_user_args():
     """Tainted: User arguments from command line"""
     return sys.argv[2] if len(sys.argv) > 2 else ""
 
+
 # CF2: Wrapped/processed taint
 def process_env_data():
     """Tainted: Processed environment data"""
-    raw = os.getenv('RAW_DATA', '')
+    raw = os.getenv("RAW_DATA", "")
     processed = f"processed_{raw}"
     return processed
 
+
 # CF3: Taint through class instantiation
 provider = TaintedDataProvider()
+
 
 def get_class_env():
     """Tainted: Environment data via class"""
     return provider.get_env_data()
 
+
 def get_class_argv():
     """Tainted: Command line data via class"""
     return provider.get_argv_data()
 
+
 # CF4: Constants and safe data (for comparison)
 SAFE_CONSTANT = "safe_module_constant"
+
 
 def get_safe_module_data():
     """Safe: Module constant"""
     return SAFE_CONSTANT
 
+
 def get_version():
     """Safe: Version information"""
     return "1.0.0"
+
 
 # CF5: Mixed functions with conditional taint
 def get_mixed_data(use_env=True):
     """Mixed: Conditional taint"""
     if use_env:
-        return os.environ.get('MIXED', '')  # Tainted path
+        return os.environ.get("MIXED", "")  # Tainted path
     else:
-        return "safe_default"              # Safe path
+        return "safe_default"  # Safe path
+
 
 __all__ = [
-    'TaintedDataProvider',
-    'get_database_config',
-    'get_user_args', 
-    'process_env_data',
-    'get_class_env',
-    'get_class_argv',
-    'get_safe_module_data',
-    'get_version',
-    'get_mixed_data',
-    'provider'
-] 
+    "TaintedDataProvider",
+    "get_database_config",
+    "get_user_args",
+    "process_env_data",
+    "get_class_env",
+    "get_class_argv",
+    "get_safe_module_data",
+    "get_version",
+    "get_mixed_data",
+    "provider",
+]

--- a/test_files/accuracy_tests/cross_file/module_b.py
+++ b/test_files/accuracy_tests/cross_file/module_b.py
@@ -11,29 +11,33 @@ from module_a import (
     get_class_env,
     get_safe_module_data,
     get_version,
-    TaintedDataProvider
+    TaintedDataProvider,
 )
+
 
 # CF-B1: Direct propagation of tainted data
 def propagate_db_config():
     """Tainted: Propagates database config from module A"""
     config = get_database_config()  # Tainted from module_a
-    return f"propagated_{config}"   # Still tainted
+    return f"propagated_{config}"  # Still tainted
+
 
 def propagate_user_args():
     """Tainted: Propagates user args from module A"""
     args = get_user_args()  # Tainted from module_a
-    return args.upper()     # Still tainted
+    return args.upper()  # Still tainted
+
 
 # CF-B2: Combining multiple tainted sources
 def combine_tainted_sources():
     """Tainted: Combines multiple tainted sources"""
     db_config = get_database_config()  # Tainted
-    user_args = get_user_args()        # Tainted
-    processed = process_env_data()     # Tainted
-    
+    user_args = get_user_args()  # Tainted
+    processed = process_env_data()  # Tainted
+
     combined = f"{db_config}_{user_args}_{processed}"
     return combined  # Tainted (combination of tainted sources)
+
 
 # CF-B3: Class-based taint propagation
 def propagate_class_taint():
@@ -41,12 +45,14 @@ def propagate_class_taint():
     class_data = get_class_env()  # Tainted from module_a class
     return f"class_processed_{class_data}"
 
+
 # CF-B4: Safe data propagation (should NOT be flagged)
 def propagate_safe_data():
     """Safe: Propagates safe data from module A"""
     safe_data = get_safe_module_data()  # Safe from module_a
-    version = get_version()             # Safe from module_a
-    return f"{safe_data}_v{version}"    # Should remain safe
+    version = get_version()  # Safe from module_a
+    return f"{safe_data}_v{version}"  # Should remain safe
+
 
 # CF-B5: Mixed safe and tainted (should be flagged)
 def mix_safe_and_tainted():
@@ -55,43 +61,48 @@ def mix_safe_and_tainted():
     tainted_part = get_database_config()  # Tainted
     return f"{safe_part}_{tainted_part}"  # Should be considered tainted
 
+
 # CF-B6: Local taint source for comparison
 def get_local_taint():
     """Tainted: Local taint source in module B"""
-    return os.environ.get('MODULE_B_LOCAL', '')
+    return os.environ.get("MODULE_B_LOCAL", "")
+
 
 # CF-B7: Complex processing chain
 def complex_processing_chain():
     """Tainted: Complex multi-step processing"""
     # Step 1: Get tainted data from module A
     raw_tainted = get_database_config()
-    
+
     # Step 2: Process it locally
     step1 = f"step1_{raw_tainted}"
-    
+
     # Step 3: Further processing
-    step2 = step1.replace('_', '-')
-    
+    step2 = step1.replace("_", "-")
+
     # Step 4: Final processing
     final = f"final_{step2}"
-    
+
     return final  # Should still be tainted
+
 
 # CF-B8: Instance creation and usage
 provider_instance = TaintedDataProvider()
+
 
 def use_class_instance():
     """Tainted: Uses class instance from module A"""
     return provider_instance.get_env_data()  # Tainted via class
 
+
 __all__ = [
-    'propagate_db_config',
-    'propagate_user_args',
-    'combine_tainted_sources',
-    'propagate_class_taint', 
-    'propagate_safe_data',
-    'mix_safe_and_tainted',
-    'get_local_taint',
-    'complex_processing_chain',
-    'use_class_instance'
-] 
+    "propagate_db_config",
+    "propagate_user_args",
+    "combine_tainted_sources",
+    "propagate_class_taint",
+    "propagate_safe_data",
+    "mix_safe_and_tainted",
+    "get_local_taint",
+    "complex_processing_chain",
+    "use_class_instance",
+]

--- a/test_files/accuracy_tests/cross_file/module_c.py
+++ b/test_files/accuracy_tests/cross_file/module_c.py
@@ -15,8 +15,9 @@ from module_b import (
     mix_safe_and_tainted,
     get_local_taint,
     complex_processing_chain,
-    use_class_instance
+    use_class_instance,
 )
+
 
 # CF-C1: Direct A->C taint flow (SHOULD detect)
 def test_direct_a_to_c():
@@ -24,11 +25,13 @@ def test_direct_a_to_c():
     db_config = get_database_config()  # Tainted from module_a
     eval(db_config)  # Vulnerable sink - SHOULD detect
 
+
 # CF-C2: A->B->C taint flow (SHOULD detect)
 def test_a_to_b_to_c():
     """SHOULD detect: Taint flow A->B->C"""
     propagated = propagate_db_config()  # Tainted from module_a via module_b
     exec(propagated)  # Vulnerable sink - SHOULD detect
+
 
 # CF-C3: Multiple source combination (SHOULD detect)
 def test_combined_sources():
@@ -36,11 +39,13 @@ def test_combined_sources():
     combined = combine_tainted_sources()  # Multiple tainted sources via module_b
     os.system(combined)  # Vulnerable sink - SHOULD detect
 
+
 # CF-C4: Class-based taint flow (SHOULD detect)
 def test_class_taint():
     """SHOULD detect: Class-based taint flow"""
     class_data = propagate_class_taint()  # Tainted class data via module_b
-    compile(class_data, '<string>', 'exec')  # Vulnerable sink - SHOULD detect
+    compile(class_data, "<string>", "exec")  # Vulnerable sink - SHOULD detect
+
 
 # CF-C5: Safe data flow (should NOT detect)
 def test_safe_flow():
@@ -48,11 +53,13 @@ def test_safe_flow():
     safe_data = propagate_safe_data()  # Safe data via module_b
     eval(safe_data)  # Should NOT be flagged - safe data
 
+
 # CF-C6: Mixed safe/tainted (SHOULD detect conservatively)
 def test_mixed_flow():
     """SHOULD detect: Mixed safe/tainted data"""
     mixed = mix_safe_and_tainted()  # Mixed data via module_b
     exec(mixed)  # Should detect - conservative approach
+
 
 # CF-C7: Local B taint (SHOULD detect)
 def test_local_b_taint():
@@ -60,17 +67,20 @@ def test_local_b_taint():
     local_taint = get_local_taint()  # Tainted locally in module_b
     eval(local_taint)  # SHOULD detect
 
+
 # CF-C8: Complex processing chain (SHOULD detect)
 def test_complex_chain():
     """SHOULD detect: Complex processing chain"""
     chain_result = complex_processing_chain()  # Complex tainted chain via module_b
     os.system(chain_result)  # SHOULD detect
 
+
 # CF-C9: Class instance usage (SHOULD detect)
 def test_class_instance():
     """SHOULD detect: Class instance taint"""
     instance_data = use_class_instance()  # Tainted via class instance
     exec(instance_data)  # SHOULD detect
+
 
 # CF-C10: Multiple hops from A (SHOULD detect)
 def test_multiple_hops():
@@ -79,12 +89,14 @@ def test_multiple_hops():
     local_processed = f"final_{user_args}"  # Local processing
     eval(local_processed)  # SHOULD detect original taint
 
+
 # CF-C11: Safe direct from A (should NOT detect)
 def test_safe_direct():
     """Should NOT detect: Safe data direct from A"""
     safe_from_a = get_safe_module_data()  # Safe from module_a
     version = get_version()  # Safe from module_a
     eval(f"{safe_from_a}_{version}")  # Should NOT detect
+
 
 # CF-C12: False positive test (should NOT detect)
 def test_false_positive():
@@ -93,11 +105,13 @@ def test_false_positive():
     local_db_config = "safe_local_config"
     eval(local_db_config)  # Should NOT detect
 
+
 # CF-C13: String literal test (should NOT detect)
 def test_string_literals():
     """Should NOT detect: String literals containing patterns"""
     eval("get_database_config()")  # Should NOT detect - literal string
     exec("os.environ")  # Should NOT detect - literal string
+
 
 # CF-C14: Subprocess with tainted data (SHOULD detect)
 def test_subprocess_taint():
@@ -105,18 +119,20 @@ def test_subprocess_taint():
     tainted_cmd = propagate_db_config()  # Tainted via module_b
     subprocess.call(tainted_cmd, shell=True)  # SHOULD detect
 
+
 # CF-C15: Complex multi-import scenario (SHOULD detect)
 def test_multi_import():
     """SHOULD detect: Complex multi-import taint"""
     # Import from A
     direct_a = get_database_config()
-    
+
     # Import from B (which imports from A)
-    via_b = propagate_db_config() 
-    
+    via_b = propagate_db_config()
+
     # Combine both
     combined = f"{direct_a}_{via_b}"
     eval(combined)  # SHOULD detect both flows
 
+
 if __name__ == "__main__":
-    print("Cross-file accuracy tests - testing complex multi-file taint flows") 
+    print("Cross-file accuracy tests - testing complex multi-file taint flows")

--- a/test_files/accuracy_tests/edge_cases/tricky_sink.py
+++ b/test_files/accuracy_tests/edge_cases/tricky_sink.py
@@ -6,24 +6,26 @@ EDGE CASES: Complex cross-file scenarios testing analysis accuracy
 import os
 from tricky_source import (
     get_user_data,
-    get_safe_data, 
+    get_safe_data,
     get_conditional_data,
     get_nested_data,
     get_multi_return,
     get_reassigned_data,
     get_mixed_data,
     get_comment_test,
-    get_aliased_data
+    get_aliased_data,
 )
+
 
 # EC1: Should detect tainted, NOT detect safe (same variable name)
 def test_variable_scope():
     """Should detect tainted user_data, NOT safe user_data"""
     tainted_data = get_user_data()  # Tainted - SHOULD detect
     eval(tainted_data)
-    
+
     safe_data = get_safe_data()  # Safe - should NOT detect
     eval(safe_data)
+
 
 # EC2: Conditional flows - should detect potential taint
 def test_conditional():
@@ -31,23 +33,26 @@ def test_conditional():
     cond_data = get_conditional_data(True)  # Could be tainted - SHOULD detect
     exec(cond_data)
 
+
 # EC3: Nested function taint - should detect
 def test_nested():
     """Should detect nested taint"""
     nested_data = get_nested_data()  # Tainted - SHOULD detect
     eval(nested_data)
 
+
 # EC4: Multiple return paths - should detect tainted paths
 def test_multi_return():
     """Should detect multiple tainted paths"""
     data1 = get_multi_return(1)  # Tainted - SHOULD detect
     eval(data1)
-    
+
     data2 = get_multi_return(2)  # Safe - should NOT detect
     eval(data2)
-    
+
     data3 = get_multi_return(3)  # Tainted - SHOULD detect
     eval(data3)
+
 
 # EC5: Variable reassignment - should detect final tainted state
 def test_reassignment():
@@ -55,11 +60,13 @@ def test_reassignment():
     reassigned = get_reassigned_data()  # Tainted - SHOULD detect
     exec(reassigned)
 
+
 # EC6: Mixed data - should detect (conservatively tainted)
 def test_mixed():
     """Should detect mixed safe/tainted data"""
     mixed = get_mixed_data()  # Tainted - SHOULD detect
     eval(mixed)
+
 
 # EC7: Comments should NOT confuse parser
 def test_comments():
@@ -68,11 +75,13 @@ def test_comments():
     # This eval() call should not be flagged
     eval(comment_data)
 
+
 # EC8: Aliased variables - should detect
 def test_aliasing():
     """Should detect aliased tainted data"""
     aliased = get_aliased_data()  # Tainted via alias - SHOULD detect
     exec(aliased)
+
 
 # EC9: False positive test - similar names but no connection
 def test_false_positive():
@@ -81,29 +90,33 @@ def test_false_positive():
     local_user_data = "safe_local_data"  # No connection to get_user_data()
     eval(local_user_data)  # Should NOT be flagged
 
+
 # EC10: String literals containing taint patterns (should NOT detect)
 def test_string_literals():
     """Should NOT detect - string literals"""
     # These are just string literals, not actual taint
     eval("os.environ")  # Should NOT detect - literal string
-    exec("sys.argv")   # Should NOT detect - literal string
+    exec("sys.argv")  # Should NOT detect - literal string
+
 
 # EC11: Variable name confusion (should be precise)
 def test_name_confusion():
     """Should be precise about variable identity"""
     user_data = "safe_local"  # Local safe variable
     safe_data = get_safe_data()  # Safe function result
-    
-    eval(user_data)    # Should NOT detect - local safe
-    eval(safe_data)    # Should NOT detect - safe function
+
+    eval(user_data)  # Should NOT detect - local safe
+    eval(safe_data)  # Should NOT detect - safe function
+
 
 # EC12: Complex assignment chains
 def test_assignment_chain():
     """Should track through assignment chains"""
     step1 = get_user_data()  # Tainted
-    step2 = step1            # Still tainted
-    step3 = step2            # Still tainted
-    eval(step3)              # SHOULD detect - tainted through chain
+    step2 = step1  # Still tainted
+    step3 = step2  # Still tainted
+    eval(step3)  # SHOULD detect - tainted through chain
+
 
 if __name__ == "__main__":
-    print("Edge case tests for analysis accuracy") 
+    print("Edge case tests for analysis accuracy")

--- a/test_files/accuracy_tests/edge_cases/tricky_source.py
+++ b/test_files/accuracy_tests/edge_cases/tricky_source.py
@@ -6,55 +6,65 @@ EDGE CASES: Tricky patterns that test the accuracy of taint analysis
 import os
 import sys
 
+
 # EC1: Same variable name, different scope (should be separate)
 def get_user_data():
     """Edge case: Variable name collision"""
-    user_data = os.environ.get('USER_INPUT', '')  # Tainted
+    user_data = os.environ.get("USER_INPUT", "")  # Tainted
     return user_data
+
 
 def get_safe_data():
     """Edge case: Same variable name but safe"""
     user_data = "safe_constant"  # Safe (same name, different data)
     return user_data
 
+
 # EC2: Conditional taint (complex control flow)
 def get_conditional_data(use_env=True):
     """Edge case: Conditional taint source"""
     if use_env:
-        return os.environ.get('CONDITIONAL', '')  # Tainted path
+        return os.environ.get("CONDITIONAL", "")  # Tainted path
     else:
         return "safe_default"  # Safe path
+
 
 # EC3: Nested function calls
 def get_nested_data():
     """Edge case: Nested function with taint"""
+
     def inner():
         return sys.argv[1] if len(sys.argv) > 1 else ""  # Tainted
+
     return inner()
+
 
 # EC4: Multiple return paths
 def get_multi_return(flag):
     """Edge case: Multiple return paths"""
     if flag == 1:
-        return os.environ.get('PATH1', '')  # Tainted
+        return os.environ.get("PATH1", "")  # Tainted
     elif flag == 2:
         return "safe_path"  # Safe
     else:
         return sys.argv[0]  # Tainted
 
+
 # EC5: Variable reassignment
 def get_reassigned_data():
     """Edge case: Variable reassignment"""
     data = "safe_initial"  # Safe initially
-    data = os.environ.get('REASSIGNED', data)  # Now tainted
+    data = os.environ.get("REASSIGNED", data)  # Now tainted
     return data
+
 
 # EC6: Mixed safe and tainted
 def get_mixed_data():
     """Edge case: Mixing safe and tainted data"""
     safe_part = "prefix_"
-    tainted_part = os.getenv('SUFFIX', '')  # Tainted
+    tainted_part = os.getenv("SUFFIX", "")  # Tainted
     return safe_part + tainted_part  # Should be considered tainted
+
 
 # EC7: Comments and strings containing patterns (should NOT confuse parser)
 def get_comment_test():
@@ -64,20 +74,22 @@ def get_comment_test():
     # eval() in comment should not confuse parser
     return data
 
+
 # EC8: Variable aliasing
 def get_aliased_data():
     """Edge case: Variable aliasing"""
     environ_alias = os.environ  # Alias to tainted source
-    return environ_alias.get('ALIASED', '')  # Should still be tainted
+    return environ_alias.get("ALIASED", "")  # Should still be tainted
+
 
 __all__ = [
-    'get_user_data',
-    'get_safe_data',
-    'get_conditional_data',
-    'get_nested_data',
-    'get_multi_return',
-    'get_reassigned_data',
-    'get_mixed_data',
-    'get_comment_test',
-    'get_aliased_data'
-] 
+    "get_user_data",
+    "get_safe_data",
+    "get_conditional_data",
+    "get_nested_data",
+    "get_multi_return",
+    "get_reassigned_data",
+    "get_mixed_data",
+    "get_comment_test",
+    "get_aliased_data",
+]

--- a/test_files/accuracy_tests/run_accuracy_tests.py
+++ b/test_files/accuracy_tests/run_accuracy_tests.py
@@ -9,173 +9,177 @@ import os
 import sys
 from typing import Dict, List, Set, Tuple
 
+
 class AccuracyTestRunner:
     def __init__(self):
         self.test_results = {}
         self.expected_detections = {}
         self.setup_expected_results()
-    
+
     def setup_expected_results(self):
         """Define expected detection results for each test case"""
-        
+
         # TRUE POSITIVES: Should detect these vulnerabilities
-        self.expected_detections['true_positives'] = {
-            'should_detect': {
-                'sink.py': [
-                    'vulnerable_eval',      # TP1: Cross-file eval
-                    'vulnerable_exec',      # TP2: Cross-file exec 
-                    'vulnerable_system',    # TP3: Cross-file system
-                    'vulnerable_compile',   # TP4: Cross-file compile
-                    'vulnerable_chain',     # TP5: Chained cross-file
-                    'vulnerable_processed', # TP6: Processed cross-file
-                    'vulnerable_multiple',  # TP7: Multiple sources
-                    'vulnerable_assignment' # TP8: Local assignment with cross-file
+        self.expected_detections["true_positives"] = {
+            "should_detect": {
+                "sink.py": [
+                    "vulnerable_eval",  # TP1: Cross-file eval
+                    "vulnerable_exec",  # TP2: Cross-file exec
+                    "vulnerable_system",  # TP3: Cross-file system
+                    "vulnerable_compile",  # TP4: Cross-file compile
+                    "vulnerable_chain",  # TP5: Chained cross-file
+                    "vulnerable_processed",  # TP6: Processed cross-file
+                    "vulnerable_multiple",  # TP7: Multiple sources
+                    "vulnerable_assignment",  # TP8: Local assignment with cross-file
                 ]
             },
-            'should_not_detect': {}
+            "should_not_detect": {},
         }
-        
+
         # TRUE NEGATIVES: Should NOT detect these (safe code)
-        self.expected_detections['true_negatives'] = {
-            'should_detect': {},
-            'should_not_detect': {
-                'safe_sink.py': [
-                    'safe_eval_constant',   # TN1: Safe constant
-                    'safe_exec_computed',   # TN2: Safe computed
-                    'safe_system_version',  # TN3: Safe version
-                    'safe_compile_version', # TN4: Safe Python version
-                    'safe_eval_hash',       # TN5: Safe hash
-                    'safe_template_usage',  # TN6: Safe template
-                    'safe_app_config',      # TN7: Safe app config
-                    'safe_validated',       # TN8: Safe validated
-                    'safe_literals',        # TN9: Safe literals
-                    'safe_no_input'         # TN10: No user input
+        self.expected_detections["true_negatives"] = {
+            "should_detect": {},
+            "should_not_detect": {
+                "safe_sink.py": [
+                    "safe_eval_constant",  # TN1: Safe constant
+                    "safe_exec_computed",  # TN2: Safe computed
+                    "safe_system_version",  # TN3: Safe version
+                    "safe_compile_version",  # TN4: Safe Python version
+                    "safe_eval_hash",  # TN5: Safe hash
+                    "safe_template_usage",  # TN6: Safe template
+                    "safe_app_config",  # TN7: Safe app config
+                    "safe_validated",  # TN8: Safe validated
+                    "safe_literals",  # TN9: Safe literals
+                    "safe_no_input",  # TN10: No user input
                 ]
-            }
+            },
         }
-        
+
         # EDGE CASES: Complex scenarios
-        self.expected_detections['edge_cases'] = {
-            'should_detect': {
-                'tricky_sink.py': [
-                    'test_variable_scope',    # EC1: Tainted user_data
-                    'test_conditional',       # EC2: Conditional taint
-                    'test_nested',           # EC3: Nested taint
-                    'test_multi_return',     # EC4: Multi return paths
-                    'test_reassignment',     # EC5: Reassigned tainted
-                    'test_mixed',            # EC6: Mixed data
-                    'test_aliasing',         # EC8: Aliased taint
-                    'test_assignment_chain'  # EC12: Assignment chain
+        self.expected_detections["edge_cases"] = {
+            "should_detect": {
+                "tricky_sink.py": [
+                    "test_variable_scope",  # EC1: Tainted user_data
+                    "test_conditional",  # EC2: Conditional taint
+                    "test_nested",  # EC3: Nested taint
+                    "test_multi_return",  # EC4: Multi return paths
+                    "test_reassignment",  # EC5: Reassigned tainted
+                    "test_mixed",  # EC6: Mixed data
+                    "test_aliasing",  # EC8: Aliased taint
+                    "test_assignment_chain",  # EC12: Assignment chain
                 ]
             },
-            'should_not_detect': {
-                'tricky_sink.py': [
-                    'test_comments',         # EC7: Comments shouldn't confuse
-                    'test_false_positive',   # EC9: No actual connection
-                    'test_string_literals',  # EC10: String literals
-                    'test_name_confusion'    # EC11: Variable name confusion
+            "should_not_detect": {
+                "tricky_sink.py": [
+                    "test_comments",  # EC7: Comments shouldn't confuse
+                    "test_false_positive",  # EC9: No actual connection
+                    "test_string_literals",  # EC10: String literals
+                    "test_name_confusion",  # EC11: Variable name confusion
                 ]
-            }
+            },
         }
-        
+
         # CROSS-FILE: Complex multi-file scenarios
-        self.expected_detections['cross_file'] = {
-            'should_detect': {
-                'module_c.py': [
-                    'test_direct_a_to_c',    # CF-C1: Direct A->C
-                    'test_a_to_b_to_c',      # CF-C2: A->B->C
-                    'test_combined_sources', # CF-C3: Combined sources
-                    'test_class_taint',      # CF-C4: Class-based
-                    'test_mixed_flow',       # CF-C6: Mixed safe/tainted
-                    'test_local_b_taint',    # CF-C7: Local B taint
-                    'test_complex_chain',    # CF-C8: Complex chain
-                    'test_class_instance',   # CF-C9: Class instance
-                    'test_multiple_hops',    # CF-C10: Multiple hops
-                    'test_subprocess_taint', # CF-C14: Subprocess
-                    'test_multi_import'      # CF-C15: Multi-import
+        self.expected_detections["cross_file"] = {
+            "should_detect": {
+                "module_c.py": [
+                    "test_direct_a_to_c",  # CF-C1: Direct A->C
+                    "test_a_to_b_to_c",  # CF-C2: A->B->C
+                    "test_combined_sources",  # CF-C3: Combined sources
+                    "test_class_taint",  # CF-C4: Class-based
+                    "test_mixed_flow",  # CF-C6: Mixed safe/tainted
+                    "test_local_b_taint",  # CF-C7: Local B taint
+                    "test_complex_chain",  # CF-C8: Complex chain
+                    "test_class_instance",  # CF-C9: Class instance
+                    "test_multiple_hops",  # CF-C10: Multiple hops
+                    "test_subprocess_taint",  # CF-C14: Subprocess
+                    "test_multi_import",  # CF-C15: Multi-import
                 ]
             },
-            'should_not_detect': {
-                'module_c.py': [
-                    'test_safe_flow',        # CF-C5: Safe data flow
-                    'test_safe_direct',      # CF-C11: Safe direct from A
-                    'test_false_positive',   # CF-C12: No connection
-                    'test_string_literals'   # CF-C13: String literals
+            "should_not_detect": {
+                "module_c.py": [
+                    "test_safe_flow",  # CF-C5: Safe data flow
+                    "test_safe_direct",  # CF-C11: Safe direct from A
+                    "test_false_positive",  # CF-C12: No connection
+                    "test_string_literals",  # CF-C13: String literals
                 ]
-            }
+            },
         }
-    
+
     def run_test_suite(self, test_dir: str) -> Dict:
         """Run taint analysis on a test directory"""
         print(f"\n🧪 Running accuracy tests on: {test_dir}")
-        
+
         cmd = [
-            'cargo', 'run', '--',
-            '--taint-analysis',
-            '--output-format', 'json',
-            f'test_files/accuracy_tests/{test_dir}',
-            'python', 
-            'rules/python/general_security.ron'
+            "cargo",
+            "run",
+            "--",
+            "--taint-analysis",
+            "--output-format",
+            "json",
+            f"test_files/accuracy_tests/{test_dir}",
+            "python",
+            "rules/python/general_security.ron",
         ]
-        
+
         try:
-            result = subprocess.run(cmd, capture_output=True, text=True, cwd='../..')
+            result = subprocess.run(cmd, capture_output=True, text=True, cwd="../..")
             if result.returncode != 0:
                 print(f"❌ Error running test: {result.stderr}")
-                return {'vulnerabilities': []}
-            
+                return {"vulnerabilities": []}
+
             # Parse JSON output - find the JSON structure
             output = result.stdout.strip()
-            
+
             # Look for the JSON structure (starts with { and contains flows)
-            json_start = output.find('{')
+            json_start = output.find("{")
             if json_start != -1:
                 json_content = output[json_start:]
                 # Clean up any trailing non-JSON content
-                json_end = json_content.rfind('}')
+                json_end = json_content.rfind("}")
                 if json_end != -1:
-                    json_line = json_content[:json_end + 1]
+                    json_line = json_content[: json_end + 1]
                 else:
                     json_line = None
             else:
                 json_line = None
-            
+
             if json_line:
                 return json.loads(json_line)
             else:
                 print(f"❌ No JSON output found")
-                return {'flows': []}
-                
+                return {"flows": []}
+
         except Exception as e:
             print(f"❌ Exception running test: {e}")
-            return {'flows': []}
-    
+            return {"flows": []}
+
     def analyze_results(self, test_category: str, results: Dict) -> Dict:
         """Analyze test results for accuracy"""
         print(f"\n📊 Analyzing {test_category} results...")
-        
+
         expected = self.expected_detections.get(test_category, {})
-        should_detect = expected.get('should_detect', {})
-        should_not_detect = expected.get('should_not_detect', {})
-        
-        # Extract detected vulnerabilities  
+        should_detect = expected.get("should_detect", {})
+        should_not_detect = expected.get("should_not_detect", {})
+
+        # Extract detected vulnerabilities
         detected_vulns = set()
-        flows = results.get('flows', [])
-        
+        flows = results.get("flows", [])
+
         for flow in flows:
             # Extract sink information from taint flow
-            if 'sink' in flow:
-                sink = flow['sink']
-                sink_file = os.path.basename(sink.get('file', ''))
-                sink_function = sink.get('function', '')
+            if "sink" in flow:
+                sink = flow["sink"]
+                sink_file = os.path.basename(sink.get("file", ""))
+                sink_function = sink.get("function", "")
                 detected_vulns.add(f"{sink_file}:{sink_function}")
-        
+
         print(f"   Detected {len(detected_vulns)} total vulnerabilities")
-        
+
         # Analyze true positives
         true_positives = 0
         false_negatives = 0
-        
+
         for file, functions in should_detect.items():
             for func in functions:
                 detection_key = f"{file}:{func}"
@@ -185,104 +189,110 @@ class AccuracyTestRunner:
                 else:
                     false_negatives += 1
                     print(f"   ❌ MISSED (False Negative): {func} in {file}")
-        
-        # Analyze true negatives  
+
+        # Analyze true negatives
         true_negatives = 0
         false_positives = 0
-        
+
         for file, functions in should_not_detect.items():
             for func in functions:
                 detection_key = f"{file}:{func}"
                 if any(detection_key in str(vuln) for vuln in detected_vulns):
                     false_positives += 1
-                    print(f"   ❌ INCORRECTLY detected (False Positive): {func} in {file}")
+                    print(
+                        f"   ❌ INCORRECTLY detected (False Positive): {func} in {file}"
+                    )
                 else:
                     true_negatives += 1
                     print(f"   ✅ Correctly ignored: {func} in {file}")
-        
+
         return {
-            'true_positives': true_positives,
-            'false_negatives': false_negatives,
-            'true_negatives': true_negatives,
-            'false_positives': false_positives,
-            'total_detected': len(detected_vulns)
+            "true_positives": true_positives,
+            "false_negatives": false_negatives,
+            "true_negatives": true_negatives,
+            "false_positives": false_positives,
+            "total_detected": len(detected_vulns),
         }
-    
+
     def calculate_metrics(self, analysis: Dict) -> Dict:
         """Calculate accuracy metrics"""
-        tp = analysis['true_positives']
-        fp = analysis['false_positives'] 
-        tn = analysis['true_negatives']
-        fn = analysis['false_negatives']
-        
+        tp = analysis["true_positives"]
+        fp = analysis["false_positives"]
+        tn = analysis["true_negatives"]
+        fn = analysis["false_negatives"]
+
         # Precision = TP / (TP + FP)
         precision = tp / (tp + fp) if (tp + fp) > 0 else 0
-        
+
         # Recall = TP / (TP + FN)
         recall = tp / (tp + fn) if (tp + fn) > 0 else 0
-        
+
         # F1 Score = 2 * (precision * recall) / (precision + recall)
-        f1_score = 2 * (precision * recall) / (precision + recall) if (precision + recall) > 0 else 0
-        
+        f1_score = (
+            2 * (precision * recall) / (precision + recall)
+            if (precision + recall) > 0
+            else 0
+        )
+
         # Accuracy = (TP + TN) / (TP + TN + FP + FN)
         accuracy = (tp + tn) / (tp + tn + fp + fn) if (tp + tn + fp + fn) > 0 else 0
-        
+
         return {
-            'precision': precision,
-            'recall': recall,
-            'f1_score': f1_score,
-            'accuracy': accuracy
+            "precision": precision,
+            "recall": recall,
+            "f1_score": f1_score,
+            "accuracy": accuracy,
         }
-    
+
     def run_comprehensive_tests(self):
         """Run all accuracy tests and generate comprehensive report"""
         print("🚀 Starting Comprehensive Taint Analysis Accuracy Tests")
         print("=" * 60)
-        
+
         test_categories = [
-            ('true_positives', 'True Positives (Real Vulnerabilities)'),
-            ('true_negatives', 'True Negatives (Safe Code)'),
-            ('edge_cases', 'Edge Cases (Complex Scenarios)'),
-            ('cross_file', 'Cross-File (Multi-Module Flows)')
+            ("true_positives", "True Positives (Real Vulnerabilities)"),
+            ("true_negatives", "True Negatives (Safe Code)"),
+            ("edge_cases", "Edge Cases (Complex Scenarios)"),
+            ("cross_file", "Cross-File (Multi-Module Flows)"),
         ]
-        
+
         overall_results = {
-            'true_positives': 0,
-            'false_negatives': 0,
-            'true_negatives': 0,
-            'false_positives': 0
+            "true_positives": 0,
+            "false_negatives": 0,
+            "true_negatives": 0,
+            "false_positives": 0,
         }
-        
+
         for test_dir, description in test_categories:
-            print(f"\n{'='*20} {description} {'='*20}")
-            
+            print(f"\n{'=' * 20} {description} {'=' * 20}")
+
             # Run tests
             results = self.run_test_suite(test_dir)
-            
+
             # Analyze results
             analysis = self.analyze_results(test_dir, results)
-            
+
             # Calculate metrics
             metrics = self.calculate_metrics(analysis)
-            
+
             # Print metrics
             print(f"\n📈 {test_dir.upper()} METRICS:")
             print(f"   Precision: {metrics['precision']:.2%}")
             print(f"   Recall:    {metrics['recall']:.2%}")
             print(f"   F1 Score:  {metrics['f1_score']:.2%}")
             print(f"   Accuracy:  {metrics['accuracy']:.2%}")
-            
+
             # Add to overall results
             for key in overall_results:
                 overall_results[key] += analysis[key]
-        
+
         # Calculate overall metrics
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("🎯 OVERALL ACCURACY RESULTS")
-        print(f"{'='*60}")
-        
+        print(f"{'=' * 60}")
+
         overall_metrics = self.calculate_metrics(overall_results)
-        
+
         print(f"True Positives:   {overall_results['true_positives']}")
         print(f"False Negatives:  {overall_results['false_negatives']}")
         print(f"True Negatives:   {overall_results['true_negatives']}")
@@ -292,32 +302,33 @@ class AccuracyTestRunner:
         print(f"Overall Recall:    {overall_metrics['recall']:.2%}")
         print(f"Overall F1 Score:  {overall_metrics['f1_score']:.2%}")
         print(f"Overall Accuracy:  {overall_metrics['accuracy']:.2%}")
-        
+
         # Quality assessment
         print(f"\n🏆 QUALITY ASSESSMENT:")
-        if overall_metrics['precision'] >= 0.9:
+        if overall_metrics["precision"] >= 0.9:
             print("✅ EXCELLENT precision - Very low false positive rate")
-        elif overall_metrics['precision'] >= 0.8:
+        elif overall_metrics["precision"] >= 0.8:
             print("✅ GOOD precision - Acceptable false positive rate")
         else:
             print("❌ POOR precision - High false positive rate")
-            
-        if overall_metrics['recall'] >= 0.9:
+
+        if overall_metrics["recall"] >= 0.9:
             print("✅ EXCELLENT recall - Very low false negative rate")
-        elif overall_metrics['recall'] >= 0.8:
+        elif overall_metrics["recall"] >= 0.8:
             print("✅ GOOD recall - Acceptable false negative rate")
         else:
             print("❌ POOR recall - High false negative rate")
-            
+
         return overall_results, overall_metrics
+
 
 if __name__ == "__main__":
     # Change to script directory
     script_dir = os.path.dirname(os.path.abspath(__file__))
     os.chdir(script_dir)
-    
+
     runner = AccuracyTestRunner()
     results, metrics = runner.run_comprehensive_tests()
-    
+
     print(f"\n🎉 Accuracy testing complete!")
-    print(f"Overall Score: {metrics['f1_score']:.1%} F1") 
+    print(f"Overall Score: {metrics['f1_score']:.1%} F1")

--- a/test_files/accuracy_tests/true_negatives/safe_sink.py
+++ b/test_files/accuracy_tests/true_negatives/safe_sink.py
@@ -12,8 +12,9 @@ from safe_source import (
     get_safe_hash,
     get_config_template,
     get_app_config,
-    get_validated_input
+    get_validated_input,
 )
+
 
 # TN1: Safe constant in eval (should NOT be flagged)
 def safe_eval_constant():
@@ -21,23 +22,27 @@ def safe_eval_constant():
     safe_val = get_safe_constant()  # Safe source
     eval(safe_val)  # Not vulnerable - safe input
 
+
 # TN2: Safe computed value in exec (should NOT be flagged)
 def safe_exec_computed():
     """Should NOT be flagged: Safe computed value in exec"""
     computed = get_computed_safe()  # Safe source
     exec(computed)  # Not vulnerable - safe input
 
-# TN3: Safe version in system command (should NOT be flagged) 
+
+# TN3: Safe version in system command (should NOT be flagged)
 def safe_system_version():
     """Should NOT be flagged: Safe version info"""
     version = get_app_version()  # Safe source
     os.system(f"echo {version}")  # Not vulnerable - safe input
 
+
 # TN4: Safe Python version in compile (should NOT be flagged)
 def safe_compile_version():
     """Should NOT be flagged: Safe Python version"""
     py_version = get_python_version()  # Safe source
-    compile(py_version, '<string>', 'eval')  # Not vulnerable - safe input
+    compile(py_version, "<string>", "eval")  # Not vulnerable - safe input
+
 
 # TN5: Safe hash in eval (should NOT be flagged)
 def safe_eval_hash():
@@ -45,23 +50,27 @@ def safe_eval_hash():
     hash_val = get_safe_hash()  # Safe source
     eval(f"'{hash_val}'")  # Not vulnerable - safe input
 
+
 # TN6: Safe config template (should NOT be flagged)
 def safe_template_usage():
     """Should NOT be flagged: Safe config template"""
     template = get_config_template()  # Safe source
     exec(template)  # Not vulnerable - safe input
 
+
 # TN7: Safe app config (should NOT be flagged)
 def safe_app_config():
     """Should NOT be flagged: Safe app configuration"""
-    config = get_app_config()  # Safe source  
+    config = get_app_config()  # Safe source
     eval(config)  # Not vulnerable - safe input
+
 
 # TN8: Safe validated input (should NOT be flagged)
 def safe_validated():
     """Should NOT be flagged: Validated safe input"""
     validated = get_validated_input()  # Safe source
     exec(validated)  # Not vulnerable - validated input
+
 
 # TN9: Hard-coded literals (should NOT be flagged)
 def safe_literals():
@@ -70,11 +79,13 @@ def safe_literals():
     exec("print('hello')")  # Not vulnerable - literal
     os.system("echo safe")  # Not vulnerable - literal
 
+
 # TN10: No user input involved (should NOT be flagged)
 def safe_no_input():
     """Should NOT be flagged: No user input"""
     safe_data = "application_constant"
     eval(safe_data)  # Not vulnerable - no user input
 
+
 if __name__ == "__main__":
-    print("True negatives - should NOT be flagged as vulnerabilities") 
+    print("True negatives - should NOT be flagged as vulnerabilities")

--- a/test_files/accuracy_tests/true_negatives/safe_source.py
+++ b/test_files/accuracy_tests/true_negatives/safe_source.py
@@ -6,26 +6,32 @@ TRUE NEGATIVES: Safe sources that should NOT be flagged as vulnerabilities
 import os
 import hashlib
 
+
 # TN1: Hard-coded safe values
 def get_safe_constant():
     """Safe: Hard-coded constant"""
     return "safe_constant_value"
 
-# TN2: Computed safe values  
+
+# TN2: Computed safe values
 def get_computed_safe():
     """Safe: Computed from safe inputs"""
     return "prefix_" + "suffix"
+
 
 # TN3: Safe configuration (not user input)
 def get_app_version():
     """Safe: Application version"""
     return "1.0.0"
 
+
 # TN4: Safe system information (not user controlled)
 def get_python_version():
     """Safe: Python version info"""
     import sys
+
     return f"{sys.version_info.major}.{sys.version_info.minor}"
+
 
 # TN5: Hash/digest (safe transformation)
 def get_safe_hash():
@@ -33,19 +39,22 @@ def get_safe_hash():
     safe_data = "application_name"
     return hashlib.sha256(safe_data.encode()).hexdigest()
 
+
 # TN6: Safe file operations (config files)
 def get_config_template():
     """Safe: Reading config template (not user input)"""
     try:
-        with open('config_template.json', 'r') as f:
+        with open("config_template.json", "r") as f:
             return f.read()
     except:
         return '{"default": true}'
 
+
 # TN7: Safe environment (application config, not user input)
 def get_app_config():
     """Safe: Application configuration"""
-    return os.getenv('APP_MODE', 'production')  # App config, not user input
+    return os.getenv("APP_MODE", "production")  # App config, not user input
+
 
 # TN8: Validated/sanitized data
 def get_validated_input():
@@ -53,13 +62,14 @@ def get_validated_input():
     # In real scenario, this would be validated
     return "validated_safe_data"
 
+
 __all__ = [
-    'get_safe_constant',
-    'get_computed_safe',
-    'get_app_version', 
-    'get_python_version',
-    'get_safe_hash',
-    'get_config_template',
-    'get_app_config',
-    'get_validated_input'
-] 
+    "get_safe_constant",
+    "get_computed_safe",
+    "get_app_version",
+    "get_python_version",
+    "get_safe_hash",
+    "get_config_template",
+    "get_app_config",
+    "get_validated_input",
+]

--- a/test_files/accuracy_tests/true_positives/sink.py
+++ b/test_files/accuracy_tests/true_positives/sink.py
@@ -10,14 +10,16 @@ from source import (
     read_user_file,
     get_request_data,
     get_config_chain,
-    process_user_input
+    process_user_input,
 )
 
-# TP1: Cross-file eval vulnerability  
+
+# TP1: Cross-file eval vulnerability
 def vulnerable_eval():
     """SHOULD BE DETECTED: Cross-file taint to eval()"""
     db_url = get_database_url()  # Tainted from source.py
     eval(db_url)  # Vulnerable sink
+
 
 # TP2: Cross-file exec vulnerability
 def vulnerable_exec():
@@ -25,17 +27,20 @@ def vulnerable_exec():
     cmd = get_user_command()  # Tainted from source.py
     exec(cmd)  # Vulnerable sink
 
+
 # TP3: Cross-file system command vulnerability
 def vulnerable_system():
     """SHOULD BE DETECTED: Cross-file taint to os.system()"""
     file_data = read_user_file()  # Tainted from source.py
     os.system(file_data)  # Vulnerable sink
 
+
 # TP4: Cross-file compile vulnerability
 def vulnerable_compile():
     """SHOULD BE DETECTED: Cross-file taint to compile()"""
     request_data = get_request_data()  # Tainted from source.py
-    compile(request_data, '<string>', 'exec')  # Vulnerable sink
+    compile(request_data, "<string>", "exec")  # Vulnerable sink
+
 
 # TP5: Chained cross-file vulnerability
 def vulnerable_chain():
@@ -43,11 +48,13 @@ def vulnerable_chain():
     config = get_config_chain()  # Tainted from source.py (chain)
     eval(config)  # Vulnerable sink
 
+
 # TP6: Processed cross-file vulnerability
 def vulnerable_processed():
     """SHOULD BE DETECTED: Processed tainted data"""
     processed = process_user_input()  # Tainted from source.py
     exec(processed)  # Vulnerable sink
+
 
 # TP7: Multiple sources to same sink
 def vulnerable_multiple():
@@ -57,11 +64,13 @@ def vulnerable_multiple():
     combined = f"{data1}_{data2}"
     eval(combined)  # Should detect both flows
 
+
 # TP8: Local assignment with cross-file source
 def vulnerable_assignment():
     """SHOULD BE DETECTED: Local variable with cross-file source"""
     local_var = get_request_data()  # Cross-file tainted assignment
     exec(local_var)  # Local vulnerable sink
 
+
 if __name__ == "__main__":
-    print("True positive vulnerabilities - should ALL be detected") 
+    print("True positive vulnerabilities - should ALL be detected")

--- a/test_files/accuracy_tests/true_positives/source.py
+++ b/test_files/accuracy_tests/true_positives/source.py
@@ -6,38 +6,44 @@ TRUE POSITIVES: Real taint sources that SHOULD be detected in cross-file analysi
 import os
 import sys
 
+
 # TP1: Environment variable source
 def get_database_url():
     """Real vulnerability: environment variable"""
-    return os.environ.get('DATABASE_URL', 'default')
+    return os.environ.get("DATABASE_URL", "default")
 
-# TP2: Command line argument source  
+
+# TP2: Command line argument source
 def get_user_command():
     """Real vulnerability: command line argument"""
     if len(sys.argv) > 1:
         return sys.argv[1]
     return ""
 
+
 # TP3: File input source
 def read_user_file():
     """Real vulnerability: file input"""
     try:
-        with open('user_input.txt', 'r') as f:
+        with open("user_input.txt", "r") as f:
             return f.read()
     except:
         return ""
 
+
 # TP4: Network-like input simulation
 def get_request_data():
     """Real vulnerability: simulated request data"""
-    return os.getenv('REQUEST_DATA', '')
+    return os.getenv("REQUEST_DATA", "")
+
 
 # TP5: Multiple chained sources
 def get_config_chain():
     """Real vulnerability: chained environment access"""
-    base = os.environ.get('BASE_CONFIG', '')
-    extended = os.environ.get('EXTENDED_CONFIG', base)
+    base = os.environ.get("BASE_CONFIG", "")
+    extended = os.environ.get("EXTENDED_CONFIG", base)
     return extended
+
 
 # TP6: Return value that propagates taint
 def process_user_input():
@@ -46,12 +52,13 @@ def process_user_input():
     processed = f"processed_{raw}"
     return processed
 
+
 # Export all vulnerable functions
 __all__ = [
-    'get_database_url',
-    'get_user_command', 
-    'read_user_file',
-    'get_request_data',
-    'get_config_chain',
-    'process_user_input'
-] 
+    "get_database_url",
+    "get_user_command",
+    "read_user_file",
+    "get_request_data",
+    "get_config_chain",
+    "process_user_input",
+]

--- a/test_files/multi_file_taint_tests/category1_valid/test1_1_sink_module.py
+++ b/test_files/multi_file_taint_tests/category1_valid/test1_1_sink_module.py
@@ -1,19 +1,21 @@
-# Test 1.1: Direct Function Import Flow - SINK MODULE  
+# Test 1.1: Direct Function Import Flow - SINK MODULE
 # Expected: Should detect flow from test1_1_source_module.get_user_data() to os.system()
 
 from test1_1_source_module import get_user_data
 import os
+
 
 def process_data():
     """
     SINK: Should detect taint flow from imported function to os.system
     """
     user_input = get_user_data()  # Import usage - tainted data
-    os.system(user_input)         # SINK - should detect flow
+    os.system(user_input)  # SINK - should detect flow
+
 
 def safe_process():
     """
     Safe function using non-tainted data
     """
     safe_data = "echo 'safe'"
-    os.system(safe_data) 
+    os.system(safe_data)

--- a/test_files/multi_file_taint_tests/category1_valid/test1_1_source_module.py
+++ b/test_files/multi_file_taint_tests/category1_valid/test1_1_source_module.py
@@ -1,14 +1,16 @@
 # Test 1.1: Direct Function Import Flow - SOURCE MODULE
 # Expected: This should be detected as a valid cross-file taint flow
 
+
 def get_user_data():
     """
     SOURCE: Direct user input - should be flagged as taint source
     """
     return input("Enter data: ")
 
+
 def safe_function():
     """
     Non-source function for negative testing
     """
-    return "safe_constant_data" 
+    return "safe_constant_data"

--- a/test_files/multi_file_taint_tests/category2_invalid/test2_1_module_a.py
+++ b/test_files/multi_file_taint_tests/category2_invalid/test2_1_module_a.py
@@ -1,6 +1,7 @@
 # Test 2.1: Phantom Flow - No Import Relationship - MODULE A
 # Expected: Should NOT create cross-file flow to module_b (no imports)
 
+
 def safe_function():
     """
     SOURCE: User input in isolated module
@@ -9,8 +10,9 @@ def safe_function():
     user_data = input("Enter: ")  # SOURCE
     return user_data
 
+
 def another_function():
     """
     Additional function to make the module realistic
     """
-    return "module_a_data" 
+    return "module_a_data"

--- a/test_files/multi_file_taint_tests/category2_invalid/test2_1_module_b.py
+++ b/test_files/multi_file_taint_tests/category2_invalid/test2_1_module_b.py
@@ -5,6 +5,7 @@
 import os
 # NOTE: NO IMPORT from test2_1_module_a - this is intentional!
 
+
 def dangerous_function():
     """
     SINK: This function has same variable name as module_a but NO connection
@@ -14,8 +15,9 @@ def dangerous_function():
     user_data = "safe_constant"  # This is NOT the same variable from module_a
     os.system(user_data)  # Should NOT detect flow - different variable entirely
 
+
 def legitimate_function():
     """
     A realistic function that could exist in this module
     """
-    return "module_b_functionality" 
+    return "module_b_functionality"

--- a/test_files/multi_file_taint_tests/category4_config/test4_1_app_initializer.py
+++ b/test_files/multi_file_taint_tests/category4_config/test4_1_app_initializer.py
@@ -4,22 +4,24 @@
 from test4_1_config_manager import setup_environment, configure_logging
 import subprocess
 
+
 def initialize():
     """
     SAFE: Using configuration functions should not create taint flows
     """
     result = setup_environment()  # Configuration function call
     subprocess.run(["echo", result])  # Safe command with config result
-    
+
     log_config = configure_logging()
     subprocess.run(["echo", log_config])  # Another safe command
+
 
 def start_application():
     """
     Application startup with configuration
     """
     initialize()
-    
+
     # Safe system commands for application startup
     subprocess.run(["echo", "Application starting..."])
-    subprocess.run(["mkdir", "-p", "/tmp/app_logs"])  # Safe file operations 
+    subprocess.run(["mkdir", "-p", "/tmp/app_logs"])  # Safe file operations

--- a/test_files/multi_file_taint_tests/category4_config/test4_1_config_manager.py
+++ b/test_files/multi_file_taint_tests/category4_config/test4_1_config_manager.py
@@ -3,6 +3,7 @@
 
 import os
 
+
 def setup_environment():
     """
     CONFIGURATION: These should NOT be flagged as sources
@@ -10,11 +11,12 @@ def setup_environment():
     """
     # These are configuration operations, not user input
     os.environ.setdefault("DEBUG", "False")
-    os.environ.setdefault("LOG_LEVEL", "INFO") 
+    os.environ.setdefault("LOG_LEVEL", "INFO")
     os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
     os.environ.setdefault("SECRET_KEY", "dev-key-not-for-production")
-    
+
     return "Configuration complete"
+
 
 def configure_logging():
     """
@@ -23,8 +25,9 @@ def configure_logging():
     log_level = os.environ.setdefault("LOG_LEVEL", "WARNING")
     return f"Logging configured to {log_level}"
 
+
 def get_config_value(key, default):
     """
     Safe configuration getter
     """
-    return os.environ.setdefault(key, default) 
+    return os.environ.setdefault(key, default)

--- a/test_files/multi_file_taint_tests/category4_config/test4_2_command_executor.py
+++ b/test_files/multi_file_taint_tests/category4_config/test4_2_command_executor.py
@@ -5,6 +5,7 @@ from test4_2_env_reader import get_user_command, get_user_input_path, safe_confi
 import subprocess
 import os
 
+
 def execute_user_command():
     """
     VULNERABLE: Should detect taint flow from user env var to subprocess
@@ -13,6 +14,7 @@ def execute_user_command():
     if cmd:
         subprocess.run(cmd, shell=True)  # SINK - dangerous!
 
+
 def process_user_file():
     """
     Another vulnerability with file operations
@@ -20,9 +22,10 @@ def process_user_file():
     user_path = get_user_input_path()  # Tainted path
     os.system(f"cat {user_path}")  # SINK - path injection
 
+
 def safe_config_operation():
     """
     Safe operation using configuration
     """
     config_dir = safe_config_read()  # Safe config value
-    subprocess.run(["ls", config_dir])  # Safe - config not user input 
+    subprocess.run(["ls", config_dir])  # Safe - config not user input

--- a/test_files/multi_file_taint_tests/category4_config/test4_2_env_reader.py
+++ b/test_files/multi_file_taint_tests/category4_config/test4_2_env_reader.py
@@ -3,6 +3,7 @@
 
 import os
 
+
 def get_user_command():
     """
     SOURCE: Reading user-controlled environment variable
@@ -10,14 +11,16 @@ def get_user_command():
     """
     return os.environ.get("USER_COMMAND")  # SOURCE - user can set this
 
+
 def get_user_input_path():
     """
     Another real vulnerability - user-controlled path
     """
     return os.environ.get("USER_INPUT_FILE", "/tmp/default")
 
+
 def safe_config_read():
     """
     Safe configuration reading for contrast
     """
-    return os.environ.get("APP_CONFIG_DIR", "/etc/myapp") 
+    return os.environ.get("APP_CONFIG_DIR", "/etc/myapp")

--- a/test_files/multi_file_taint_tests/category5_complex/test5_1_command_runner.py
+++ b/test_files/multi_file_taint_tests/category5_complex/test5_1_command_runner.py
@@ -5,6 +5,7 @@ from test5_1_data_processor import process_input, process_safe_input
 import os
 import subprocess
 
+
 def run_command():
     """
     SINK: Final destination of tainted data through 3-file chain
@@ -13,6 +14,7 @@ def run_command():
     processed = process_input()  # Receives processed but still tainted data
     os.system(processed)  # SINK - should trace back through all 3 files
 
+
 def run_safe_command():
     """
     Safe operation using non-tainted data
@@ -20,8 +22,9 @@ def run_safe_command():
     safe_processed = process_safe_input()  # Non-tainted data path
     subprocess.run(["echo", safe_processed])  # Safe operation
 
+
 def run_direct_command():
     """
     Direct safe command for contrast
     """
-    os.system("echo 'Hello World'")  # Safe - hardcoded command 
+    os.system("echo 'Hello World'")  # Safe - hardcoded command

--- a/test_files/multi_file_taint_tests/category5_complex/test5_1_data_processor.py
+++ b/test_files/multi_file_taint_tests/category5_complex/test5_1_data_processor.py
@@ -3,6 +3,7 @@
 
 from test5_1_user_input import get_input, get_safe_data
 
+
 def process_input():
     """
     PROPAGATION: Takes user input and processes it
@@ -11,6 +12,7 @@ def process_input():
     raw_data = get_input()  # Receives tainted data from file 1
     return f"processed_{raw_data}"  # Processes but keeps taint
 
+
 def process_safe_input():
     """
     Safe processing for contrast
@@ -18,10 +20,11 @@ def process_safe_input():
     safe_data = get_safe_data()  # Non-tainted data
     return f"processed_{safe_data}"
 
+
 def sanitize_input():
     """
     Example of potential sanitization (though our current system doesn't detect this)
     """
     raw_data = get_input()
     # In a real system, this might sanitize the input
-    return raw_data.replace(";", "").replace("&", "") 
+    return raw_data.replace(";", "").replace("&", "")

--- a/test_files/multi_file_taint_tests/category5_complex/test5_1_user_input.py
+++ b/test_files/multi_file_taint_tests/category5_complex/test5_1_user_input.py
@@ -1,6 +1,7 @@
 # Test 5.1: Three-File Chain - USER INPUT (File 1 of 3)
 # Expected: Should trace through all 3 files to detect complete flow
 
+
 def get_input():
     """
     SOURCE: User input that will flow through 3 files
@@ -8,8 +9,9 @@ def get_input():
     """
     return input("Enter command: ")
 
+
 def get_safe_data():
     """
     Safe function for contrast testing
     """
-    return "safe_default_command" 
+    return "safe_default_command"

--- a/test_files/multi_file_taint_tests/run_comprehensive_tests.py
+++ b/test_files/multi_file_taint_tests/run_comprehensive_tests.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from dataclasses import dataclass
 from typing import List, Dict, Any
 
+
 @dataclass
 class TestCase:
     name: str
@@ -23,6 +24,7 @@ class TestCase:
     files: List[str]
     expected_result: str  # "DETECT" or "REJECT"
     description: str
+
 
 @dataclass
 class TestResult:
@@ -32,11 +34,12 @@ class TestResult:
     details: Dict[str, Any]
     is_correct: bool
 
+
 class TaintTestSuite:
     def __init__(self):
         self.test_cases = self._define_test_cases()
         self.results = []
-        
+
     def _define_test_cases(self) -> List[TestCase]:
         """Define all test cases according to the testing strategy"""
         return [
@@ -44,107 +47,120 @@ class TaintTestSuite:
             TestCase(
                 name="test1_1_direct_import_flow",
                 category="Category 1: Valid Flows",
-                files=["category1_valid/test1_1_source_module.py", "category1_valid/test1_1_sink_module.py"],
+                files=[
+                    "category1_valid/test1_1_source_module.py",
+                    "category1_valid/test1_1_sink_module.py",
+                ],
                 expected_result="DETECT",
-                description="Direct function import flow: input() -> os.system()"
+                description="Direct function import flow: input() -> os.system()",
             ),
-            
             # Category 2: Invalid Cross-File Flows (Should REJECT)
             TestCase(
                 name="test2_1_phantom_no_import",
-                category="Category 2: Phantom Flows", 
-                files=["category2_invalid/test2_1_module_a.py", "category2_invalid/test2_1_module_b.py"],
+                category="Category 2: Phantom Flows",
+                files=[
+                    "category2_invalid/test2_1_module_a.py",
+                    "category2_invalid/test2_1_module_b.py",
+                ],
                 expected_result="REJECT",
-                description="No import relationship - should not create phantom flow"
+                description="No import relationship - should not create phantom flow",
             ),
-            
             # Category 4: Configuration vs Vulnerability
             TestCase(
                 name="test4_1_safe_config",
                 category="Category 4: Configuration Safety",
-                files=["category4_config/test4_1_config_manager.py", "category4_config/test4_1_app_initializer.py"],
-                expected_result="REJECT", 
-                description="Configuration patterns should not be flagged"
+                files=[
+                    "category4_config/test4_1_config_manager.py",
+                    "category4_config/test4_1_app_initializer.py",
+                ],
+                expected_result="REJECT",
+                description="Configuration patterns should not be flagged",
             ),
             TestCase(
                 name="test4_2_real_env_vuln",
                 category="Category 4: Real Vulnerabilities",
-                files=["category4_config/test4_2_env_reader.py", "category4_config/test4_2_command_executor.py"],
+                files=[
+                    "category4_config/test4_2_env_reader.py",
+                    "category4_config/test4_2_command_executor.py",
+                ],
                 expected_result="DETECT",
-                description="Real environment variable vulnerability"
+                description="Real environment variable vulnerability",
             ),
-            
             # Category 5: Complex Multi-File Scenarios
             TestCase(
                 name="test5_1_three_file_chain",
                 category="Category 5: Complex Scenarios",
                 files=[
                     "category5_complex/test5_1_user_input.py",
-                    "category5_complex/test5_1_data_processor.py", 
-                    "category5_complex/test5_1_command_runner.py"
+                    "category5_complex/test5_1_data_processor.py",
+                    "category5_complex/test5_1_command_runner.py",
                 ],
                 expected_result="DETECT",
-                description="Three-file chain: input() -> processor -> os.system()"
+                description="Three-file chain: input() -> processor -> os.system()",
             ),
         ]
-    
+
     def run_taint_analysis(self, test_files: List[str]) -> Dict[str, Any]:
         """Run taint analysis on test files and return results"""
-        
+
         # Create a temporary directory for this specific test
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             test_dir = Path(__file__).parent
-            
+
             # Copy only the specific test files to the temporary directory
             for test_file in test_files:
                 source_file = test_dir / test_file
-                
+
                 # Create subdirectory structure in temp dir
                 dest_file = temp_path / test_file
                 dest_file.parent.mkdir(parents=True, exist_ok=True)
-                
+
                 # Copy the file
                 shutil.copy2(source_file, dest_file)
-            
+
             # Run taint analysis on the temporary directory
             cmd = [
-                "cargo", "run", "--",
-                str(temp_path),  # Root directory to scan (temp dir with only test files)
-                "--taint-analysis"
+                "cargo",
+                "run",
+                "--",
+                str(
+                    temp_path
+                ),  # Root directory to scan (temp dir with only test files)
+                "--taint-analysis",
             ]
-            
+
             start_time = time.time()
-            
+
             try:
                 # Get the project root directory (where Cargo.toml is located)
                 project_root = Path(__file__).parent.parent.parent
-                
+
                 result = subprocess.run(
                     cmd,
                     cwd=str(project_root),  # Run from project root
                     capture_output=True,
                     text=True,
-                    timeout=30
+                    timeout=30,
                 )
-                
+
                 execution_time = time.time() - start_time
-                
+
                 return {
                     "success": result.returncode == 0,
                     "stdout": result.stdout,
                     "stderr": result.stderr,
                     "execution_time": execution_time,
-                    "return_code": result.returncode
+                    "return_code": result.returncode,
                 }
-                
+
             except subprocess.TimeoutExpired:
                 return {
                     "success": False,
                     "stdout": "",
                     "stderr": "Timeout after 30 seconds",
                     "execution_time": 30.0,
-                    "return_code": -1
+                    "return_code": -1,
                 }
             except Exception as e:
                 return {
@@ -152,110 +168,112 @@ class TaintTestSuite:
                     "stdout": "",
                     "stderr": f"Error: {str(e)}",
                     "execution_time": time.time() - start_time,
-                    "return_code": -2
+                    "return_code": -2,
                 }
-    
+
     def analyze_taint_result(self, output: str) -> str:
         """Analyze taint analysis output to determine DETECT or REJECT"""
-        
+
         # Look for taint flow indicators in output
         taint_indicators = [
             "taint flow",
             "vulnerability found",
             "cross-file flow",
             "flows found:",
-            "flows detected"
+            "flows detected",
         ]
-        
+
         output_lower = output.lower()
-        
+
         # Check for explicit flow detection
         for indicator in taint_indicators:
             if indicator in output_lower:
                 return "DETECT"
-        
+
         # Check for flow count
         if "flows found: 0" in output_lower or "no flows" in output_lower:
             return "REJECT"
-        
+
         # Look for specific vulnerability patterns
         if "command injection" in output_lower or "sql injection" in output_lower:
             return "DETECT"
-            
+
         # Check for JSON output format
         try:
-            if output.strip().startswith('{'):
+            if output.strip().startswith("{"):
                 data = json.loads(output)
-                if 'flows' in data and len(data.get('flows', [])) > 0:
+                if "flows" in data and len(data.get("flows", [])) > 0:
                     return "DETECT"
                 else:
                     return "REJECT"
         except:
             pass
-        
+
         # Default: if no clear indicators, assume REJECT
         return "REJECT"
-    
+
     def run_single_test(self, test_case: TestCase) -> TestResult:
         """Run a single test case and return results"""
-        
+
         print(f"\n🧪 Running {test_case.name}...")
         print(f"   📁 Files: {test_case.files}")
         print(f"   🎯 Expected: {test_case.expected_result}")
-        
+
         # Run taint analysis
         analysis_result = self.run_taint_analysis(test_case.files)
-        
+
         # Analyze results
         if analysis_result["success"] or analysis_result["return_code"] == 0:
             # Even if there are warnings in stderr, if return code is 0, analyze the output
             actual_result = self.analyze_taint_result(analysis_result["stdout"])
         else:
             actual_result = "ERROR"
-            
-        is_correct = (actual_result == test_case.expected_result)
-        
+
+        is_correct = actual_result == test_case.expected_result
+
         # Print immediate result
         status_emoji = "✅" if is_correct else "❌"
         print(f"   📊 Actual: {actual_result} {status_emoji}")
-        
+
         if not is_correct and actual_result != "ERROR":
-            print(f"   ⚠️  MISMATCH: Expected {test_case.expected_result}, got {actual_result}")
-        
+            print(
+                f"   ⚠️  MISMATCH: Expected {test_case.expected_result}, got {actual_result}"
+            )
+
         # Only show stderr if it's actually an error (not just warnings)
         if actual_result == "ERROR" and analysis_result.get("stderr"):
             print(f"   🚨 Error: {analysis_result['stderr'][:200]}...")
-            
+
         return TestResult(
             test_case=test_case,
             actual_result=actual_result,
             execution_time=analysis_result["execution_time"],
             details=analysis_result,
-            is_correct=is_correct
+            is_correct=is_correct,
         )
-    
+
     def run_all_tests(self) -> List[TestResult]:
         """Run all test cases and return results"""
-        
+
         print("🚀 Starting Comprehensive Multi-File Taint Analysis Test Suite")
         print("=" * 70)
-        
+
         results = []
-        
+
         for test_case in self.test_cases:
             result = self.run_single_test(test_case)
             results.append(result)
             self.results.append(result)
-            
+
         return results
-    
+
     def generate_report(self, results: List[TestResult]) -> Dict[str, Any]:
         """Generate comprehensive test report"""
-        
+
         total_tests = len(results)
         passed_tests = sum(1 for r in results if r.is_correct)
         failed_tests = total_tests - passed_tests
-        
+
         # Category breakdown
         category_stats = {}
         for result in results:
@@ -265,31 +283,40 @@ class TaintTestSuite:
             category_stats[category]["total"] += 1
             if result.is_correct:
                 category_stats[category]["passed"] += 1
-        
+
         # Performance stats
         total_time = sum(r.execution_time for r in results)
         avg_time = total_time / total_tests if total_tests > 0 else 0
-        
+
         # Critical failures
         critical_failures = []
         for result in results:
             if not result.is_correct:
                 if "phantom" in result.test_case.name.lower():
-                    critical_failures.append(f"PHANTOM FLOW DETECTED: {result.test_case.name}")
-                elif "config" in result.test_case.name.lower() and result.test_case.expected_result == "REJECT":
-                    critical_failures.append(f"CONFIG FALSE POSITIVE: {result.test_case.name}")
-        
+                    critical_failures.append(
+                        f"PHANTOM FLOW DETECTED: {result.test_case.name}"
+                    )
+                elif (
+                    "config" in result.test_case.name.lower()
+                    and result.test_case.expected_result == "REJECT"
+                ):
+                    critical_failures.append(
+                        f"CONFIG FALSE POSITIVE: {result.test_case.name}"
+                    )
+
         return {
             "summary": {
                 "total_tests": total_tests,
-                "passed_tests": passed_tests, 
+                "passed_tests": passed_tests,
                 "failed_tests": failed_tests,
-                "success_rate": round((passed_tests / total_tests) * 100, 2) if total_tests > 0 else 0
+                "success_rate": round((passed_tests / total_tests) * 100, 2)
+                if total_tests > 0
+                else 0,
             },
             "performance": {
                 "total_time": round(total_time, 3),
                 "average_time": round(avg_time, 3),
-                "meets_performance_target": avg_time < 0.2  # 200ms target
+                "meets_performance_target": avg_time < 0.2,  # 200ms target
             },
             "category_breakdown": category_stats,
             "critical_failures": critical_failures,
@@ -301,19 +328,19 @@ class TaintTestSuite:
                     "actual": r.actual_result,
                     "correct": r.is_correct,
                     "time": round(r.execution_time, 3),
-                    "description": r.test_case.description
+                    "description": r.test_case.description,
                 }
                 for r in results
-            ]
+            ],
         }
-    
+
     def print_final_report(self, report: Dict[str, Any]):
         """Print comprehensive final report"""
-        
+
         print("\n" + "=" * 70)
         print("📊 COMPREHENSIVE TAINT ANALYSIS TEST RESULTS")
         print("=" * 70)
-        
+
         # Summary
         summary = report["summary"]
         print(f"\n🎯 OVERALL RESULTS:")
@@ -321,26 +348,26 @@ class TaintTestSuite:
         print(f"   Passed: {summary['passed_tests']} ✅")
         print(f"   Failed: {summary['failed_tests']} ❌")
         print(f"   Success Rate: {summary['success_rate']}%")
-        
+
         # Success criteria check
-        meets_criteria = summary['success_rate'] >= 95
+        meets_criteria = summary["success_rate"] >= 95
         criteria_emoji = "✅" if meets_criteria else "❌"
         print(f"   Meets Success Criteria (>95%): {criteria_emoji}")
-        
+
         # Performance
         perf = report["performance"]
         print(f"\n⚡ PERFORMANCE:")
         print(f"   Total Time: {perf['total_time']}s")
         print(f"   Average Time: {perf['average_time']}s")
-        perf_emoji = "✅" if perf['meets_performance_target'] else "❌"
+        perf_emoji = "✅" if perf["meets_performance_target"] else "❌"
         print(f"   Meets Performance Target (<200ms): {perf_emoji}")
-        
+
         # Category breakdown
         print(f"\n📂 CATEGORY BREAKDOWN:")
         for category, stats in report["category_breakdown"].items():
             rate = round((stats["passed"] / stats["total"]) * 100, 2)
             print(f"   {category}: {stats['passed']}/{stats['total']} ({rate}%)")
-        
+
         # Critical failures
         if report["critical_failures"]:
             print(f"\n🚨 CRITICAL FAILURES:")
@@ -348,29 +375,32 @@ class TaintTestSuite:
                 print(f"   ❌ {failure}")
         else:
             print(f"\n✅ NO CRITICAL FAILURES")
-        
+
         # Detailed results
         print(f"\n📋 DETAILED RESULTS:")
         for result in report["detailed_results"]:
             status = "✅" if result["correct"] else "❌"
-            print(f"   {status} {result['name']}: {result['expected']} -> {result['actual']} ({result['time']}s)")
-        
+            print(
+                f"   {status} {result['name']}: {result['expected']} -> {result['actual']} ({result['time']}s)"
+            )
+
         # Final verdict
         print(f"\n" + "=" * 70)
         overall_success = (
-            summary['success_rate'] >= 95 and
-            len(report['critical_failures']) == 0 and
-            perf['meets_performance_target']
+            summary["success_rate"] >= 95
+            and len(report["critical_failures"]) == 0
+            and perf["meets_performance_target"]
         )
-        
+
         if overall_success:
             print("🎉 COMPREHENSIVE TEST SUITE: ✅ PASSED")
             print("🚀 Taint analysis fixes are working correctly!")
         else:
-            print("💥 COMPREHENSIVE TEST SUITE: ❌ FAILED") 
+            print("💥 COMPREHENSIVE TEST SUITE: ❌ FAILED")
             print("🔧 Taint analysis needs additional fixes.")
-        
+
         print("=" * 70)
+
 
 def main():
     """Main test execution"""
@@ -378,13 +408,14 @@ def main():
     results = suite.run_all_tests()
     report = suite.generate_report(results)
     suite.print_final_report(report)
-    
+
     # Save detailed report
     report_file = Path(__file__).parent / "test_report.json"
-    with open(report_file, 'w') as f:
+    with open(report_file, "w") as f:
         json.dump(report, f, indent=2)
-    
+
     print(f"\n📄 Detailed report saved to: {report_file}")
 
+
 if __name__ == "__main__":
-    main() 
+    main()

--- a/test_files/nth_degree_taint/level1_source.py
+++ b/test_files/nth_degree_taint/level1_source.py
@@ -1,12 +1,14 @@
 # Level 1: Initial Taint Source
 # This is the starting point of our nth degree taint flow
 
+
 def get_user_input():
     """
     LEVEL 1 SOURCE: Initial user input - this is where taint begins
     """
     user_input = input("Enter command: ")  # PRIMARY SOURCE
     return user_input
+
 
 def get_user_data():
     """
@@ -15,6 +17,7 @@ def get_user_data():
     user_data = input("Enter data: ")  # SECONDARY SOURCE
     return user_data
 
+
 def get_config_from_user():
     """
     LEVEL 1 SOURCE: Configuration from user
@@ -22,11 +25,13 @@ def get_config_from_user():
     user_config = input("Enter config: ")  # TERTIARY SOURCE
     return f"config_{user_config}"
 
+
 def safe_constant():
     """
     LEVEL 1 SAFE: Non-tainted constant
     """
     return "safe_constant_value"
 
+
 if __name__ == "__main__":
-    print("Level 1: Taint sources initialized") 
+    print("Level 1: Taint sources initialized")

--- a/test_files/nth_degree_taint/level2_processor.py
+++ b/test_files/nth_degree_taint/level2_processor.py
@@ -1,7 +1,13 @@
 # Level 2: First Degree Taint Propagation
 # This file receives taint from level1 and propagates it further
 
-from level1_source import get_user_input, get_user_data, get_config_from_user, safe_constant
+from level1_source import (
+    get_user_input,
+    get_user_data,
+    get_config_from_user,
+    safe_constant,
+)
+
 
 def process_user_command():
     """
@@ -11,6 +17,7 @@ def process_user_command():
     processed = f"processed_{raw_command}"
     return processed  # Propagates taint to level 3
 
+
 def transform_user_data():
     """
     LEVEL 2 PROPAGATION: Transforms tainted data from level 1
@@ -18,6 +25,7 @@ def transform_user_data():
     raw_data = get_user_data()  # Receives taint from level 1
     transformed = raw_data.upper()
     return f"transformed_{transformed}"  # Propagates taint to level 3
+
 
 def combine_tainted_inputs():
     """
@@ -29,6 +37,7 @@ def combine_tainted_inputs():
     combined = f"{cmd}|{data}|{config}"
     return combined  # Propagates combined taint to level 3
 
+
 def mix_safe_and_tainted():
     """
     LEVEL 2 PROPAGATION: Mixes safe and tainted data
@@ -37,6 +46,7 @@ def mix_safe_and_tainted():
     tainted = get_user_input()  # Tainted
     mixed = f"{safe}_{tainted}"
     return mixed  # Should still be considered tainted
+
 
 def process_with_validation():
     """
@@ -48,5 +58,6 @@ def process_with_validation():
         return validated  # Still tainted despite validation
     return "empty"
 
+
 if __name__ == "__main__":
-    print("Level 2: Taint propagation layer initialized") 
+    print("Level 2: Taint propagation layer initialized")

--- a/test_files/nth_degree_taint/level2_simple.py
+++ b/test_files/nth_degree_taint/level2_simple.py
@@ -2,6 +2,7 @@
 import os
 from level1_source import get_user_input
 
+
 def execute_user_command():
     """
     LEVEL 2 SINK: Simple cross-file taint test
@@ -10,6 +11,7 @@ def execute_user_command():
     user_cmd = get_user_input()  # Should receive taint from level1
     os.system(user_cmd)  # SINK - Should detect cross-file taint
 
+
 if __name__ == "__main__":
     print("Level 2: Simple cross-file taint test")
-    execute_user_command() 
+    execute_user_command()

--- a/test_files/nth_degree_taint/level3_transformer.py
+++ b/test_files/nth_degree_taint/level3_transformer.py
@@ -2,12 +2,13 @@
 # This file receives taint from level2 and propagates it further
 
 from level2_processor import (
-    process_user_command, 
-    transform_user_data, 
+    process_user_command,
+    transform_user_data,
     combine_tainted_inputs,
     mix_safe_and_tainted,
-    process_with_validation
+    process_with_validation,
 )
+
 
 def advanced_command_processing():
     """
@@ -17,6 +18,7 @@ def advanced_command_processing():
     advanced = f"advanced_{processed_cmd}"
     return advanced  # Propagates taint to level 4
 
+
 def data_transformation_pipeline():
     """
     LEVEL 3 PROPAGATION: Data transformation pipeline
@@ -25,6 +27,7 @@ def data_transformation_pipeline():
     pipelined = f"pipeline_{transformed}"
     return pipelined  # Propagates taint to level 4
 
+
 def complex_data_merger():
     """
     LEVEL 3 PROPAGATION: Complex merger of multiple tainted sources
@@ -32,9 +35,10 @@ def complex_data_merger():
     combined = combine_tainted_inputs()  # Receives taint from level 2
     mixed = mix_safe_and_tainted()  # Receives taint from level 2
     validated = process_with_validation()  # Receives taint from level 2
-    
+
     merged = f"merged_{combined}_{mixed}_{validated}"
     return merged  # Propagates complex taint to level 4
+
 
 def conditional_processing():
     """
@@ -46,19 +50,22 @@ def conditional_processing():
         return conditional  # Propagates taint to level 4
     return "no_processing"
 
+
 def class_based_processing():
     """
     LEVEL 3 PROPAGATION: Class-based taint propagation
     """
+
     class TaintProcessor:
         def __init__(self):
             self.data = transform_user_data()  # Receives taint from level 2
-        
+
         def process(self):
             return f"class_processed_{self.data}"  # Propagates taint
-    
+
     processor = TaintProcessor()
     return processor.process()  # Propagates taint to level 4
 
+
 if __name__ == "__main__":
-    print("Level 3: Advanced taint transformation layer initialized") 
+    print("Level 3: Advanced taint transformation layer initialized")

--- a/test_files/nth_degree_taint/level4_aggregator.py
+++ b/test_files/nth_degree_taint/level4_aggregator.py
@@ -6,8 +6,9 @@ from level3_transformer import (
     data_transformation_pipeline,
     complex_data_merger,
     conditional_processing,
-    class_based_processing
+    class_based_processing,
 )
+
 
 def enterprise_data_aggregation():
     """
@@ -15,9 +16,10 @@ def enterprise_data_aggregation():
     """
     advanced = advanced_command_processing()  # Receives taint from level 3
     pipeline = data_transformation_pipeline()  # Receives taint from level 3
-    
+
     aggregated = f"enterprise_{advanced}_{pipeline}"
     return aggregated  # Propagates taint to level 5
+
 
 def multi_source_consolidation():
     """
@@ -26,9 +28,10 @@ def multi_source_consolidation():
     merged = complex_data_merger()  # Receives taint from level 3
     conditional = conditional_processing()  # Receives taint from level 3
     class_based = class_based_processing()  # Receives taint from level 3
-    
+
     consolidated = f"consolidated_{merged}_{conditional}_{class_based}"
     return consolidated  # Propagates taint to level 5
+
 
 def workflow_orchestration():
     """
@@ -39,11 +42,12 @@ def workflow_orchestration():
         data_transformation_pipeline(),  # Tainted
         complex_data_merger(),  # Tainted
         conditional_processing(),  # Tainted
-        class_based_processing()  # Tainted
+        class_based_processing(),  # Tainted
     ]
-    
+
     orchestrated = "orchestrated_" + "_".join(all_sources)
     return orchestrated  # Propagates complex taint to level 5
+
 
 def distributed_processing():
     """
@@ -53,9 +57,12 @@ def distributed_processing():
     node1_data = advanced_command_processing()  # Tainted from level 3
     node2_data = data_transformation_pipeline()  # Tainted from level 3
     node3_data = complex_data_merger()  # Tainted from level 3
-    
-    distributed = f"distributed_node1_{node1_data}_node2_{node2_data}_node3_{node3_data}"
+
+    distributed = (
+        f"distributed_node1_{node1_data}_node2_{node2_data}_node3_{node3_data}"
+    )
     return distributed  # Propagates distributed taint to level 5
+
 
 def caching_layer():
     """
@@ -65,5 +72,6 @@ def caching_layer():
     cache_key = f"cache_{hash(cached_data) % 10000}"
     return f"{cache_key}_{cached_data}"  # Propagates cached taint to level 5
 
+
 if __name__ == "__main__":
-    print("Level 4: Enterprise aggregation layer initialized") 
+    print("Level 4: Enterprise aggregation layer initialized")

--- a/test_files/nth_degree_taint/level5_sink.py
+++ b/test_files/nth_degree_taint/level5_sink.py
@@ -8,8 +8,9 @@ from level4_aggregator import (
     multi_source_consolidation,
     workflow_orchestration,
     distributed_processing,
-    caching_layer
+    caching_layer,
 )
+
 
 def execute_enterprise_command():
     """
@@ -19,6 +20,7 @@ def execute_enterprise_command():
     enterprise_data = enterprise_data_aggregation()  # 4th degree taint
     os.system(enterprise_data)  # SINK - Should detect 4th degree taint
 
+
 def process_consolidated_data():
     """
     LEVEL 5 SINK: Processes consolidated tainted data
@@ -26,6 +28,7 @@ def process_consolidated_data():
     """
     consolidated = multi_source_consolidation()  # 4th degree taint
     eval(consolidated)  # SINK - Should detect 4th degree taint
+
 
 def execute_orchestrated_workflow():
     """
@@ -35,6 +38,7 @@ def execute_orchestrated_workflow():
     orchestrated = workflow_orchestration()  # 4th degree taint
     exec(orchestrated)  # SINK - Should detect 4th degree taint
 
+
 def run_distributed_command():
     """
     LEVEL 5 SINK: Runs distributed command
@@ -42,6 +46,7 @@ def run_distributed_command():
     """
     distributed = distributed_processing()  # 4th degree taint
     subprocess.run(distributed, shell=True)  # SINK - Should detect 4th degree taint
+
 
 def execute_cached_operation():
     """
@@ -51,6 +56,7 @@ def execute_cached_operation():
     cached = caching_layer()  # 4th degree taint (with internal recursion)
     os.system(cached)  # SINK - Should detect 4th degree taint
 
+
 def complex_multi_sink():
     """
     LEVEL 5 SINK: Complex sink using multiple 4th degree sources
@@ -58,11 +64,12 @@ def complex_multi_sink():
     enterprise = enterprise_data_aggregation()  # 4th degree taint
     consolidated = multi_source_consolidation()  # 4th degree taint
     orchestrated = workflow_orchestration()  # 4th degree taint
-    
+
     # Multiple sinks with 4th degree taint
     os.system(enterprise)  # SINK 1
     eval(consolidated)  # SINK 2
     exec(orchestrated)  # SINK 3
+
 
 def safe_operation():
     """
@@ -71,14 +78,15 @@ def safe_operation():
     safe_data = "safe_constant"
     os.system(f"echo {safe_data}")  # Should NOT be flagged
 
+
 if __name__ == "__main__":
     print("Level 5: Final sink layer - 4th degree taint reception ready")
     print("Testing nth degree taint propagation...")
-    
+
     # These should all be detected as tainted
     print("1. Enterprise command execution")
-    print("2. Consolidated data processing") 
+    print("2. Consolidated data processing")
     print("3. Orchestrated workflow execution")
     print("4. Distributed command execution")
     print("5. Cached operation execution")
-    print("6. Complex multi-sink operations") 
+    print("6. Complex multi-sink operations")

--- a/test_files/nth_degree_taint/level6_ultimate_sink.py
+++ b/test_files/nth_degree_taint/level6_ultimate_sink.py
@@ -6,11 +6,12 @@ import subprocess
 from level5_sink import (
     enterprise_data_aggregation as level5_enterprise,
     multi_source_consolidation as level5_consolidated,
-    workflow_orchestration as level5_orchestrated
+    workflow_orchestration as level5_orchestrated,
 )
 
 # Import level 4 functions directly to test bypass scenarios
 from level4_aggregator import enterprise_data_aggregation as level4_enterprise
+
 
 def ultimate_command_execution():
     """
@@ -21,6 +22,7 @@ def ultimate_command_execution():
     ultimate_data = f"ultimate_{level5_enterprise()}"
     os.system(ultimate_data)  # SINK - Should detect 5th degree taint
 
+
 def recursive_taint_amplification():
     """
     LEVEL 6 SINK: Recursive amplification of taint
@@ -30,23 +32,26 @@ def recursive_taint_amplification():
     enterprise_4th = level4_enterprise()  # 4th degree
     consolidated_5th = level5_consolidated()  # 5th degree
     orchestrated_5th = level5_orchestrated()  # 5th degree
-    
+
     recursive_data = f"recursive_{enterprise_4th}_{consolidated_5th}_{orchestrated_5th}"
     eval(recursive_data)  # SINK - Should detect 5th degree taint
+
 
 def deep_nested_processing():
     """
     LEVEL 6 SINK: Deep nested processing with maximum taint depth
     """
+
     def inner_processor():
         return level5_enterprise()  # 5th degree taint
-    
+
     def outer_processor():
         inner_result = inner_processor()
         return f"outer_{inner_result}"
-    
+
     nested_result = outer_processor()
     exec(nested_result)  # SINK - Should detect 5th degree taint
+
 
 def cross_level_contamination():
     """
@@ -55,55 +60,60 @@ def cross_level_contamination():
     # Mix different degree taints
     level4_data = level4_enterprise()  # 4th degree
     level5_data = level5_consolidated()  # 5th degree
-    
+
     # This should be treated as 5th degree (highest degree wins)
     contaminated = f"contaminated_{level4_data}_{level5_data}"
     subprocess.run(contaminated, shell=True)  # SINK - Should detect 5th degree taint
+
 
 def enterprise_simulation():
     """
     LEVEL 6 SINK: Enterprise-level simulation with maximum complexity
     """
+
     class UltimateProcessor:
         def __init__(self):
             self.level5_data = level5_orchestrated()  # 5th degree taint
-            self.level4_data = level4_enterprise()   # 4th degree taint
-        
+            self.level4_data = level4_enterprise()  # 4th degree taint
+
         def process_ultimate(self):
             # Simulate complex enterprise processing
             processed = f"enterprise_sim_{self.level5_data}_{self.level4_data}"
             return processed
-        
+
         def execute_ultimate(self):
             processed = self.process_ultimate()
             os.system(processed)  # SINK - Should detect 5th degree taint
-    
+
     processor = UltimateProcessor()
     processor.execute_ultimate()
+
 
 def stress_test_nth_degree():
     """
     LEVEL 6 SINK: Stress test for nth degree taint tracking
     """
+
     # Create a complex chain of function calls within this level
     def chain_step_1():
         return level5_enterprise()  # 5th degree
-    
+
     def chain_step_2():
         return f"step2_{chain_step_1()}"
-    
+
     def chain_step_3():
         return f"step3_{chain_step_2()}"
-    
+
     def chain_step_4():
         return f"step4_{chain_step_3()}"
-    
+
     final_chain = chain_step_4()
-    
+
     # Multiple sinks to test detection
     os.system(final_chain)  # SINK 1 - 5th degree
-    eval(final_chain)       # SINK 2 - 5th degree  
-    exec(final_chain)       # SINK 3 - 5th degree
+    eval(final_chain)  # SINK 2 - 5th degree
+    exec(final_chain)  # SINK 3 - 5th degree
+
 
 if __name__ == "__main__":
     print("Level 6: Ultimate sink layer - 5th degree taint reception")
@@ -113,4 +123,4 @@ if __name__ == "__main__":
     print("- Cross-level contamination scenarios")
     print("- Recursive taint amplification")
     print("- Enterprise-level complexity simulation")
-    print("- Stress testing nth degree limits") 
+    print("- Stress testing nth degree limits")

--- a/test_files/nth_degree_taint/simple_taint_test.py
+++ b/test_files/nth_degree_taint/simple_taint_test.py
@@ -2,23 +2,27 @@
 import os
 import subprocess
 
+
 def test_direct_taint():
     """Direct taint flow - should be detected"""
     user_input = input("Enter command: ")  # SOURCE
     os.system(user_input)  # SINK - Should detect taint flow
+
 
 def test_eval_taint():
     """Eval taint flow - should be detected"""
     user_data = input("Enter code: ")  # SOURCE
     eval(user_data)  # SINK - Should detect taint flow
 
+
 def test_subprocess_taint():
     """Subprocess taint flow - should be detected"""
     user_cmd = input("Enter subprocess command: ")  # SOURCE
     subprocess.run(user_cmd, shell=True)  # SINK - Should detect taint flow
 
+
 if __name__ == "__main__":
     print("Simple taint test - validating pattern matching")
     test_direct_taint()
     test_eval_taint()
-    test_subprocess_taint() 
+    test_subprocess_taint()

--- a/test_files/nth_degree_validation/degree1/level1_source.py
+++ b/test_files/nth_degree_validation/degree1/level1_source.py
@@ -1,12 +1,14 @@
 # Level 1: Initial Taint Source
 # This is the starting point of our nth degree taint flow
 
+
 def get_user_input():
     """
     LEVEL 1 SOURCE: Initial user input - this is where taint begins
     """
     user_input = input("Enter command: ")  # PRIMARY SOURCE
     return user_input
+
 
 def get_user_data():
     """
@@ -15,6 +17,7 @@ def get_user_data():
     user_data = input("Enter data: ")  # SECONDARY SOURCE
     return user_data
 
+
 def get_config_from_user():
     """
     LEVEL 1 SOURCE: Configuration from user
@@ -22,11 +25,13 @@ def get_config_from_user():
     user_config = input("Enter config: ")  # TERTIARY SOURCE
     return f"config_{user_config}"
 
+
 def safe_constant():
     """
     LEVEL 1 SAFE: Non-tainted constant
     """
     return "safe_constant_value"
 
+
 if __name__ == "__main__":
-    print("Level 1: Taint sources initialized") 
+    print("Level 1: Taint sources initialized")

--- a/test_files/nth_degree_validation/degree1/level2_simple.py
+++ b/test_files/nth_degree_validation/degree1/level2_simple.py
@@ -2,6 +2,7 @@
 import os
 from level1_source import get_user_input
 
+
 def execute_user_command():
     """
     LEVEL 2 SINK: Simple cross-file taint test
@@ -10,6 +11,7 @@ def execute_user_command():
     user_cmd = get_user_input()  # Should receive taint from level1
     os.system(user_cmd)  # SINK - Should detect cross-file taint
 
+
 if __name__ == "__main__":
     print("Level 2: Simple cross-file taint test")
-    execute_user_command() 
+    execute_user_command()

--- a/test_files/nth_degree_validation/degree2/level1_source.py
+++ b/test_files/nth_degree_validation/degree2/level1_source.py
@@ -1,12 +1,14 @@
 # Level 1: Initial Taint Source
 # This is the starting point of our nth degree taint flow
 
+
 def get_user_input():
     """
     LEVEL 1 SOURCE: Initial user input - this is where taint begins
     """
     user_input = input("Enter command: ")  # PRIMARY SOURCE
     return user_input
+
 
 def get_user_data():
     """
@@ -15,6 +17,7 @@ def get_user_data():
     user_data = input("Enter data: ")  # SECONDARY SOURCE
     return user_data
 
+
 def get_config_from_user():
     """
     LEVEL 1 SOURCE: Configuration from user
@@ -22,11 +25,13 @@ def get_config_from_user():
     user_config = input("Enter config: ")  # TERTIARY SOURCE
     return f"config_{user_config}"
 
+
 def safe_constant():
     """
     LEVEL 1 SAFE: Non-tainted constant
     """
     return "safe_constant_value"
 
+
 if __name__ == "__main__":
-    print("Level 1: Taint sources initialized") 
+    print("Level 1: Taint sources initialized")

--- a/test_files/nth_degree_validation/degree2/level2_processor.py
+++ b/test_files/nth_degree_validation/degree2/level2_processor.py
@@ -1,7 +1,13 @@
 # Level 2: First Degree Taint Propagation
 # This file receives taint from level1 and propagates it further
 
-from level1_source import get_user_input, get_user_data, get_config_from_user, safe_constant
+from level1_source import (
+    get_user_input,
+    get_user_data,
+    get_config_from_user,
+    safe_constant,
+)
+
 
 def process_user_command():
     """
@@ -11,6 +17,7 @@ def process_user_command():
     processed = f"processed_{raw_command}"
     return processed  # Propagates taint to level 3
 
+
 def transform_user_data():
     """
     LEVEL 2 PROPAGATION: Transforms tainted data from level 1
@@ -18,6 +25,7 @@ def transform_user_data():
     raw_data = get_user_data()  # Receives taint from level 1
     transformed = raw_data.upper()
     return f"transformed_{transformed}"  # Propagates taint to level 3
+
 
 def combine_tainted_inputs():
     """
@@ -29,6 +37,7 @@ def combine_tainted_inputs():
     combined = f"{cmd}|{data}|{config}"
     return combined  # Propagates combined taint to level 3
 
+
 def mix_safe_and_tainted():
     """
     LEVEL 2 PROPAGATION: Mixes safe and tainted data
@@ -37,6 +46,7 @@ def mix_safe_and_tainted():
     tainted = get_user_input()  # Tainted
     mixed = f"{safe}_{tainted}"
     return mixed  # Should still be considered tainted
+
 
 def process_with_validation():
     """
@@ -48,5 +58,6 @@ def process_with_validation():
         return validated  # Still tainted despite validation
     return "empty"
 
+
 if __name__ == "__main__":
-    print("Level 2: Taint propagation layer initialized") 
+    print("Level 2: Taint propagation layer initialized")

--- a/test_files/nth_degree_validation/degree2/level3_sink.py
+++ b/test_files/nth_degree_validation/degree2/level3_sink.py
@@ -4,6 +4,7 @@
 import os
 from level2_processor import process_user_command
 
+
 def execute_processed_command():
     """
     LEVEL 3 SINK: 2nd degree taint reception
@@ -12,6 +13,7 @@ def execute_processed_command():
     processed_cmd = process_user_command()  # 2nd degree taint
     os.system(processed_cmd)  # SINK - Should detect 2nd degree taint
 
+
 if __name__ == "__main__":
     print("Level 3: 2nd degree taint sink")
-    execute_processed_command() 
+    execute_processed_command()

--- a/test_files/nth_degree_validation/degree2/level3_transformer.py
+++ b/test_files/nth_degree_validation/degree2/level3_transformer.py
@@ -2,12 +2,13 @@
 # This file receives taint from level2 and propagates it further
 
 from level2_processor import (
-    process_user_command, 
-    transform_user_data, 
+    process_user_command,
+    transform_user_data,
     combine_tainted_inputs,
     mix_safe_and_tainted,
-    process_with_validation
+    process_with_validation,
 )
+
 
 def advanced_command_processing():
     """
@@ -17,6 +18,7 @@ def advanced_command_processing():
     advanced = f"advanced_{processed_cmd}"
     return advanced  # Propagates taint to level 4
 
+
 def data_transformation_pipeline():
     """
     LEVEL 3 PROPAGATION: Data transformation pipeline
@@ -25,6 +27,7 @@ def data_transformation_pipeline():
     pipelined = f"pipeline_{transformed}"
     return pipelined  # Propagates taint to level 4
 
+
 def complex_data_merger():
     """
     LEVEL 3 PROPAGATION: Complex merger of multiple tainted sources
@@ -32,9 +35,10 @@ def complex_data_merger():
     combined = combine_tainted_inputs()  # Receives taint from level 2
     mixed = mix_safe_and_tainted()  # Receives taint from level 2
     validated = process_with_validation()  # Receives taint from level 2
-    
+
     merged = f"merged_{combined}_{mixed}_{validated}"
     return merged  # Propagates complex taint to level 4
+
 
 def conditional_processing():
     """
@@ -46,19 +50,22 @@ def conditional_processing():
         return conditional  # Propagates taint to level 4
     return "no_processing"
 
+
 def class_based_processing():
     """
     LEVEL 3 PROPAGATION: Class-based taint propagation
     """
+
     class TaintProcessor:
         def __init__(self):
             self.data = transform_user_data()  # Receives taint from level 2
-        
+
         def process(self):
             return f"class_processed_{self.data}"  # Propagates taint
-    
+
     processor = TaintProcessor()
     return processor.process()  # Propagates taint to level 4
 
+
 if __name__ == "__main__":
-    print("Level 3: Advanced taint transformation layer initialized") 
+    print("Level 3: Advanced taint transformation layer initialized")

--- a/test_files/nth_degree_validation/degree3/level1_source.py
+++ b/test_files/nth_degree_validation/degree3/level1_source.py
@@ -1,12 +1,14 @@
 # Level 1: Initial Taint Source
 # This is the starting point of our nth degree taint flow
 
+
 def get_user_input():
     """
     LEVEL 1 SOURCE: Initial user input - this is where taint begins
     """
     user_input = input("Enter command: ")  # PRIMARY SOURCE
     return user_input
+
 
 def get_user_data():
     """
@@ -15,6 +17,7 @@ def get_user_data():
     user_data = input("Enter data: ")  # SECONDARY SOURCE
     return user_data
 
+
 def get_config_from_user():
     """
     LEVEL 1 SOURCE: Configuration from user
@@ -22,11 +25,13 @@ def get_config_from_user():
     user_config = input("Enter config: ")  # TERTIARY SOURCE
     return f"config_{user_config}"
 
+
 def safe_constant():
     """
     LEVEL 1 SAFE: Non-tainted constant
     """
     return "safe_constant_value"
 
+
 if __name__ == "__main__":
-    print("Level 1: Taint sources initialized") 
+    print("Level 1: Taint sources initialized")

--- a/test_files/nth_degree_validation/degree3/level2_processor.py
+++ b/test_files/nth_degree_validation/degree3/level2_processor.py
@@ -1,7 +1,13 @@
 # Level 2: First Degree Taint Propagation
 # This file receives taint from level1 and propagates it further
 
-from level1_source import get_user_input, get_user_data, get_config_from_user, safe_constant
+from level1_source import (
+    get_user_input,
+    get_user_data,
+    get_config_from_user,
+    safe_constant,
+)
+
 
 def process_user_command():
     """
@@ -11,6 +17,7 @@ def process_user_command():
     processed = f"processed_{raw_command}"
     return processed  # Propagates taint to level 3
 
+
 def transform_user_data():
     """
     LEVEL 2 PROPAGATION: Transforms tainted data from level 1
@@ -18,6 +25,7 @@ def transform_user_data():
     raw_data = get_user_data()  # Receives taint from level 1
     transformed = raw_data.upper()
     return f"transformed_{transformed}"  # Propagates taint to level 3
+
 
 def combine_tainted_inputs():
     """
@@ -29,6 +37,7 @@ def combine_tainted_inputs():
     combined = f"{cmd}|{data}|{config}"
     return combined  # Propagates combined taint to level 3
 
+
 def mix_safe_and_tainted():
     """
     LEVEL 2 PROPAGATION: Mixes safe and tainted data
@@ -37,6 +46,7 @@ def mix_safe_and_tainted():
     tainted = get_user_input()  # Tainted
     mixed = f"{safe}_{tainted}"
     return mixed  # Should still be considered tainted
+
 
 def process_with_validation():
     """
@@ -48,5 +58,6 @@ def process_with_validation():
         return validated  # Still tainted despite validation
     return "empty"
 
+
 if __name__ == "__main__":
-    print("Level 2: Taint propagation layer initialized") 
+    print("Level 2: Taint propagation layer initialized")

--- a/test_files/nth_degree_validation/degree3/level3_transformer.py
+++ b/test_files/nth_degree_validation/degree3/level3_transformer.py
@@ -2,12 +2,13 @@
 # This file receives taint from level2 and propagates it further
 
 from level2_processor import (
-    process_user_command, 
-    transform_user_data, 
+    process_user_command,
+    transform_user_data,
     combine_tainted_inputs,
     mix_safe_and_tainted,
-    process_with_validation
+    process_with_validation,
 )
+
 
 def advanced_command_processing():
     """
@@ -17,6 +18,7 @@ def advanced_command_processing():
     advanced = f"advanced_{processed_cmd}"
     return advanced  # Propagates taint to level 4
 
+
 def data_transformation_pipeline():
     """
     LEVEL 3 PROPAGATION: Data transformation pipeline
@@ -25,6 +27,7 @@ def data_transformation_pipeline():
     pipelined = f"pipeline_{transformed}"
     return pipelined  # Propagates taint to level 4
 
+
 def complex_data_merger():
     """
     LEVEL 3 PROPAGATION: Complex merger of multiple tainted sources
@@ -32,9 +35,10 @@ def complex_data_merger():
     combined = combine_tainted_inputs()  # Receives taint from level 2
     mixed = mix_safe_and_tainted()  # Receives taint from level 2
     validated = process_with_validation()  # Receives taint from level 2
-    
+
     merged = f"merged_{combined}_{mixed}_{validated}"
     return merged  # Propagates complex taint to level 4
+
 
 def conditional_processing():
     """
@@ -46,19 +50,22 @@ def conditional_processing():
         return conditional  # Propagates taint to level 4
     return "no_processing"
 
+
 def class_based_processing():
     """
     LEVEL 3 PROPAGATION: Class-based taint propagation
     """
+
     class TaintProcessor:
         def __init__(self):
             self.data = transform_user_data()  # Receives taint from level 2
-        
+
         def process(self):
             return f"class_processed_{self.data}"  # Propagates taint
-    
+
     processor = TaintProcessor()
     return processor.process()  # Propagates taint to level 4
 
+
 if __name__ == "__main__":
-    print("Level 3: Advanced taint transformation layer initialized") 
+    print("Level 3: Advanced taint transformation layer initialized")

--- a/test_files/nth_degree_validation/degree3/level4_sink.py
+++ b/test_files/nth_degree_validation/degree3/level4_sink.py
@@ -2,10 +2,12 @@
 import os
 from level3_transformer import advanced_command_processing
 
+
 def execute_advanced_command():
     """3rd degree taint: Level1 -> Level2 -> Level3 -> Level4"""
     advanced_cmd = advanced_command_processing()  # 3rd degree taint
     os.system(advanced_cmd)  # SINK - Should detect 3rd degree taint
+
 
 if __name__ == "__main__":
     execute_advanced_command()

--- a/test_files/python/another_test.py
+++ b/test_files/python/another_test.py
@@ -1,17 +1,20 @@
 import subprocess
 import os
 
+
 def execute_user_command(cmd):
     # Command injection vulnerability
     result = os.system(f"bash -c '{cmd}'")
     return result
 
+
 def unsafe_eval(user_input):
-    # Code injection vulnerability  
+    # Code injection vulnerability
     return eval(user_input)
+
 
 def process_file(filename):
     # Path traversal vulnerability
     path = f"../data/{filename}"
     with open(path) as f:
-        return f.read() 
+        return f.read()

--- a/test_files/python/better_flow_example.py
+++ b/test_files/python/better_flow_example.py
@@ -8,39 +8,42 @@ import subprocess
 import shlex
 from flask import request
 
+
 def complex_flow_example():
     # SOURCE: User input enters here
-    user_input = request.args.get('cmd')
-    
+    user_input = request.args.get("cmd")
+
     # TRACE: Data flows through string operations
     prefix = "echo "
-    
+
     # TRACE: String concatenation propagates taint
     command = prefix + user_input
-    
+
     # TRACE: Further manipulation
     final_command = command.upper()
-    
+
     # SINK: Tainted data reaches dangerous function
     os.system(final_command)
-    
+
     return "Done"
+
 
 def sanitized_flow_example():
     # SOURCE: User input
-    user_input = request.args.get('file')
-    
+    user_input = request.args.get("file")
+
     # TRACE: Data flows
     filename = user_input + ".txt"
-    
+
     # SANITIZER: Proper sanitization breaks the flow
     safe_filename = shlex.quote(filename)
-    
+
     # SINK: Now safe due to sanitization
     os.system(f"cat {safe_filename}")
-    
+
     return "Safe"
+
 
 if __name__ == "__main__":
     complex_flow_example()
-    sanitized_flow_example() 
+    sanitized_flow_example()

--- a/test_files/python/complete_flow_test.py
+++ b/test_files/python/complete_flow_test.py
@@ -12,123 +12,134 @@ import yaml
 
 app = Flask(__name__)
 
+
 # Command Injection Flow
-@app.route('/command')
+@app.route("/command")
 def command_injection():
     # Source: User input from request
-    user_input = request.args.get('cmd', '')
-    
+    user_input = request.args.get("cmd", "")
+
     # Sink: Direct command execution (VULNERABLE)
     os.system(user_input)
-    
+
     # Another flow with propagation
     command = f"echo {user_input}"
     subprocess.run(command, shell=True)
-    
+
     return "Command executed"
 
-# SQL Injection Flow  
-@app.route('/query')
+
+# SQL Injection Flow
+@app.route("/query")
 def sql_injection():
     # Source: User input
-    user_id = request.args.get('id', '')
-    
+    user_id = request.args.get("id", "")
+
     # Propagation through string formatting
     query = f"SELECT * FROM users WHERE id = {user_id}"
-    
+
     # Sink: Database execution (VULNERABLE)
-    conn = sqlite3.connect('database.db')
+    conn = sqlite3.connect("database.db")
     cursor = conn.cursor()
     cursor.execute(query)
-    
+
     return "Query executed"
 
+
 # Sanitized Flow
-@app.route('/safe_command')
+@app.route("/safe_command")
 def safe_command():
     # Source: User input
-    user_input = request.args.get('cmd', '')
-    
+    user_input = request.args.get("cmd", "")
+
     # Sanitization
     import shlex
+
     safe_input = shlex.quote(user_input)
-    
+
     # Sink: Command execution (SAFE due to sanitization)
     os.system(f"echo {safe_input}")
-    
+
     return "Safe command executed"
 
+
 # Path Traversal Flow
-@app.route('/file')
+@app.route("/file")
 def path_traversal():
     # Source: User input
-    filename = request.args.get('file', '')
-    
+    filename = request.args.get("file", "")
+
     # Propagation
-    filepath = os.path.join('/uploads', filename)
-    
+    filepath = os.path.join("/uploads", filename)
+
     # Sink: File operation (VULNERABLE)
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         content = f.read()
-    
+
     return content
 
+
 # Template Injection Flow
-@app.route('/template')
+@app.route("/template")
 def template_injection():
     # Source: User input
-    template_string = request.args.get('template', '')
-    
+    template_string = request.args.get("template", "")
+
     # Sink: Template rendering (VULNERABLE)
     return render_template_string(template_string)
 
+
 # Deserialization Flow
-@app.route('/deserialize')
+@app.route("/deserialize")
 def deserialization():
     # Source: User data
     data = request.get_data()
-    
+
     # Sink: Unsafe deserialization (VULNERABLE)
     obj = pickle.loads(data)
-    
+
     return str(obj)
 
+
 # Multiple hops flow
-@app.route('/multi_hop')
+@app.route("/multi_hop")
 def multi_hop_flow():
     # Source
-    user_input = request.args.get('data', '')
-    
+    user_input = request.args.get("data", "")
+
     # First hop: assignment
     temp_var = user_input
-    
+
     # Second hop: string manipulation
     processed = temp_var.upper()
-    
+
     # Third hop: formatting
     final_command = f"echo {processed}"
-    
+
     # Sink: command execution
     os.system(final_command)
-    
+
     return "Multi-hop flow executed"
+
 
 # Environment variable flow
 def env_flow():
     # Source: Environment variable
-    config_value = os.environ.get('CONFIG_CMD', '')
-    
+    config_value = os.environ.get("CONFIG_CMD", "")
+
     # Sink: Command execution
     subprocess.call(config_value, shell=True)
+
 
 # File-based flow
 def file_flow():
     # Source: File input
-    with open('user_input.txt', 'r') as f:
+    with open("user_input.txt", "r") as f:
         user_data = f.read()
-    
+
     # Sink: Code execution
     eval(user_data)
 
-if __name__ == '__main__':
-    app.run(debug=True) 
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/test_files/python/comprehensive_taint_test.py
+++ b/test_files/python/comprehensive_taint_test.py
@@ -7,65 +7,77 @@ import os
 import sys
 import subprocess
 
+
 def test_direct_variable_usage():
     """Test 1: Direct variable usage - should work"""
-    user_input = os.environ.get('USER_DATA')
+    user_input = os.environ.get("USER_DATA")
     eval(user_input)  # Direct usage
+
 
 def test_f_string_formatting():
     """Test 2: F-string formatting - currently fails"""
-    user_input = os.environ.get('USER_DATA')
+    user_input = os.environ.get("USER_DATA")
     eval(f"print({user_input})")  # F-string
+
 
 def test_string_format_method():
     """Test 3: String format method - currently fails"""
-    user_input = os.environ.get('USER_DATA')
+    user_input = os.environ.get("USER_DATA")
     eval("print({})".format(user_input))  # Format method
+
 
 def test_string_concatenation():
     """Test 4: String concatenation - currently fails"""
-    user_input = os.environ.get('USER_DATA')
+    user_input = os.environ.get("USER_DATA")
     eval("print(" + user_input + ")")  # Concatenation
+
 
 def test_percent_formatting():
     """Test 5: Percent formatting - currently fails"""
-    user_input = os.environ.get('USER_DATA')
+    user_input = os.environ.get("USER_DATA")
     eval("print(%s)" % user_input)  # Percent formatting
+
 
 def test_multiple_variables():
     """Test 6: Multiple variables in one sink"""
-    user_input = os.environ.get('USER_DATA')
-    db_config = os.environ.get('DB_CONFIG')
+    user_input = os.environ.get("USER_DATA")
+    db_config = os.environ.get("DB_CONFIG")
     eval(user_input)  # Should work
-    eval(db_config)   # Should work
+    eval(db_config)  # Should work
+
 
 def test_nested_function_calls():
     """Test 7: Nested function calls"""
+
     def get_tainted_data():
-        return os.environ.get('USER_DATA')
-    
+        return os.environ.get("USER_DATA")
+
     user_input = get_tainted_data()
     eval(user_input)  # Should work
 
+
 def test_class_methods():
     """Test 8: Class methods"""
+
     class DataProvider:
         def get_data(self):
-            return os.environ.get('USER_DATA')
-    
+            return os.environ.get("USER_DATA")
+
     provider = DataProvider()
     user_input = provider.get_data()
     eval(user_input)  # Should work
 
+
 def test_different_sink_types():
     """Test 9: Different sink types"""
-    user_input = os.environ.get('USER_DATA')
-    
+    user_input = os.environ.get("USER_DATA")
+
     # Different sinks
-    eval(user_input)           # eval
-    exec(user_input)           # exec
-    os.system(user_input)      # os.system
+    eval(user_input)  # eval
+    exec(user_input)  # exec
+    os.system(user_input)  # os.system
     subprocess.call(user_input, shell=True)  # subprocess.call
+
 
 def test_command_line_args():
     """Test 10: Command line arguments"""
@@ -73,52 +85,60 @@ def test_command_line_args():
         user_input = sys.argv[1]
         eval(user_input)  # Should work
 
+
 def test_input_function():
     """Test 11: Input function"""
     # user_input = input("Enter data: ")  # Commented out to avoid blocking
     user_input = "test_input"  # Simulated input
     eval(user_input)  # Should work
 
+
 def test_safe_vs_unsafe():
     """Test 12: Safe vs unsafe patterns"""
     # Unsafe - should be detected
-    user_input = os.environ.get('USER_DATA')
+    user_input = os.environ.get("USER_DATA")
     eval(user_input)
-    
+
     # Safe - should NOT be detected
     safe_data = "print('hello')"
     eval(safe_data)
 
+
 def test_complex_expressions():
     """Test 13: Complex expressions"""
-    user_input = os.environ.get('USER_DATA')
-    
+    user_input = os.environ.get("USER_DATA")
+
     # Complex but direct usage
     result = eval(user_input + " + 1")  # Should work
-    result = eval(user_input.strip())   # Should work
-    
+    result = eval(user_input.strip())  # Should work
+
     # Complex with formatting
     result = eval(f"process({user_input})")  # Should fail
 
+
 def test_import_statements():
     """Test 14: Import statements"""
-    module_name = os.environ.get('MODULE_NAME')
+    module_name = os.environ.get("MODULE_NAME")
     __import__(module_name)  # Should work
+
 
 def test_file_operations():
     """Test 15: File operations"""
-    filename = os.environ.get('FILENAME')
-    with open(filename, 'r') as f:  # Should work
+    filename = os.environ.get("FILENAME")
+    with open(filename, "r") as f:  # Should work
         pass
+
 
 def test_sql_operations():
     """Test 16: SQL operations"""
     import sqlite3
-    user_input = os.environ.get('USER_DATA')
-    
-    conn = sqlite3.connect(':memory:')
+
+    user_input = os.environ.get("USER_DATA")
+
+    conn = sqlite3.connect(":memory:")
     cursor = conn.cursor()
     cursor.execute(f"SELECT * FROM users WHERE name = '{user_input}'")  # Should fail
+
 
 if __name__ == "__main__":
     # Run all tests
@@ -137,4 +157,4 @@ if __name__ == "__main__":
     test_complex_expressions()
     test_import_statements()
     test_file_operations()
-    test_sql_operations() 
+    test_sql_operations()

--- a/test_files/python/comprehensive_unified_test.py
+++ b/test_files/python/comprehensive_unified_test.py
@@ -18,252 +18,270 @@ app = Flask(__name__)
 # SEARCH MODE TESTS
 # ============================
 
+
 def test_all_weak_crypto_patterns():
     """Test all weak cryptography patterns that should be detected"""
-    
+
     # Hashlib weak algorithms
     md5_1 = hashlib.md5(b"test")
     md5_2 = hashlib.md5("test".encode())
     sha1_1 = hashlib.sha1(b"test")
     sha1_2 = hashlib.sha1("test".encode())
-    
+
     # Crypto library weak algorithms
     md5_crypto = MD5.new()
     sha1_crypto = SHA1.new()
-    
+
     # Weak ciphers
     des_cipher = DES.new(b"12345678", DES.MODE_ECB)
     arc4_cipher = ARC4.new(b"secret")
-    
+
     return "All weak crypto patterns tested"
+
 
 def test_sql_execution_patterns():
     """Test SQL execution patterns that should be detected"""
-    
-    conn = sqlite3.connect(':memory:')
+
+    conn = sqlite3.connect(":memory:")
     cursor = conn.cursor()
-    
+
     # Various execute patterns
     cursor.execute("SELECT 1")
     cursor.executemany("INSERT INTO test VALUES (?)", [(1,)])
     cursor.executescript("CREATE TABLE test (id INTEGER)")
-    
+
     # Connection execute
     conn.execute("SELECT 2")
     conn.executemany("INSERT INTO test VALUES (?)", [(2,)])
-    
+
     return "All SQL execution patterns tested"
+
 
 # ============================
 # TAINT ANALYSIS TESTS
 # ============================
 
+
 def test_all_source_patterns():
     """Test all taint source patterns"""
-    
+
     # Request sources
-    arg_data = request.args.get('data')
-    form_data = request.form.get('data')
-    json_data = request.json.get('data')
-    
+    arg_data = request.args.get("data")
+    form_data = request.form.get("data")
+    json_data = request.json.get("data")
+
     # Input source
     user_input = input("Enter data: ")
-    
+
     # Environment source
-    env_data = os.environ.get('DATA')
-    
+    env_data = os.environ.get("DATA")
+
     return [arg_data, form_data, json_data, user_input, env_data]
+
 
 def test_all_sink_patterns():
     """Test all taint sink patterns"""
     data = "test_data"
-    
+
     # Command execution sinks
     os.system(data)
     subprocess.call(data, shell=True)
     subprocess.run(data, shell=True)
-    
+
     # Code execution sinks
     eval(data)
     exec(data)
-    
+
     # File operation sinks
-    filepath = os.path.join('/tmp', data)
-    with open(filepath, 'w') as f:
+    filepath = os.path.join("/tmp", data)
+    with open(filepath, "w") as f:
         f.write("test")
-    
+
     return "All sink patterns tested"
+
 
 def test_complex_taint_flows():
     """Test complex taint propagation scenarios"""
-    
+
     # Multi-source flow
-    source1 = request.args.get('cmd1')
-    source2 = request.form.get('cmd2')
-    
+    source1 = request.args.get("cmd1")
+    source2 = request.form.get("cmd2")
+
     # Complex propagation
     combined = source1 + " && " + source2
     processed = combined.strip().upper()
     final_cmd = f"bash -c '{processed}'"
-    
+
     # Multiple sinks
     os.system(final_cmd)
     subprocess.run(final_cmd, shell=True)
-    
+
     return "Complex taint flows tested"
+
 
 def test_sanitization_scenarios():
     """Test various sanitization scenarios"""
-    
+
     # Sanitized flow 1
-    user_input1 = request.args.get('file')
+    user_input1 = request.args.get("file")
     safe_file = shlex.quote(user_input1)
     os.system(f"cat {safe_file}")
-    
+
     # Sanitized flow 2
-    user_input2 = request.args.get('data')
+    user_input2 = request.args.get("data")
     escaped_data = shlex.quote(user_input2)
     subprocess.call(f"echo {escaped_data}", shell=True)
-    
+
     return "Sanitization scenarios tested"
+
 
 # ============================
 # MIXED VULNERABILITY TESTS
 # ============================
 
+
 def test_crypto_plus_injection():
     """Test weak crypto combined with injection vulnerabilities"""
-    
+
     # Source: user password
-    password = request.args.get('password')
-    
+    password = request.args.get("password")
+
     # Weak crypto (search pattern)
     weak_hash = hashlib.md5(password.encode())
     hash_string = weak_hash.hexdigest()
-    
+
     # Injection (taint flow)
     os.system(f"echo 'Hash: {hash_string}'")
-    
+
     return "Crypto + injection tested"
+
 
 def test_sql_search_and_taint():
     """Test SQL vulnerabilities detected by both search and taint"""
-    
+
     # User input (taint source)
-    table_name = request.args.get('table')
-    user_id = request.args.get('id')
-    
+    table_name = request.args.get("table")
+    user_id = request.args.get("id")
+
     # Build query (taint propagation)
     query = f"SELECT * FROM {table_name} WHERE id = {user_id}"
-    
+
     # Execute query (both search pattern AND taint sink)
-    conn = sqlite3.connect(':memory:')
+    conn = sqlite3.connect(":memory:")
     cursor = conn.cursor()
     cursor.execute(query)  # Should trigger both search and taint detection
-    
+
     return "SQL search + taint tested"
+
 
 def test_nested_function_calls():
     """Test nested function calls with taint"""
-    
+
     def process_input(data):
         return data.upper().strip()
-    
+
     def execute_command(cmd):
         return os.system(cmd)
-    
+
     # Taint flow through nested calls
-    user_data = request.args.get('command')
+    user_data = request.args.get("command")
     processed = process_input(user_data)
     result = execute_command(processed)
-    
+
     return result
+
 
 def test_conditional_flows():
     """Test taint flows through conditional statements"""
-    
-    user_input = request.args.get('action')
-    
-    if user_input == 'system':
+
+    user_input = request.args.get("action")
+
+    if user_input == "system":
         os.system(user_input)
-    elif user_input == 'eval':
+    elif user_input == "eval":
         eval(user_input)
     else:
         subprocess.call(user_input, shell=True)
-    
+
     return "Conditional flows tested"
+
 
 def test_loop_propagation():
     """Test taint propagation through loops"""
-    
-    commands = request.args.getlist('commands')
-    
+
+    commands = request.args.getlist("commands")
+
     for cmd in commands:
         processed_cmd = cmd.strip()
         os.system(processed_cmd)
-    
+
     return "Loop propagation tested"
+
 
 # ============================
 # EDGE CASES
 # ============================
 
+
 def test_multiple_assignments():
     """Test multiple assignments in taint flow"""
-    
-    source = request.args.get('data')
+
+    source = request.args.get("data")
     var1 = source
     var2 = var1
     var3 = var2
     final = var3
-    
+
     os.system(final)
-    
+
     return "Multiple assignments tested"
+
 
 def test_string_operations():
     """Test taint through string operations"""
-    
-    base_cmd = request.args.get('base')
-    
+
+    base_cmd = request.args.get("base")
+
     # Various string operations
     upper_cmd = base_cmd.upper()
     lower_cmd = base_cmd.lower()
     stripped_cmd = base_cmd.strip()
-    replaced_cmd = base_cmd.replace(' ', '_')
+    replaced_cmd = base_cmd.replace(" ", "_")
     formatted_cmd = f"exec {base_cmd}"
-    
+
     # All should be tainted
     os.system(upper_cmd)
     os.system(lower_cmd)
     os.system(stripped_cmd)
     os.system(replaced_cmd)
     os.system(formatted_cmd)
-    
+
     return "String operations tested"
+
 
 def test_mixed_sources_single_sink():
     """Test multiple sources flowing to single sink"""
-    
-    arg_data = request.args.get('arg')
-    form_data = request.form.get('form')
-    env_data = os.environ.get('ENV_VAR')
-    
+
+    arg_data = request.args.get("arg")
+    form_data = request.form.get("form")
+    env_data = os.environ.get("ENV_VAR")
+
     # Combine multiple sources
     combined = f"{arg_data} {form_data} {env_data}"
-    
+
     # Single sink
     os.system(combined)
-    
+
     return "Mixed sources tested"
+
 
 if __name__ == "__main__":
     print("Comprehensive unified rules test file")
     print("Run with Flask to test web-based patterns")
-    
+
     # Test non-web patterns
     test_all_weak_crypto_patterns()
     test_sql_execution_patterns()
     test_all_sink_patterns()
-    
-    print("Non-web patterns tested successfully") 
+
+    print("Non-web patterns tested successfully")

--- a/test_files/python/debug_string_test.py
+++ b/test_files/python/debug_string_test.py
@@ -6,11 +6,11 @@ Debug string matching test
 import os
 
 # Test 1: Simple eval
-user_input = os.environ.get('USER_DATA')
+user_input = os.environ.get("USER_DATA")
 eval(user_input)
 
 # Test 2: Simple exec
 exec(user_input)
 
 # Test 3: Simple os.system
-os.system(user_input) 
+os.system(user_input)

--- a/test_files/python/debug_taint.py
+++ b/test_files/python/debug_taint.py
@@ -6,20 +6,23 @@ Debug test file for taint analysis pattern matching
 import os
 import sys
 
+
 def test_simple_taint():
     # Simple taint source
-    user_input = os.environ.get('USER_DATA')
-    
+    user_input = os.environ.get("USER_DATA")
+
     # Simple taint sink
     eval(user_input)
 
+
 def test_complex_taint():
     # Complex taint source
-    db_config = os.environ.get('DATABASE_CONFIG', '')
-    
+    db_config = os.environ.get("DATABASE_CONFIG", "")
+
     # Complex taint sink
     os.system(f"echo {db_config}")
 
+
 if __name__ == "__main__":
     test_simple_taint()
-    test_complex_taint() 
+    test_complex_taint()

--- a/test_files/python/django/django_views.py
+++ b/test_files/python/django/django_views.py
@@ -2,29 +2,35 @@ from django.http import HttpResponse
 from django.shortcuts import render
 import pickle
 
+
 # XSS vulnerability - should be detected by xss_prevention.ron
 def unsafe_response(request):
-    user_input = request.GET.get('data', '')
+    user_input = request.GET.get("data", "")
     return HttpResponse(user_input)  # Direct user input to response - XSS risk
 
-# SQL injection vulnerability - should be detected by sql_injection.ron  
+
+# SQL injection vulnerability - should be detected by sql_injection.ron
 def unsafe_query(request):
     from django.db import connection
-    user_id = request.GET.get('id', '')
+
+    user_id = request.GET.get("id", "")
     cursor = connection.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # String formatting - SQL injection risk
     cursor.execute(query)
     return cursor.fetchall()
 
+
 # Unsafe deserialization - should be detected by deserialization.ron
 def unsafe_unpickle(request):
-    data = request.POST.get('data', '')
+    data = request.POST.get("data", "")
     return pickle.loads(data)  # Pickle with user input - deserialization attack
+
 
 # Code injection - should be detected by test rule
 def unsafe_eval(request):
-    user_code = request.POST.get('code', '')
+    user_code = request.POST.get("code", "")
     return eval(user_code)  # Code injection via eval
 
+
 # Hardcoded secret - should be detected by security_settings.ron
-SECRET_KEY = 'django-insecure-hardcoded-secret-key-123456789'  # Hardcoded secret 
+SECRET_KEY = "django-insecure-hardcoded-secret-key-123456789"  # Hardcoded secret

--- a/test_files/python/django_views.py
+++ b/test_files/python/django_views.py
@@ -2,29 +2,35 @@ from django.http import HttpResponse
 from django.shortcuts import render
 import pickle
 
+
 # XSS vulnerability - should be detected by xss_prevention.ron
 def unsafe_response(request):
-    user_input = request.GET.get('data', '')
+    user_input = request.GET.get("data", "")
     return HttpResponse(user_input)  # Direct user input to response - XSS risk
 
-# SQL injection vulnerability - should be detected by sql_injection.ron  
+
+# SQL injection vulnerability - should be detected by sql_injection.ron
 def unsafe_query(request):
     from django.db import connection
-    user_id = request.GET.get('id', '')
+
+    user_id = request.GET.get("id", "")
     cursor = connection.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # String formatting - SQL injection risk
     cursor.execute(query)
     return cursor.fetchall()
 
+
 # Unsafe deserialization - should be detected by deserialization.ron
 def unsafe_unpickle(request):
-    data = request.POST.get('data', '')
+    data = request.POST.get("data", "")
     return pickle.loads(data)  # Pickle with user input - deserialization attack
+
 
 # Code injection - should be detected by test rule
 def unsafe_eval(request):
-    user_code = request.POST.get('code', '')
+    user_code = request.POST.get("code", "")
     return eval(user_code)  # Code injection via eval
 
+
 # Hardcoded secret - should be detected by security_settings.ron
-SECRET_KEY = 'django-insecure-hardcoded-secret-key-123456789'  # Hardcoded secret 
+SECRET_KEY = "django-insecure-hardcoded-secret-key-123456789"  # Hardcoded secret

--- a/test_files/python/general/another_test.py
+++ b/test_files/python/general/another_test.py
@@ -1,17 +1,20 @@
 import subprocess
 import os
 
+
 def execute_user_command(cmd):
     # Command injection vulnerability
     result = os.system(f"bash -c '{cmd}'")
     return result
 
+
 def unsafe_eval(user_input):
-    # Code injection vulnerability  
+    # Code injection vulnerability
     return eval(user_input)
+
 
 def process_file(filename):
     # Path traversal vulnerability
     path = f"../data/{filename}"
     with open(path) as f:
-        return f.read() 
+        return f.read()

--- a/test_files/python/general/migration_example.py
+++ b/test_files/python/general/migration_example.py
@@ -1,17 +1,21 @@
 from django.db import migrations, models
 import alembic
 
+
 class Migration(migrations.Migration):
     dependencies = [
-        ('myapp', '0001_initial'),
+        ("myapp", "0001_initial"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='User',
+            name="User",
             fields=[
-                ('id', models.AutoField(primary_key=True)),
-                ('password', models.CharField(max_length=128, default="admin123")),  # This has a vulnerability but should be filtered out
+                ("id", models.AutoField(primary_key=True)),
+                (
+                    "password",
+                    models.CharField(max_length=128, default="admin123"),
+                ),  # This has a vulnerability but should be filtered out
             ],
         ),
-    ] 
+    ]

--- a/test_files/python/general/simple_eval.py
+++ b/test_files/python/general/simple_eval.py
@@ -1,2 +1,2 @@
 # Simple eval test
-x = eval("1+1") 
+x = eval("1+1")

--- a/test_files/python/general/test_1.py
+++ b/test_files/python/general/test_1.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python/general/test_10.py
+++ b/test_files/python/general/test_10.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python/general/test_20.py
+++ b/test_files/python/general/test_20.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python/general/test_filtering.py
+++ b/test_files/python/general/test_filtering.py
@@ -2,10 +2,11 @@ import unittest
 import pytest
 from django.test import TestCase
 
+
 class MyTestCase(unittest.TestCase):
     def test_something(self):
         # This should be filtered out in general scanning
         # but included in malicious scanning
         user_input = "malicious'; DROP TABLE users; --"
         query = f"SELECT * FROM users WHERE name = '{user_input}'"
-        self.assertEqual(query, "test") 
+        self.assertEqual(query, "test")

--- a/test_files/python/general/vulnerable_test.py
+++ b/test_files/python/general/vulnerable_test.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python/malicious/test_multiple_patterns.py
+++ b/test_files/python/malicious/test_multiple_patterns.py
@@ -11,19 +11,22 @@ import tkinter as tk
 from tkinter import clipboard
 import win32clipboard
 
+
 def test_pyperclip():
     # Should be detected by patterns: ["pyperclip.paste", "pyperclip.copy"]
     data = pyperclip.paste()
     pyperclip.copy("some data")
     return data
 
+
 def test_pandas_clipboard():
     # Should be detected by pattern: "pandas.read_clipboard"
     df = pd.read_clipboard()
-    
+
     # Should be detected by pattern: "*.to_clipboard"
     df.to_clipboard()
     return df
+
 
 def test_tkinter_clipboard():
     # Should be detected by pattern: "tkinter.clipboard"
@@ -31,32 +34,40 @@ def test_tkinter_clipboard():
     clipboard.get()
     clipboard.append("data")
 
+
 def test_win32_clipboard():
     # Should be detected by pattern: "win32clipboard"
     win32clipboard.OpenClipboard()
     data = win32clipboard.GetClipboardData()
     win32clipboard.CloseClipboard()
 
+
 def test_keyboard_hooks():
     # These should be detected by the keyboard patterns
     import keyboard
+
     keyboard.hook(lambda x: print(x))
     keyboard.on_press(lambda x: print(x))
+
 
 def test_suspicious_domains():
     # These should be detected by suspicious domain patterns
     import requests
+
     requests.get("http://malicious.tk/payload")
     requests.get("http://phishing.ml/steal")
     requests.get("http://spam.ga/bot")
     requests.get("http://fake.cf/virus")
 
+
 def test_url_shorteners():
     # These should be detected by URL shortener patterns
     import urllib.request
+
     urllib.request.urlopen("http://bit.ly/malicious")
     urllib.request.urlopen("http://t.co/phishing")
     urllib.request.urlopen("http://tinyurl.com/spam")
+
 
 if __name__ == "__main__":
     test_pyperclip()
@@ -65,4 +76,4 @@ if __name__ == "__main__":
     test_win32_clipboard()
     test_keyboard_hooks()
     test_suspicious_domains()
-    test_url_shorteners() 
+    test_url_shorteners()

--- a/test_files/python/malicious/test_multiple_patterns_alt.py
+++ b/test_files/python/malicious/test_multiple_patterns_alt.py
@@ -11,19 +11,22 @@ import tkinter as tk
 from tkinter import clipboard
 import win32clipboard
 
+
 def test_pyperclip():
     # Should be detected by patterns: ["pyperclip.paste", "pyperclip.copy"]
     data = pyperclip.paste()
     pyperclip.copy("some data")
     return data
 
+
 def test_pandas_clipboard():
     # Should be detected by pattern: "pandas.read_clipboard"
     df = pd.read_clipboard()
-    
+
     # Should be detected by pattern: "*.to_clipboard"
     df.to_clipboard()
     return df
+
 
 def test_tkinter_clipboard():
     # Should be detected by pattern: "tkinter.clipboard"
@@ -31,32 +34,40 @@ def test_tkinter_clipboard():
     clipboard.get()
     clipboard.append("data")
 
+
 def test_win32_clipboard():
     # Should be detected by pattern: "win32clipboard"
     win32clipboard.OpenClipboard()
     data = win32clipboard.GetClipboardData()
     win32clipboard.CloseClipboard()
 
+
 def test_keyboard_hooks():
     # These should be detected by the keyboard patterns
     import keyboard
+
     keyboard.hook(lambda x: print(x))
     keyboard.on_press(lambda x: print(x))
+
 
 def test_suspicious_domains():
     # These should be detected by suspicious domain patterns
     import requests
+
     requests.get("http://malicious.tk/payload")
     requests.get("http://phishing.ml/steal")
     requests.get("http://spam.ga/bot")
     requests.get("http://fake.cf/virus")
 
+
 def test_url_shorteners():
     # These should be detected by URL shortener patterns
     import urllib.request
+
     urllib.request.urlopen("http://bit.ly/malicious")
     urllib.request.urlopen("http://t.co/phishing")
     urllib.request.urlopen("http://tinyurl.com/spam")
+
 
 if __name__ == "__main__":
     test_pyperclip()
@@ -65,4 +76,4 @@ if __name__ == "__main__":
     test_win32_clipboard()
     test_keyboard_hooks()
     test_suspicious_domains()
-    test_url_shorteners() 
+    test_url_shorteners()

--- a/test_files/python/migration_example.py
+++ b/test_files/python/migration_example.py
@@ -1,17 +1,21 @@
 from django.db import migrations, models
 import alembic
 
+
 class Migration(migrations.Migration):
     dependencies = [
-        ('myapp', '0001_initial'),
+        ("myapp", "0001_initial"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='User',
+            name="User",
             fields=[
-                ('id', models.AutoField(primary_key=True)),
-                ('password', models.CharField(max_length=128, default="admin123")),  # This has a vulnerability but should be filtered out
+                ("id", models.AutoField(primary_key=True)),
+                (
+                    "password",
+                    models.CharField(max_length=128, default="admin123"),
+                ),  # This has a vulnerability but should be filtered out
             ],
         ),
-    ] 
+    ]

--- a/test_files/python/minimal_sql_test.py
+++ b/test_files/python/minimal_sql_test.py
@@ -1,3 +1,4 @@
 import sqlite3
+
 cursor = sqlite3.connect("test.db").cursor()
-cursor.execute("SELECT * FROM users WHERE username = '%s'" % "test") 
+cursor.execute("SELECT * FROM users WHERE username = '%s'" % "test")

--- a/test_files/python/mixed_vulnerabilities.py
+++ b/test_files/python/mixed_vulnerabilities.py
@@ -13,117 +13,125 @@ from Crypto.Cipher import DES
 
 app = Flask(__name__)
 
-@app.route('/vulnerable_endpoint')
+
+@app.route("/vulnerable_endpoint")
 def vulnerable_endpoint():
     """Endpoint with multiple vulnerability types"""
-    
+
     # TAINT FLOW: User input to command execution
-    user_command = request.args.get('cmd')
+    user_command = request.args.get("cmd")
     os.system(user_command)  # Should be detected by taint analysis
-    
+
     # SEARCH PATTERN: Weak cryptography
     weak_hash = hashlib.md5(b"sensitive data")  # Should be detected by search
-    
+
     # TAINT FLOW: SQL injection via taint
-    user_id = request.args.get('id')
+    user_id = request.args.get("id")
     query = f"SELECT * FROM users WHERE id = {user_id}"
-    
+
     # SEARCH PATTERN: SQL execution
-    conn = sqlite3.connect('app.db')
+    conn = sqlite3.connect("app.db")
     cursor = conn.cursor()
     cursor.execute(query)  # Should be detected by both search AND taint
-    
+
     return "Endpoint processed"
+
 
 def crypto_weakness_examples():
     """Examples of weak cryptography (search patterns)"""
-    
+
     # Weak hashing algorithms
     md5_hash = hashlib.md5(b"password")
     sha1_hash = hashlib.sha1(b"secret")
-    
+
     # Weak encryption
     crypto_md5 = MD5.new()
     weak_cipher = DES.new(b"12345678", DES.MODE_ECB)
-    
+
     return "Crypto examples done"
+
 
 def command_injection_variations():
     """Various command injection patterns (taint flows)"""
-    
+
     # Direct user input to system
-    cmd1 = request.args.get('command1')
+    cmd1 = request.args.get("command1")
     os.system(cmd1)
-    
+
     # Through subprocess
-    cmd2 = request.form.get('command2')
+    cmd2 = request.form.get("command2")
     subprocess.call(cmd2, shell=True)
     subprocess.run(cmd2, shell=True)
-    
+
     # Through eval/exec
-    code = request.args.get('code')
+    code = request.args.get("code")
     eval(code)
     exec(code)
-    
+
     return "Command injection examples done"
+
 
 def path_operations():
     """File path operations (taint flows)"""
-    
+
     # Path traversal
-    filename = request.args.get('filename')
-    full_path = os.path.join('/uploads', filename)
-    
+    filename = request.args.get("filename")
+    full_path = os.path.join("/uploads", filename)
+
     # File operations
-    with open(full_path, 'r') as f:
+    with open(full_path, "r") as f:
         content = f.read()
-    
+
     return content
+
 
 def database_operations():
     """Database operations (both search and taint)"""
-    
+
     # Raw SQL with user input (taint flow)
-    table_name = request.args.get('table')
-    user_filter = request.args.get('filter')
-    
-    conn = sqlite3.connect('database.db')
+    table_name = request.args.get("table")
+    user_filter = request.args.get("filter")
+
+    conn = sqlite3.connect("database.db")
     cursor = conn.cursor()
-    
+
     # These should trigger search patterns
     cursor.execute(f"SELECT * FROM {table_name} WHERE {user_filter}")
     cursor.executemany("INSERT INTO logs VALUES (?, ?)", [(1, "test")])
-    
+
     # Direct connection execute (search pattern)
     conn.execute("DELETE FROM temp_table")
-    
+
     return "Database operations done"
+
 
 def environment_based_attacks():
     """Environment variable based attacks"""
-    
+
     # Environment variable as source (taint flow)
-    malicious_cmd = os.environ.get('MALICIOUS_COMMAND')
+    malicious_cmd = os.environ.get("MALICIOUS_COMMAND")
     if malicious_cmd:
         os.system(malicious_cmd)
         subprocess.call(malicious_cmd, shell=True)
-    
+
     return "Environment attacks done"
+
 
 def mixed_crypto_and_injection():
     """Mix of crypto weaknesses and injection"""
-    
+
     # Weak crypto (search pattern)
-    user_password = request.args.get('password')
+    user_password = request.args.get("password")
     weak_hash = hashlib.sha1(user_password.encode())  # Weak + taint
-    
+
     # Use weak hash in command (double vulnerability)
     hash_str = weak_hash.hexdigest()
     os.system(f"echo {hash_str}")  # Command injection via taint
-    
+
     return "Mixed vulnerabilities done"
+
 
 if __name__ == "__main__":
     print("Mixed vulnerability test file")
     crypto_weakness_examples()
-    print("Run with Flask to test web-based vulnerabilities") 
+    print("Run with Flask to test web-based vulnerabilities")

--- a/test_files/python/multi_file_test/enhanced_sink_file.py
+++ b/test_files/python/multi_file_test/enhanced_sink_file.py
@@ -6,46 +6,56 @@ Enhanced sink file that uses tainted data from enhanced_source_file.py with rule
 import os
 import subprocess
 from enhanced_source_file import (
-    get_user_input, 
-    get_environment_config, 
-    get_file_content, 
+    get_user_input,
+    get_environment_config,
+    get_file_content,
     get_network_data,
     get_request_parameter,
     process_user_data,
-    format_config
+    format_config,
 )
+
 
 def vulnerable_eval_cross_file():
     """CROSS-FILE TAINT FLOW: Uses tainted data from another file in eval() - SHOULD BE DETECTED"""
-    config = get_environment_config()  # Tainted data from enhanced_source_file.py (os.environ)
+    config = (
+        get_environment_config()
+    )  # Tainted data from enhanced_source_file.py (os.environ)
     eval(config)  # Vulnerable sink - matches rule pattern eval()
+
 
 def vulnerable_exec_cross_file():
     """CROSS-FILE TAINT FLOW: Uses tainted data from another file in exec() - SHOULD BE DETECTED"""
     user_data = get_user_input()  # Tainted data from enhanced_source_file.py (sys.argv)
     exec(user_data)  # Vulnerable sink - matches rule pattern exec()
 
+
 def vulnerable_system_cross_file():
     """CROSS-FILE TAINT FLOW: Uses tainted data in os.system() - SHOULD BE DETECTED"""
-    network_data = get_network_data()  # Tainted data from enhanced_source_file.py (os.getenv)
+    network_data = (
+        get_network_data()
+    )  # Tainted data from enhanced_source_file.py (os.getenv)
     os.system(network_data)  # Vulnerable sink - matches rule pattern os.system()
+
 
 def complex_cross_file_flow():
     """COMPLEX CROSS-FILE TAINT FLOW: Multiple steps with taint propagation"""
     # Step 1: Get tainted data from another file
     raw_data = get_user_input()  # Tainted source from enhanced_source_file.py
-    
+
     # Step 2: Process data (still tainted)
     processed = process_user_data(raw_data)  # Taint propagates through processing
-    
+
     # Step 3: Use in vulnerable sink
     eval(processed)  # Vulnerable sink - should detect the flow
+
 
 # Local vulnerable functions for comparison
 def local_vulnerable_function():
     """LOCAL TAINT FLOW: For comparison with cross-file flows"""
-    local_input = os.environ.get('LOCAL_VAR', '')  # Local tainted source
+    local_input = os.environ.get("LOCAL_VAR", "")  # Local tainted source
     eval(local_input)  # Local vulnerable sink
 
+
 if __name__ == "__main__":
-    print("This file contains cross-file taint vulnerabilities for testing") 
+    print("This file contains cross-file taint vulnerabilities for testing")

--- a/test_files/python/multi_file_test/enhanced_source_file.py
+++ b/test_files/python/multi_file_test/enhanced_source_file.py
@@ -6,36 +6,42 @@ Enhanced source file with multiple taint sources matching rule patterns
 import os
 import sys
 
+
 def get_user_input():
     """Source: user input via command line args - TAINTED"""
     if len(sys.argv) > 1:
         return sys.argv[1]  # Tainted source: sys.argv
     return "default"
 
+
 def get_environment_config():
     """Source: environment variables - TAINTED"""
-    config = os.environ.get('DATABASE_URL', 'default')  # Tainted source: os.environ
+    config = os.environ.get("DATABASE_URL", "default")  # Tainted source: os.environ
     return config
+
 
 def get_file_content():
     """Source: file input - TAINTED"""
     try:
-        with open('user_input.txt', 'r') as f:
+        with open("user_input.txt", "r") as f:
             return f.read()  # Tainted source: file input
     except FileNotFoundError:
         return "no file found"
 
+
 def get_network_data():
     """Source: simulated network input - TAINTED"""
     # This simulates user-controlled data from network
-    user_data = os.getenv('NETWORK_DATA', 'default')  # Tainted source: os.getenv
+    user_data = os.getenv("NETWORK_DATA", "default")  # Tainted source: os.getenv
     return user_data
+
 
 def get_request_parameter():
     """Source: simulated HTTP request parameter - TAINTED"""
     # Simulates request.args.get() or similar
-    param = os.environ.get('REQUEST_PARAM', '')  # Tainted source: os.environ.get
+    param = os.environ.get("REQUEST_PARAM", "")  # Tainted source: os.environ.get
     return param
+
 
 # Additional helper functions that propagate taint
 def process_user_data(data):
@@ -43,17 +49,19 @@ def process_user_data(data):
     processed = f"processed_{data}"
     return processed
 
+
 def format_config(config):
     """Propagates tainted config data"""
     return f"config:{config}"
 
+
 # Export all functions for import by other files
 __all__ = [
-    'get_user_input', 
-    'get_environment_config', 
-    'get_file_content', 
-    'get_network_data', 
-    'get_request_parameter',
-    'process_user_data',
-    'format_config'
-] 
+    "get_user_input",
+    "get_environment_config",
+    "get_file_content",
+    "get_network_data",
+    "get_request_parameter",
+    "process_user_data",
+    "format_config",
+]

--- a/test_files/python/multi_file_test/sink_file.py
+++ b/test_files/python/multi_file_test/sink_file.py
@@ -7,15 +7,18 @@ import os
 import subprocess
 from source_file import get_user_input, get_config, UserInputProvider
 
+
 def vulnerable_command():
     """Uses tainted data from another file in a vulnerable way"""
     user_input = get_user_input()  # Tainted data from source_file.py
     os.system(user_input)  # Vulnerable sink
 
+
 def vulnerable_config():
     """Uses tainted config from another file"""
     config = get_config()  # Tainted data from source_file.py
     eval(config)  # Vulnerable sink
+
 
 def vulnerable_class_usage():
     """Uses tainted data from a class in another file"""
@@ -23,9 +26,10 @@ def vulnerable_class_usage():
     data = provider.get_data()  # Tainted data
     subprocess.call(data, shell=True)  # Vulnerable sink
 
+
 def complex_flow():
     """Complex flow through multiple variables"""
     raw_input = get_user_input()  # Tainted source from other file
     processed_input = raw_input.upper()  # Local propagation
     command = f"echo {processed_input}"  # String formatting
-    os.system(command)  # Vulnerable sink 
+    os.system(command)  # Vulnerable sink

--- a/test_files/python/multi_file_test/source_file.py
+++ b/test_files/python/multi_file_test/source_file.py
@@ -5,20 +5,24 @@ Source file that provides tainted data to other files
 
 from flask import request
 
+
 def get_user_input():
     """Function that returns tainted user input"""
-    user_data = request.args.get('input', '')
+    user_data = request.args.get("input", "")
     return user_data
+
 
 def get_config():
     """Function that returns tainted config data"""
     import os
-    config = os.environ.get('CONFIG', '')
+
+    config = os.environ.get("CONFIG", "")
     return config
+
 
 class UserInputProvider:
     def __init__(self):
-        self.data = request.form.get('data', '')
-    
+        self.data = request.form.get("data", "")
+
     def get_data(self):
-        return self.data 
+        return self.data

--- a/test_files/python/pattern_test.py
+++ b/test_files/python/pattern_test.py
@@ -6,14 +6,14 @@ Test file to debug pattern matching
 import os
 
 # Test 1: Direct eval with tainted variable
-user_input = os.environ.get('USER_DATA')
+user_input = os.environ.get("USER_DATA")
 eval(user_input)
 
 # Test 2: Direct eval with literal
 eval("print('hello')")
 
-# Test 3: Direct exec with tainted variable  
+# Test 3: Direct exec with tainted variable
 exec(user_input)
 
 # Test 4: Direct exec with literal
-exec("print('hello')") 
+exec("print('hello')")

--- a/test_files/python/python_test.py
+++ b/test_files/python/python_test.py
@@ -2,4 +2,4 @@ import os
 
 # This should trigger a vulnerability
 user_input = input("Enter command: ")
-os.system(user_input) 
+os.system(user_input)

--- a/test_files/python/simple_direct_test.py
+++ b/test_files/python/simple_direct_test.py
@@ -6,7 +6,7 @@ Minimal test for direct variable taint analysis
 import os
 
 # Simple taint source
-user_input = os.environ.get('USER_DATA')
+user_input = os.environ.get("USER_DATA")
 
 # Simple taint sink - direct usage
-eval(user_input) 
+eval(user_input)

--- a/test_files/python/simple_eval.py
+++ b/test_files/python/simple_eval.py
@@ -1,2 +1,2 @@
 # Simple eval test
-x = eval("1+1") 
+x = eval("1+1")

--- a/test_files/python/simple_test.py
+++ b/test_files/python/simple_test.py
@@ -1,8 +1,9 @@
 import os
 
+
 def vulnerable_function(user_input):
     # This should trigger command injection
     os.system(user_input)
-    
+
     # This should trigger code injection
-    eval(user_input) 
+    eval(user_input)

--- a/test_files/python/sql_injection_test.py
+++ b/test_files/python/sql_injection_test.py
@@ -6,22 +6,26 @@ import requests
 from lxml import etree
 
 # Example hardcoded AWS credentials (sensitive data leakage)
-aws_access_key_id = 'AKIA2JAPX77RGLB664VE'
-aws_secret = 'v5xpjkWYoy45fGKFSMajSn+sqs22WI2niacX9yO5'
+aws_access_key_id = "AKIA2JAPX77RGLB664VE"
+aws_secret = "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"
 
 app = Flask(__name__)
 
-@app.route('/', methods=['GET', 'POST'])
+
+@app.route("/", methods=["GET", "POST"])
 def index():
-    output = ''
+    output = ""
     # 1 - SQL Injection
     db = sqlite3.connect("tutorial.db")
     cursor = db.cursor()
-    username = ''
-    password = ''
+    username = ""
+    password = ""
     try:
-        cursor.execute("SELECT * FROM users WHERE username = '%s' AND password = '%s'" % (username, password))
+        cursor.execute(
+            "SELECT * FROM users WHERE username = '%s' AND password = '%s'"
+            % (username, password)
+        )
     except:
         pass
 
-    return "test" 
+    return "test"

--- a/test_files/python/taint_test.py
+++ b/test_files/python/taint_test.py
@@ -8,43 +8,47 @@ import subprocess
 import sqlite3
 from flask import request
 
+
 def vulnerable_function():
     # Taint source: user input
-    user_input = request.args.get('input')
-    
-    # Taint sink: SQL injection 
-    cursor = sqlite3.connect(':memory:').cursor()
+    user_input = request.args.get("input")
+
+    # Taint sink: SQL injection
+    cursor = sqlite3.connect(":memory:").cursor()
     query = f"SELECT * FROM users WHERE name = '{user_input}'"
     cursor.execute(query)
-    
+
     # Taint sink: command injection
     os.system(f"echo {user_input}")
-    
+
     return "Done"
+
 
 def another_vulnerable_function():
     # Taint source: environment variable
-    env_var = os.environ.get('USER_DATA')
-    
+    env_var = os.environ.get("USER_DATA")
+
     # Taint sink: code injection
     eval(env_var)
-    
+
     # Taint propagator: string formatting
     formatted = env_var.format("test")
-    
+
     # Taint sink: command execution
     subprocess.run(formatted, shell=True)
+
 
 def safe_function():
     # This should not trigger taint analysis
     static_query = "SELECT * FROM users WHERE id = 1"
-    cursor = sqlite3.connect(':memory:').cursor()
+    cursor = sqlite3.connect(":memory:").cursor()
     cursor.execute(static_query)
-    
+
     # Safe command execution
     subprocess.run(["echo", "hello world"])
+
 
 if __name__ == "__main__":
     vulnerable_function()
     another_vulnerable_function()
-    safe_function() 
+    safe_function()

--- a/test_files/python/test_1.py
+++ b/test_files/python/test_1.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python/test_10.py
+++ b/test_files/python/test_10.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python/test_20.py
+++ b/test_files/python/test_20.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python/test_filtering.py
+++ b/test_files/python/test_filtering.py
@@ -2,10 +2,11 @@ import unittest
 import pytest
 from django.test import TestCase
 
+
 class MyTestCase(unittest.TestCase):
     def test_something(self):
         # This should be filtered out in general scanning
         # but included in malicious scanning
         user_input = "malicious'; DROP TABLE users; --"
         query = f"SELECT * FROM users WHERE name = '{user_input}'"
-        self.assertEqual(query, "test") 
+        self.assertEqual(query, "test")

--- a/test_files/python/test_multiple_patterns.py
+++ b/test_files/python/test_multiple_patterns.py
@@ -11,19 +11,22 @@ import tkinter as tk
 from tkinter import clipboard
 import win32clipboard
 
+
 def test_pyperclip():
     # Should be detected by patterns: ["pyperclip.paste", "pyperclip.copy"]
     data = pyperclip.paste()
     pyperclip.copy("some data")
     return data
 
+
 def test_pandas_clipboard():
     # Should be detected by pattern: "pandas.read_clipboard"
     df = pd.read_clipboard()
-    
+
     # Should be detected by pattern: "*.to_clipboard"
     df.to_clipboard()
     return df
+
 
 def test_tkinter_clipboard():
     # Should be detected by pattern: "tkinter.clipboard"
@@ -31,32 +34,40 @@ def test_tkinter_clipboard():
     clipboard.get()
     clipboard.append("data")
 
+
 def test_win32_clipboard():
     # Should be detected by pattern: "win32clipboard"
     win32clipboard.OpenClipboard()
     data = win32clipboard.GetClipboardData()
     win32clipboard.CloseClipboard()
 
+
 def test_keyboard_hooks():
     # These should be detected by the keyboard patterns
     import keyboard
+
     keyboard.hook(lambda x: print(x))
     keyboard.on_press(lambda x: print(x))
+
 
 def test_suspicious_domains():
     # These should be detected by suspicious domain patterns
     import requests
+
     requests.get("http://malicious.tk/payload")
     requests.get("http://phishing.ml/steal")
     requests.get("http://spam.ga/bot")
     requests.get("http://fake.cf/virus")
 
+
 def test_url_shorteners():
     # These should be detected by URL shortener patterns
     import urllib.request
+
     urllib.request.urlopen("http://bit.ly/malicious")
     urllib.request.urlopen("http://t.co/phishing")
     urllib.request.urlopen("http://tinyurl.com/spam")
+
 
 if __name__ == "__main__":
     test_pyperclip()
@@ -65,4 +76,4 @@ if __name__ == "__main__":
     test_win32_clipboard()
     test_keyboard_hooks()
     test_suspicious_domains()
-    test_url_shorteners() 
+    test_url_shorteners()

--- a/test_files/python/test_multiple_patterns_alt.py
+++ b/test_files/python/test_multiple_patterns_alt.py
@@ -11,19 +11,22 @@ import tkinter as tk
 from tkinter import clipboard
 import win32clipboard
 
+
 def test_pyperclip():
     # Should be detected by patterns: ["pyperclip.paste", "pyperclip.copy"]
     data = pyperclip.paste()
     pyperclip.copy("some data")
     return data
 
+
 def test_pandas_clipboard():
     # Should be detected by pattern: "pandas.read_clipboard"
     df = pd.read_clipboard()
-    
+
     # Should be detected by pattern: "*.to_clipboard"
     df.to_clipboard()
     return df
+
 
 def test_tkinter_clipboard():
     # Should be detected by pattern: "tkinter.clipboard"
@@ -31,32 +34,40 @@ def test_tkinter_clipboard():
     clipboard.get()
     clipboard.append("data")
 
+
 def test_win32_clipboard():
     # Should be detected by pattern: "win32clipboard"
     win32clipboard.OpenClipboard()
     data = win32clipboard.GetClipboardData()
     win32clipboard.CloseClipboard()
 
+
 def test_keyboard_hooks():
     # These should be detected by the keyboard patterns
     import keyboard
+
     keyboard.hook(lambda x: print(x))
     keyboard.on_press(lambda x: print(x))
+
 
 def test_suspicious_domains():
     # These should be detected by suspicious domain patterns
     import requests
+
     requests.get("http://malicious.tk/payload")
     requests.get("http://phishing.ml/steal")
     requests.get("http://spam.ga/bot")
     requests.get("http://fake.cf/virus")
 
+
 def test_url_shorteners():
     # These should be detected by URL shortener patterns
     import urllib.request
+
     urllib.request.urlopen("http://bit.ly/malicious")
     urllib.request.urlopen("http://t.co/phishing")
     urllib.request.urlopen("http://tinyurl.com/spam")
+
 
 if __name__ == "__main__":
     test_pyperclip()
@@ -65,4 +76,4 @@ if __name__ == "__main__":
     test_win32_clipboard()
     test_keyboard_hooks()
     test_suspicious_domains()
-    test_url_shorteners() 
+    test_url_shorteners()

--- a/test_files/python/unified_test_search.py
+++ b/test_files/python/unified_test_search.py
@@ -8,53 +8,56 @@ import hashlib
 from Crypto.Hash import MD5, SHA1
 from Crypto.Cipher import DES, ARC4
 
+
 def sql_injection_tests():
     """Test SQL injection patterns"""
-    conn = sqlite3.connect('test.db')
+    conn = sqlite3.connect("test.db")
     cursor = conn.cursor()
-    
+
     # These should match the "execute" pattern
     cursor.execute("SELECT * FROM users WHERE id = 1")
-    cursor.executemany("INSERT INTO users VALUES (?, ?)", [(1, 'test')])
-    
+    cursor.executemany("INSERT INTO users VALUES (?, ?)", [(1, "test")])
+
     # Direct connection execute
     conn.execute("DELETE FROM users WHERE id = 1")
-    
+
     return "SQL tests done"
+
 
 def weak_crypto_tests():
     """Test weak cryptography patterns"""
-    
+
     # These should match weak hash patterns
     md5_hash = hashlib.md5(b"test data")
     sha1_hash = hashlib.sha1(b"test data")
-    
+
     # Crypto library weak hashes
     md5_crypto = MD5.new()
     sha1_crypto = SHA1.new()
-    
+
     # Weak ciphers
     des_cipher = DES.new(b"12345678", DES.MODE_ECB)
     arc4_cipher = ARC4.new(b"secret_key")
-    
+
     return "Crypto tests done"
+
 
 def complex_sql_injection():
     """More complex SQL injection scenarios"""
-    database = sqlite3.connect(':memory:')
+    database = sqlite3.connect(":memory:")
     db_cursor = database.cursor()
-    
+
     # Should match cursor.execute pattern
     db_cursor.execute("CREATE TABLE test (id INTEGER, name TEXT)")
-    
+
     # Should match executemany
-    db_cursor.executemany("INSERT INTO test VALUES (?, ?)", 
-                         [(1, "Alice"), (2, "Bob")])
-    
+    db_cursor.executemany("INSERT INTO test VALUES (?, ?)", [(1, "Alice"), (2, "Bob")])
+
     return "Complex SQL done"
+
 
 if __name__ == "__main__":
     sql_injection_tests()
     weak_crypto_tests()
     complex_sql_injection()
-    print("All search pattern tests completed") 
+    print("All search pattern tests completed")

--- a/test_files/python/unified_test_taint.py
+++ b/test_files/python/unified_test_taint.py
@@ -10,112 +10,121 @@ from flask import Flask, request
 
 app = Flask(__name__)
 
+
 def command_injection_flow():
     """Test command injection taint flow"""
     # Source: request.args.get
-    user_cmd = request.args.get('command')
-    
+    user_cmd = request.args.get("command")
+
     # Sink: os.system
     os.system(user_cmd)
-    
+
     return "Command executed"
+
 
 def subprocess_flow():
     """Test subprocess taint flow"""
     # Source: request.form.get
-    script_name = request.form.get('script')
-    
+    script_name = request.form.get("script")
+
     # Sink: subprocess.call
     subprocess.call(script_name, shell=True)
-    
+
     # Another sink: subprocess.run
     subprocess.run(script_name, shell=True)
-    
+
     return "Subprocess executed"
+
 
 def input_to_eval_flow():
     """Test input to eval flow"""
     # Source: input(
     user_code = input("Enter Python code: ")
-    
+
     # Sink: eval
     result = eval(user_code)
-    
+
     # Another sink: exec
     exec(user_code)
-    
+
     return result
+
 
 def path_traversal_flow():
     """Test path traversal taint flow"""
     # Source: request.args.get
-    filename = request.args.get('file')
-    
+    filename = request.args.get("file")
+
     # Propagation through os.path.join
-    full_path = os.path.join('/uploads', filename)
-    
+    full_path = os.path.join("/uploads", filename)
+
     # Sink: open(
-    with open(full_path, 'r') as f:
+    with open(full_path, "r") as f:
         content = f.read()
-    
+
     return content
+
 
 def sanitized_command_flow():
     """Test sanitized flow (should be marked as safe)"""
     # Source: request.args.get
-    user_input = request.args.get('data')
-    
+    user_input = request.args.get("data")
+
     # Sanitization: shlex.quote
     safe_input = shlex.quote(user_input)
-    
+
     # Sink: os.system (but sanitized)
     os.system(f"echo {safe_input}")
-    
+
     return "Safe command executed"
+
 
 def multi_hop_taint_flow():
     """Test multi-hop taint propagation"""
     # Source: request.form.get
-    raw_data = request.form.get('data')
-    
+    raw_data = request.form.get("data")
+
     # First hop: assignment
     processed_data = raw_data
-    
+
     # Second hop: string manipulation
     formatted_data = processed_data.upper()
-    
+
     # Third hop: format string
     command = f"echo {formatted_data}"
-    
+
     # Sink: subprocess.run
     subprocess.run(command, shell=True)
-    
+
     return "Multi-hop flow executed"
+
 
 def environment_variable_flow():
     """Test environment variable source"""
     # Source: os.environ.get
-    config_cmd = os.environ.get('USER_COMMAND')
-    
+    config_cmd = os.environ.get("USER_COMMAND")
+
     # Sink: os.system
     os.system(config_cmd)
-    
+
     return "Environment command executed"
+
 
 def complex_propagation_flow():
     """Test complex propagation patterns"""
     # Source: request.json
-    json_data = request.json.get('payload')
-    
+    json_data = request.json.get("payload")
+
     # Propagation through string operations
     step1 = json_data.strip()
-    step2 = step1.replace('"', '')
+    step2 = step1.replace('"', "")
     step3 = step2.lower()
-    
+
     # Sink: eval
     eval(step3)
-    
+
     return "Complex flow executed"
 
+
 if __name__ == "__main__":
-    print("Taint analysis test file - run with Flask to test properly") 
+    print("Taint analysis test file - run with Flask to test properly")

--- a/test_files/python/unified_tests/comprehensive_unified_test.py
+++ b/test_files/python/unified_tests/comprehensive_unified_test.py
@@ -18,252 +18,270 @@ app = Flask(__name__)
 # SEARCH MODE TESTS
 # ============================
 
+
 def test_all_weak_crypto_patterns():
     """Test all weak cryptography patterns that should be detected"""
-    
+
     # Hashlib weak algorithms
     md5_1 = hashlib.md5(b"test")
     md5_2 = hashlib.md5("test".encode())
     sha1_1 = hashlib.sha1(b"test")
     sha1_2 = hashlib.sha1("test".encode())
-    
+
     # Crypto library weak algorithms
     md5_crypto = MD5.new()
     sha1_crypto = SHA1.new()
-    
+
     # Weak ciphers
     des_cipher = DES.new(b"12345678", DES.MODE_ECB)
     arc4_cipher = ARC4.new(b"secret")
-    
+
     return "All weak crypto patterns tested"
+
 
 def test_sql_execution_patterns():
     """Test SQL execution patterns that should be detected"""
-    
-    conn = sqlite3.connect(':memory:')
+
+    conn = sqlite3.connect(":memory:")
     cursor = conn.cursor()
-    
+
     # Various execute patterns
     cursor.execute("SELECT 1")
     cursor.executemany("INSERT INTO test VALUES (?)", [(1,)])
     cursor.executescript("CREATE TABLE test (id INTEGER)")
-    
+
     # Connection execute
     conn.execute("SELECT 2")
     conn.executemany("INSERT INTO test VALUES (?)", [(2,)])
-    
+
     return "All SQL execution patterns tested"
+
 
 # ============================
 # TAINT ANALYSIS TESTS
 # ============================
 
+
 def test_all_source_patterns():
     """Test all taint source patterns"""
-    
+
     # Request sources
-    arg_data = request.args.get('data')
-    form_data = request.form.get('data')
-    json_data = request.json.get('data')
-    
+    arg_data = request.args.get("data")
+    form_data = request.form.get("data")
+    json_data = request.json.get("data")
+
     # Input source
     user_input = input("Enter data: ")
-    
+
     # Environment source
-    env_data = os.environ.get('DATA')
-    
+    env_data = os.environ.get("DATA")
+
     return [arg_data, form_data, json_data, user_input, env_data]
+
 
 def test_all_sink_patterns():
     """Test all taint sink patterns"""
     data = "test_data"
-    
+
     # Command execution sinks
     os.system(data)
     subprocess.call(data, shell=True)
     subprocess.run(data, shell=True)
-    
+
     # Code execution sinks
     eval(data)
     exec(data)
-    
+
     # File operation sinks
-    filepath = os.path.join('/tmp', data)
-    with open(filepath, 'w') as f:
+    filepath = os.path.join("/tmp", data)
+    with open(filepath, "w") as f:
         f.write("test")
-    
+
     return "All sink patterns tested"
+
 
 def test_complex_taint_flows():
     """Test complex taint propagation scenarios"""
-    
+
     # Multi-source flow
-    source1 = request.args.get('cmd1')
-    source2 = request.form.get('cmd2')
-    
+    source1 = request.args.get("cmd1")
+    source2 = request.form.get("cmd2")
+
     # Complex propagation
     combined = source1 + " && " + source2
     processed = combined.strip().upper()
     final_cmd = f"bash -c '{processed}'"
-    
+
     # Multiple sinks
     os.system(final_cmd)
     subprocess.run(final_cmd, shell=True)
-    
+
     return "Complex taint flows tested"
+
 
 def test_sanitization_scenarios():
     """Test various sanitization scenarios"""
-    
+
     # Sanitized flow 1
-    user_input1 = request.args.get('file')
+    user_input1 = request.args.get("file")
     safe_file = shlex.quote(user_input1)
     os.system(f"cat {safe_file}")
-    
+
     # Sanitized flow 2
-    user_input2 = request.args.get('data')
+    user_input2 = request.args.get("data")
     escaped_data = shlex.quote(user_input2)
     subprocess.call(f"echo {escaped_data}", shell=True)
-    
+
     return "Sanitization scenarios tested"
+
 
 # ============================
 # MIXED VULNERABILITY TESTS
 # ============================
 
+
 def test_crypto_plus_injection():
     """Test weak crypto combined with injection vulnerabilities"""
-    
+
     # Source: user password
-    password = request.args.get('password')
-    
+    password = request.args.get("password")
+
     # Weak crypto (search pattern)
     weak_hash = hashlib.md5(password.encode())
     hash_string = weak_hash.hexdigest()
-    
+
     # Injection (taint flow)
     os.system(f"echo 'Hash: {hash_string}'")
-    
+
     return "Crypto + injection tested"
+
 
 def test_sql_search_and_taint():
     """Test SQL vulnerabilities detected by both search and taint"""
-    
+
     # User input (taint source)
-    table_name = request.args.get('table')
-    user_id = request.args.get('id')
-    
+    table_name = request.args.get("table")
+    user_id = request.args.get("id")
+
     # Build query (taint propagation)
     query = f"SELECT * FROM {table_name} WHERE id = {user_id}"
-    
+
     # Execute query (both search pattern AND taint sink)
-    conn = sqlite3.connect(':memory:')
+    conn = sqlite3.connect(":memory:")
     cursor = conn.cursor()
     cursor.execute(query)  # Should trigger both search and taint detection
-    
+
     return "SQL search + taint tested"
+
 
 def test_nested_function_calls():
     """Test nested function calls with taint"""
-    
+
     def process_input(data):
         return data.upper().strip()
-    
+
     def execute_command(cmd):
         return os.system(cmd)
-    
+
     # Taint flow through nested calls
-    user_data = request.args.get('command')
+    user_data = request.args.get("command")
     processed = process_input(user_data)
     result = execute_command(processed)
-    
+
     return result
+
 
 def test_conditional_flows():
     """Test taint flows through conditional statements"""
-    
-    user_input = request.args.get('action')
-    
-    if user_input == 'system':
+
+    user_input = request.args.get("action")
+
+    if user_input == "system":
         os.system(user_input)
-    elif user_input == 'eval':
+    elif user_input == "eval":
         eval(user_input)
     else:
         subprocess.call(user_input, shell=True)
-    
+
     return "Conditional flows tested"
+
 
 def test_loop_propagation():
     """Test taint propagation through loops"""
-    
-    commands = request.args.getlist('commands')
-    
+
+    commands = request.args.getlist("commands")
+
     for cmd in commands:
         processed_cmd = cmd.strip()
         os.system(processed_cmd)
-    
+
     return "Loop propagation tested"
+
 
 # ============================
 # EDGE CASES
 # ============================
 
+
 def test_multiple_assignments():
     """Test multiple assignments in taint flow"""
-    
-    source = request.args.get('data')
+
+    source = request.args.get("data")
     var1 = source
     var2 = var1
     var3 = var2
     final = var3
-    
+
     os.system(final)
-    
+
     return "Multiple assignments tested"
+
 
 def test_string_operations():
     """Test taint through string operations"""
-    
-    base_cmd = request.args.get('base')
-    
+
+    base_cmd = request.args.get("base")
+
     # Various string operations
     upper_cmd = base_cmd.upper()
     lower_cmd = base_cmd.lower()
     stripped_cmd = base_cmd.strip()
-    replaced_cmd = base_cmd.replace(' ', '_')
+    replaced_cmd = base_cmd.replace(" ", "_")
     formatted_cmd = f"exec {base_cmd}"
-    
+
     # All should be tainted
     os.system(upper_cmd)
     os.system(lower_cmd)
     os.system(stripped_cmd)
     os.system(replaced_cmd)
     os.system(formatted_cmd)
-    
+
     return "String operations tested"
+
 
 def test_mixed_sources_single_sink():
     """Test multiple sources flowing to single sink"""
-    
-    arg_data = request.args.get('arg')
-    form_data = request.form.get('form')
-    env_data = os.environ.get('ENV_VAR')
-    
+
+    arg_data = request.args.get("arg")
+    form_data = request.form.get("form")
+    env_data = os.environ.get("ENV_VAR")
+
     # Combine multiple sources
     combined = f"{arg_data} {form_data} {env_data}"
-    
+
     # Single sink
     os.system(combined)
-    
+
     return "Mixed sources tested"
+
 
 if __name__ == "__main__":
     print("Comprehensive unified rules test file")
     print("Run with Flask to test web-based patterns")
-    
+
     # Test non-web patterns
     test_all_weak_crypto_patterns()
     test_sql_execution_patterns()
     test_all_sink_patterns()
-    
-    print("Non-web patterns tested successfully") 
+
+    print("Non-web patterns tested successfully")

--- a/test_files/python/unified_tests/mixed_vulnerabilities.py
+++ b/test_files/python/unified_tests/mixed_vulnerabilities.py
@@ -13,117 +13,125 @@ from Crypto.Cipher import DES
 
 app = Flask(__name__)
 
-@app.route('/vulnerable_endpoint')
+
+@app.route("/vulnerable_endpoint")
 def vulnerable_endpoint():
     """Endpoint with multiple vulnerability types"""
-    
+
     # TAINT FLOW: User input to command execution
-    user_command = request.args.get('cmd')
+    user_command = request.args.get("cmd")
     os.system(user_command)  # Should be detected by taint analysis
-    
+
     # SEARCH PATTERN: Weak cryptography
     weak_hash = hashlib.md5(b"sensitive data")  # Should be detected by search
-    
+
     # TAINT FLOW: SQL injection via taint
-    user_id = request.args.get('id')
+    user_id = request.args.get("id")
     query = f"SELECT * FROM users WHERE id = {user_id}"
-    
+
     # SEARCH PATTERN: SQL execution
-    conn = sqlite3.connect('app.db')
+    conn = sqlite3.connect("app.db")
     cursor = conn.cursor()
     cursor.execute(query)  # Should be detected by both search AND taint
-    
+
     return "Endpoint processed"
+
 
 def crypto_weakness_examples():
     """Examples of weak cryptography (search patterns)"""
-    
+
     # Weak hashing algorithms
     md5_hash = hashlib.md5(b"password")
     sha1_hash = hashlib.sha1(b"secret")
-    
+
     # Weak encryption
     crypto_md5 = MD5.new()
     weak_cipher = DES.new(b"12345678", DES.MODE_ECB)
-    
+
     return "Crypto examples done"
+
 
 def command_injection_variations():
     """Various command injection patterns (taint flows)"""
-    
+
     # Direct user input to system
-    cmd1 = request.args.get('command1')
+    cmd1 = request.args.get("command1")
     os.system(cmd1)
-    
+
     # Through subprocess
-    cmd2 = request.form.get('command2')
+    cmd2 = request.form.get("command2")
     subprocess.call(cmd2, shell=True)
     subprocess.run(cmd2, shell=True)
-    
+
     # Through eval/exec
-    code = request.args.get('code')
+    code = request.args.get("code")
     eval(code)
     exec(code)
-    
+
     return "Command injection examples done"
+
 
 def path_operations():
     """File path operations (taint flows)"""
-    
+
     # Path traversal
-    filename = request.args.get('filename')
-    full_path = os.path.join('/uploads', filename)
-    
+    filename = request.args.get("filename")
+    full_path = os.path.join("/uploads", filename)
+
     # File operations
-    with open(full_path, 'r') as f:
+    with open(full_path, "r") as f:
         content = f.read()
-    
+
     return content
+
 
 def database_operations():
     """Database operations (both search and taint)"""
-    
+
     # Raw SQL with user input (taint flow)
-    table_name = request.args.get('table')
-    user_filter = request.args.get('filter')
-    
-    conn = sqlite3.connect('database.db')
+    table_name = request.args.get("table")
+    user_filter = request.args.get("filter")
+
+    conn = sqlite3.connect("database.db")
     cursor = conn.cursor()
-    
+
     # These should trigger search patterns
     cursor.execute(f"SELECT * FROM {table_name} WHERE {user_filter}")
     cursor.executemany("INSERT INTO logs VALUES (?, ?)", [(1, "test")])
-    
+
     # Direct connection execute (search pattern)
     conn.execute("DELETE FROM temp_table")
-    
+
     return "Database operations done"
+
 
 def environment_based_attacks():
     """Environment variable based attacks"""
-    
+
     # Environment variable as source (taint flow)
-    malicious_cmd = os.environ.get('MALICIOUS_COMMAND')
+    malicious_cmd = os.environ.get("MALICIOUS_COMMAND")
     if malicious_cmd:
         os.system(malicious_cmd)
         subprocess.call(malicious_cmd, shell=True)
-    
+
     return "Environment attacks done"
+
 
 def mixed_crypto_and_injection():
     """Mix of crypto weaknesses and injection"""
-    
+
     # Weak crypto (search pattern)
-    user_password = request.args.get('password')
+    user_password = request.args.get("password")
     weak_hash = hashlib.sha1(user_password.encode())  # Weak + taint
-    
+
     # Use weak hash in command (double vulnerability)
     hash_str = weak_hash.hexdigest()
     os.system(f"echo {hash_str}")  # Command injection via taint
-    
+
     return "Mixed vulnerabilities done"
+
 
 if __name__ == "__main__":
     print("Mixed vulnerability test file")
     crypto_weakness_examples()
-    print("Run with Flask to test web-based vulnerabilities") 
+    print("Run with Flask to test web-based vulnerabilities")

--- a/test_files/python/unified_tests/source_sink_test.py
+++ b/test_files/python/unified_tests/source_sink_test.py
@@ -10,79 +10,86 @@ from flask import Flask, request
 
 app = Flask(__name__)
 
+
 def test_sources_with_crypto():
     """Test cases where sources feed into crypto sinks"""
-    
+
     # Source: user input via request
-    user_password = request.args.get('password')
-    
+    user_password = request.args.get("password")
+
     # Sink: weak crypto
     weak_hash = hashlib.md5(user_password.encode())
-    
+
     return weak_hash.hexdigest()
+
 
 def test_sources_with_sql():
     """Test cases where sources feed into SQL sinks"""
-    
+
     # Source: user input via request
-    user_id = request.args.get('id')
-    
+    user_id = request.args.get("id")
+
     # Sink: SQL execution
-    conn = sqlite3.connect('test.db')
+    conn = sqlite3.connect("test.db")
     cursor = conn.cursor()
     cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
-    
+
     return cursor.fetchall()
+
 
 def test_environment_source():
     """Test environment variable as source"""
-    
+
     # Source: environment variable
-    config_value = os.environ.get('CONFIG')
-    
+    config_value = os.environ.get("CONFIG")
+
     # Sink: weak crypto
     hash_result = hashlib.sha1(config_value.encode())
-    
+
     return hash_result
+
 
 def test_input_source():
     """Test direct input as source"""
-    
+
     # Source: user input
     user_data = input("Enter data: ")
-    
+
     # Sink: weak crypto
     result = hashlib.md5(user_data.encode())
-    
+
     return result
+
 
 def test_multiple_sources():
     """Test multiple sources in same function"""
-    
+
     # Source 1: request parameter
-    param1 = request.form.get('param1')
-    
+    param1 = request.form.get("param1")
+
     # Source 2: environment
-    param2 = os.environ.get('PARAM2')
-    
+    param2 = os.environ.get("PARAM2")
+
     # Combine sources
     combined = param1 + param2
-    
+
     # Sink: weak crypto
     final_hash = hashlib.sha1(combined.encode())
-    
+
     return final_hash
+
 
 def test_no_source():
     """Test sink without obvious source (should only show sink)"""
-    
+
     # No source - just literal data
     literal_data = "static_string"
-    
+
     # Sink: weak crypto
     hash_result = hashlib.md5(literal_data.encode())
-    
+
     return hash_result
 
+
 if __name__ == "__main__":
-    print("Source and sink detection test") 
+    print("Source and sink detection test")

--- a/test_files/python/unified_tests/unified_test_search.py
+++ b/test_files/python/unified_tests/unified_test_search.py
@@ -8,53 +8,56 @@ import hashlib
 from Crypto.Hash import MD5, SHA1
 from Crypto.Cipher import DES, ARC4
 
+
 def sql_injection_tests():
     """Test SQL injection patterns"""
-    conn = sqlite3.connect('test.db')
+    conn = sqlite3.connect("test.db")
     cursor = conn.cursor()
-    
+
     # These should match the "execute" pattern
     cursor.execute("SELECT * FROM users WHERE id = 1")
-    cursor.executemany("INSERT INTO users VALUES (?, ?)", [(1, 'test')])
-    
+    cursor.executemany("INSERT INTO users VALUES (?, ?)", [(1, "test")])
+
     # Direct connection execute
     conn.execute("DELETE FROM users WHERE id = 1")
-    
+
     return "SQL tests done"
+
 
 def weak_crypto_tests():
     """Test weak cryptography patterns"""
-    
+
     # These should match weak hash patterns
     md5_hash = hashlib.md5(b"test data")
     sha1_hash = hashlib.sha1(b"test data")
-    
+
     # Crypto library weak hashes
     md5_crypto = MD5.new()
     sha1_crypto = SHA1.new()
-    
+
     # Weak ciphers
     des_cipher = DES.new(b"12345678", DES.MODE_ECB)
     arc4_cipher = ARC4.new(b"secret_key")
-    
+
     return "Crypto tests done"
+
 
 def complex_sql_injection():
     """More complex SQL injection scenarios"""
-    database = sqlite3.connect(':memory:')
+    database = sqlite3.connect(":memory:")
     db_cursor = database.cursor()
-    
+
     # Should match cursor.execute pattern
     db_cursor.execute("CREATE TABLE test (id INTEGER, name TEXT)")
-    
+
     # Should match executemany
-    db_cursor.executemany("INSERT INTO test VALUES (?, ?)", 
-                         [(1, "Alice"), (2, "Bob")])
-    
+    db_cursor.executemany("INSERT INTO test VALUES (?, ?)", [(1, "Alice"), (2, "Bob")])
+
     return "Complex SQL done"
+
 
 if __name__ == "__main__":
     sql_injection_tests()
     weak_crypto_tests()
     complex_sql_injection()
-    print("All search pattern tests completed") 
+    print("All search pattern tests completed")

--- a/test_files/python/unified_tests/unified_test_taint.py
+++ b/test_files/python/unified_tests/unified_test_taint.py
@@ -10,112 +10,121 @@ from flask import Flask, request
 
 app = Flask(__name__)
 
+
 def command_injection_flow():
     """Test command injection taint flow"""
     # Source: request.args.get
-    user_cmd = request.args.get('command')
-    
+    user_cmd = request.args.get("command")
+
     # Sink: os.system
     os.system(user_cmd)
-    
+
     return "Command executed"
+
 
 def subprocess_flow():
     """Test subprocess taint flow"""
     # Source: request.form.get
-    script_name = request.form.get('script')
-    
+    script_name = request.form.get("script")
+
     # Sink: subprocess.call
     subprocess.call(script_name, shell=True)
-    
+
     # Another sink: subprocess.run
     subprocess.run(script_name, shell=True)
-    
+
     return "Subprocess executed"
+
 
 def input_to_eval_flow():
     """Test input to eval flow"""
     # Source: input(
     user_code = input("Enter Python code: ")
-    
+
     # Sink: eval
     result = eval(user_code)
-    
+
     # Another sink: exec
     exec(user_code)
-    
+
     return result
+
 
 def path_traversal_flow():
     """Test path traversal taint flow"""
     # Source: request.args.get
-    filename = request.args.get('file')
-    
+    filename = request.args.get("file")
+
     # Propagation through os.path.join
-    full_path = os.path.join('/uploads', filename)
-    
+    full_path = os.path.join("/uploads", filename)
+
     # Sink: open(
-    with open(full_path, 'r') as f:
+    with open(full_path, "r") as f:
         content = f.read()
-    
+
     return content
+
 
 def sanitized_command_flow():
     """Test sanitized flow (should be marked as safe)"""
     # Source: request.args.get
-    user_input = request.args.get('data')
-    
+    user_input = request.args.get("data")
+
     # Sanitization: shlex.quote
     safe_input = shlex.quote(user_input)
-    
+
     # Sink: os.system (but sanitized)
     os.system(f"echo {safe_input}")
-    
+
     return "Safe command executed"
+
 
 def multi_hop_taint_flow():
     """Test multi-hop taint propagation"""
     # Source: request.form.get
-    raw_data = request.form.get('data')
-    
+    raw_data = request.form.get("data")
+
     # First hop: assignment
     processed_data = raw_data
-    
+
     # Second hop: string manipulation
     formatted_data = processed_data.upper()
-    
+
     # Third hop: format string
     command = f"echo {formatted_data}"
-    
+
     # Sink: subprocess.run
     subprocess.run(command, shell=True)
-    
+
     return "Multi-hop flow executed"
+
 
 def environment_variable_flow():
     """Test environment variable source"""
     # Source: os.environ.get
-    config_cmd = os.environ.get('USER_COMMAND')
-    
+    config_cmd = os.environ.get("USER_COMMAND")
+
     # Sink: os.system
     os.system(config_cmd)
-    
+
     return "Environment command executed"
+
 
 def complex_propagation_flow():
     """Test complex propagation patterns"""
     # Source: request.json
-    json_data = request.json.get('payload')
-    
+    json_data = request.json.get("payload")
+
     # Propagation through string operations
     step1 = json_data.strip()
-    step2 = step1.replace('"', '')
+    step2 = step1.replace('"', "")
     step3 = step2.lower()
-    
+
     # Sink: eval
     eval(step3)
-    
+
     return "Complex flow executed"
 
+
 if __name__ == "__main__":
-    print("Taint analysis test file - run with Flask to test properly") 
+    print("Taint analysis test file - run with Flask to test properly")

--- a/test_files/python/vulnerable_test.py
+++ b/test_files/python/vulnerable_test.py
@@ -4,39 +4,50 @@ import os
 import subprocess
 import sqlite3
 
+
 # SQL Injection vulnerability
 def get_user(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
     query = f"SELECT * FROM users WHERE id = {user_id}"  # Vulnerable to SQL injection
     cursor.execute(query)
     return cursor.fetchone()
 
-# Command injection vulnerability  
+
+# Command injection vulnerability
 def run_command(user_input):
     cmd = f"ls -la {user_input}"  # Vulnerable to command injection
     return subprocess.call(cmd, shell=True)
 
+
 # Path traversal vulnerability
 def read_file(filename):
     filepath = f"/var/www/uploads/{filename}"  # Vulnerable to path traversal
-    with open(filepath, 'r') as f:
+    with open(filepath, "r") as f:
         return f.read()
+
 
 # Weak random generation
 import random
+
+
 def generate_password():
     return str(random.randint(100000, 999999))  # Weak random generation
+
 
 # Hardcoded secret
 API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
 
+
 # Safe patterns (should not trigger)
 def safe_query(user_id):
-    conn = sqlite3.connect('users.db')
+    conn = sqlite3.connect("users.db")
     cursor = conn.cursor()
-    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))  # Safe parameterized query
+    cursor.execute(
+        "SELECT * FROM users WHERE id = ?", (user_id,)
+    )  # Safe parameterized query
     return cursor.fetchone()
 
+
 if __name__ == "__main__":
-    print("Test file with vulnerabilities") 
+    print("Test file with vulnerabilities")

--- a/test_files/python_test.py
+++ b/test_files/python_test.py
@@ -2,4 +2,4 @@ import os
 
 # This should trigger a vulnerability
 user_input = input("Enter command: ")
-os.system(user_input) 
+os.system(user_input)

--- a/tests/end_to_end/end_to_end_injection_tests.rs
+++ b/tests/end_to_end/end_to_end_injection_tests.rs
@@ -149,7 +149,7 @@ def count_users():
         println!("Found {} findings", findings.len());
         for finding in &findings {
             println!("Finding: {} in {} at line {} - {}", 
-                finding.finding_type, finding.file, finding.line, finding.code);
+                finding.finding_type, finding.file, finding.line, finding.snippet);
         }
 
         // Should find 3 vulnerabilities in vulnerable.py, none in safe.py
@@ -216,7 +216,7 @@ def run_safe_command():
         println!("Found {} command injection findings", findings.len());
         for finding in &findings {
             println!("Finding: {} in {} at line {} - {}", 
-                finding.finding_type, finding.file, finding.line, finding.code);
+                finding.finding_type, finding.file, finding.line, finding.snippet);
         }
 
         // Should find command injection vulnerabilities
@@ -274,7 +274,7 @@ public class VulnerableService {
             use find_vulns::parser::LanguageParser;
             use find_vulns::language::LanguageSupport;
             use find_vulns::rules::check_for_injection_pattern;
-            use find_vulns::scanner::types::Finding;
+            use find_vulns::models::Finding;
             
             // Create findings vector to store our results
             let mut findings = Vec::new();
@@ -330,12 +330,20 @@ public class VulnerableService {
                                             findings.push(Finding {
                                                 file: filepath.to_string(),
                                                 line,
+                                                column: 0,
+                                                end_line: line,
+                                                end_column: 0,
                                                 function: func_name.to_string(),
                                                 finding_type: "sql_injection".to_string(),
-                                                code: node_text.to_string(),
+                                                snippet: node_text.to_string(),
                                                 severity: "High".to_string(),
-                                                source: None,
-                                                sink: None,
+                                                confidence: "High".to_string(),
+                                                description: None,
+                                                cwe_id: None,
+                                                source_info: None,
+                                                sink_info: None,
+                                                traces: None,
+                                                tags: None,
                                             });
                                         }
                                     }
@@ -365,12 +373,20 @@ public class VulnerableService {
                                             findings.push(Finding {
                                                 file: filepath.to_string(),
                                                 line,
+                                                column: 0,
+                                                end_line: line,
+                                                end_column: 0,
                                                 function: func_name.to_string(),
                                                 finding_type: "command_injection".to_string(),
-                                                code: node_text.to_string(),
+                                                snippet: node_text.to_string(),
                                                 severity: "High".to_string(),
-                                                source: None,
-                                                sink: None,
+                                                confidence: "High".to_string(),
+                                                description: None,
+                                                cwe_id: None,
+                                                source_info: None,
+                                                sink_info: None,
+                                                traces: None,
+                                                tags: None,
                                             });
                                         }
                                     }
@@ -395,7 +411,7 @@ public class VulnerableService {
             println!("\nFound {} Java findings", findings.len());
             for finding in &findings {
                 println!("Finding: {} in {} at line {} - {}", 
-                    finding.finding_type, finding.file, finding.line, finding.code);
+                    finding.finding_type, finding.file, finding.line, finding.snippet);
             }
             
             // Verify results
@@ -502,7 +518,7 @@ function safeQuery() {
         println!("Found {} JavaScript findings", findings.len());
         for finding in &findings {
             println!("Finding: {} in {} at line {} - {}", 
-                finding.finding_type, finding.file, finding.line, finding.code);
+                finding.finding_type, finding.file, finding.line, finding.snippet);
         }
 
         // Should find multiple vulnerabilities
@@ -561,7 +577,7 @@ def safe_print():
             println!("Found {} findings in safe code (should be 0)", findings.len());
             for finding in &findings {
                 println!("Unexpected finding: {} in {} at line {} - {}", 
-                    finding.finding_type, finding.file, finding.line, finding.code);
+                    finding.finding_type, finding.file, finding.line, finding.snippet);
             }
 
             // Should find no vulnerabilities in safe code


### PR DESCRIPTION
While integration on fusion, made the following changes

- embed rules as part of binary so that we don't have to export along with rules everytime.
- added cwe_id field as part of response so that consumer of this doesn't have to map it, or guess which tag to use.
- Added Dockerfile that we can export linux compatible binary
- ruff format 