### PR TITLE
dependency update to fix build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +364,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -376,6 +399,22 @@ name = "humantime"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
+
+[[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
 
 [[package]]
 name = "indexmap"
@@ -744,6 +783,7 @@ dependencies = [
  "dbg_breakpoint",
  "env_logger",
  "glob",
+ "ignore",
  "indicatif",
  "lazy_static",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tempfile = "3.8"
 
 [profile.release]
 opt-level = 3
-lto = true
+lto = "thin"
 
 [[test]]
 name = "unit_tests"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 # Multi-stage Dockerfile for building sighthound binary
 # Stage 1: Build the binary
-FROM rust:1.81-slim AS builder
+FROM rust:1.89-slim AS builder
 
-# Install build dependencies
+# Install build dependencies including cross-compilation tools
 RUN apt-get update && apt-get install -y \
     pkg-config \
     libssl-dev \
+    gcc-x86-64-linux-gnu \
+    gcc-aarch64-linux-gnu \
     && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
@@ -23,10 +25,7 @@ ARG BUILD_DATE
 ENV GIT_HASH=${GIT_HASH}
 ENV BUILD_DATE=${BUILD_DATE}
 
-# Create cargo config for cross-compilation
-RUN mkdir -p .cargo && echo '[profile.release]\nopt-level = 3\nlto = "thin"\ncodegen-units = 1\npanic = "abort"' > .cargo/config.toml
-
-# Build the release binary with cross-compilation safe settings
+# Build the release binary
 ENV CARGO_TARGET_DIR=/app/target
 RUN cargo build --release
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Multi-stage Dockerfile for building sighthound binary
 # Stage 1: Build the binary
-FROM rust:1.80-slim AS builder
+FROM rust:1.81-slim AS builder
 
 # Install build dependencies
 RUN apt-get update && apt-get install -y \
@@ -23,7 +23,11 @@ ARG BUILD_DATE
 ENV GIT_HASH=${GIT_HASH}
 ENV BUILD_DATE=${BUILD_DATE}
 
-# Build the release binary
+# Create cargo config for cross-compilation
+RUN mkdir -p .cargo && echo '[profile.release]\nopt-level = 3\nlto = "thin"\ncodegen-units = 1\npanic = "abort"' > .cargo/config.toml
+
+# Build the release binary with cross-compilation safe settings
+ENV CARGO_TARGET_DIR=/app/target
 RUN cargo build --release
 
 # Runtime stage - minimal image for running the container


### PR DESCRIPTION
Looks like some dependencies for package has changed and require rust 1.81 now, so updated. 

```

3.452 error: rustc 1.80.1 is not supported by the following packages:
3.452   deranged@0.5.3 requires rustc 1.81.0
3.452   time@0.3.43 requires rustc 1.81.0
3.452   time-core@0.1.6 requires rustc 1.81.0
3.452 Either upgrade rustc or select compatible dependency versions with
3.452 `cargo update <name>@<current-ver> --precise <compatible-ver>`
3.452 where `<compatible-ver>` is the latest version supporting rustc 1.80.1
3.452
------
Dockerfile:27

--------------------
  25 |
  26 |     # Build the release binary
  27 | >>> RUN cargo build --release
  28 |
  29 |     # Runtime stage - minimal image for running the container
--------------------
ERROR: failed to solve: process "/bin/sh -c cargo build --release" did not complete successfully: exit code: 101

```

Then was getting this error, so fixed it to support cross-compilation: 
```
17.69    Compiling console v0.15.11
17.70 error: could not compile `console` (lib)
17.70
17.70 Caused by:
17.70   process didn't exit successfully: `/usr/local/rustup/toolchains/1.81.0-x86_64-unknown-linux-gnu/bin/rustc --crate-name console --edition=2021 /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/console-0.15.11/src/lib.rs --error-format=json --json=diagnostic-rendered-ansi,artifacts,future-incompat --crate-type lib --emit=dep-info,metadata,link -C opt-level=3 -C linker-plugin-lto --cfg 'feature="ansi-parsing"' --cfg 'feature="unicode-width"' --check-cfg 'cfg(docsrs)' --check-cfg 'cfg(feature, values("ansi-parsing", "default", "unicode-width", "windows-console-colors"))' -C metadata=ec16e68191182ff0 -C extra-filename=-ec16e68191182ff0 --out-dir /app/target/release/deps -C strip=debuginfo -L dependency=/app/target/release/deps --extern libc=/app/target/release/deps/liblibc-d9c6b40802f99ed0.rmeta --extern once_cell=/app/target/release/deps/libonce_cell-5a574add6cd0fc4c.rmeta --extern unicode_width=/app/target/release/deps/libunicode_width-1cbf847f67a486aa.rmeta --cap-lints allow` (signal: 4, SIGILL: illegal instruction)
17.70 warning: build failed, waiting for other jobs to finish...
------
Dockerfile:27
```