### PR TITLE
Modernize scanner engine (taint propagation, prefilter, parallel scan)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,2 +1,2 @@
 // Re-export Cli from models for backward compatibility
-pub use crate::models::Cli; 
+pub use crate::models::Cli;

--- a/src/code_type_detector.rs
+++ b/src/code_type_detector.rs
@@ -1,6 +1,6 @@
+use crate::parser;
 use std::collections::{HashMap, HashSet};
 use tree_sitter::{Node, Tree};
-use crate::parser;
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum CodeType {
@@ -39,6 +39,12 @@ struct FrameworkInfo {
     code_type: CodeType,
 }
 
+impl Default for FrameworkRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl FrameworkRegistry {
     pub fn new() -> Self {
         let mut frameworks = HashMap::new();
@@ -46,7 +52,10 @@ impl FrameworkRegistry {
         // Frontend frameworks
         let frontend_frameworks = vec![
             ("React", vec!["react", "react-dom"]),
-            ("Next.js", vec!["next/link", "next/router", "next/head", "@next/"]),
+            (
+                "Next.js",
+                vec!["next/link", "next/router", "next/head", "@next/"],
+            ),
             ("Angular", vec!["@angular/core"]),
             ("Vue", vec!["vue", "vue-router"]),
             ("Nuxt.js", vec!["nuxt", "@nuxtjs", "@nuxt/"]),
@@ -74,7 +83,10 @@ impl FrameworkRegistry {
             ("Recoil", vec!["recoil"]),
             ("MobX", vec!["mobx"]),
             ("Pinia", vec!["pinia"]),
-            ("TanStack Query", vec!["@tanstack/react-query", "@tanstack/vue-query"]),
+            (
+                "TanStack Query",
+                vec!["@tanstack/react-query", "@tanstack/vue-query"],
+            ),
             ("SWR", vec!["swr"]),
             ("Vite", vec!["vite", "@vitejs/"]),
             ("Webpack", vec!["webpack"]),
@@ -110,10 +122,13 @@ impl FrameworkRegistry {
         ];
 
         for (name, sigs) in frontend_frameworks {
-            frameworks.insert(name, FrameworkInfo {
-                signatures: sigs,
-                code_type: CodeType::Frontend,
-            });
+            frameworks.insert(
+                name,
+                FrameworkInfo {
+                    signatures: sigs,
+                    code_type: CodeType::Frontend,
+                },
+            );
         }
 
         // Backend frameworks
@@ -146,10 +161,13 @@ impl FrameworkRegistry {
         ];
 
         for (name, sigs) in backend_frameworks {
-            frameworks.insert(name, FrameworkInfo {
-                signatures: sigs,
-                code_type: CodeType::Backend,
-            });
+            frameworks.insert(
+                name,
+                FrameworkInfo {
+                    signatures: sigs,
+                    code_type: CodeType::Backend,
+                },
+            );
         }
 
         Self { frameworks }
@@ -177,9 +195,11 @@ impl FrameworkRegistry {
         let mut frontend_matches = 0;
         let mut backend_matches = 0;
 
-        for (_, info) in &self.frameworks {
+        for info in self.frameworks.values() {
             let has_match = info.signatures.iter().any(|sig| {
-                imports.iter().any(|imp| imp.to_lowercase().contains(&sig.to_lowercase()))
+                imports
+                    .iter()
+                    .any(|imp| imp.to_lowercase().contains(&sig.to_lowercase()))
             });
 
             if has_match {
@@ -214,17 +234,20 @@ impl CodeTypeDetector {
         }
     }
 
-    pub fn detect_code_type(&self, file_path: &str, content: &str, language: &str) -> CodeType {
+    pub fn detect_code_type(&self, _file_path: &str, content: &str, language: &str) -> CodeType {
         // First try framework detection
         let imports = self.extract_imports(content, language);
         let framework_result = self.framework_registry.detect_from_frameworks(&imports);
-        
+
         if framework_result != CodeType::Unknown {
             return framework_result;
         }
 
         // Then try AST analysis for JavaScript/TypeScript
-        if matches!(language.to_lowercase().as_str(), "javascript" | "typescript" | "tsx") {
+        if matches!(
+            language.to_lowercase().as_str(),
+            "javascript" | "typescript" | "tsx"
+        ) {
             if let Ok(mut parser) = crate::parser::LanguageParser::new(language) {
                 if let Ok(tree) = parser.parse(content.as_bytes()) {
                     let ast_result = self.detect_from_ast(&tree, content.as_bytes());
@@ -244,12 +267,14 @@ impl CodeTypeDetector {
         // Default fallback based on language
         match language.to_lowercase().as_str() {
             "javascript" | "typescript" | "tsx" | "jsx" => CodeType::Frontend,
-            "python" | "java" | "rust" | "go" | "php" | "ruby" | "c" | "cpp" | "c#" | "csharp" => CodeType::Backend,
+            "python" | "java" | "rust" | "go" | "php" | "ruby" | "c" | "cpp" | "c#" | "csharp" => {
+                CodeType::Backend
+            }
             _ => CodeType::Unknown,
         }
     }
 
-    fn extract_imports(&self, content: &str, language: &str) -> Vec<String> {
+    fn extract_imports(&self, content: &str, _language: &str) -> Vec<String> {
         let mut imports = Vec::new();
 
         // Extract require() calls
@@ -276,15 +301,13 @@ impl CodeTypeDetector {
 
         // Frontend signals
         frontend_score += self.score_frontend_signals(tree, source);
-        
+
         // Backend signals
         backend_score += self.score_backend_signals(tree, source);
 
         if frontend_score > 0 && backend_score == 0 {
             CodeType::Frontend
-        } else if backend_score > 0 && frontend_score == 0 {
-            CodeType::Backend
-        } else if backend_score > frontend_score {
+        } else if backend_score > 0 && (frontend_score == 0 || backend_score > frontend_score) {
             CodeType::Backend
         } else if frontend_score > backend_score {
             CodeType::Frontend
@@ -299,26 +322,42 @@ impl CodeTypeDetector {
 
         // DOM methods
         let dom_methods = vec![
-            "getElementById", "getElementsByClassName", "querySelector", "querySelectorAll",
-            "createElement", "appendChild", "addEventListener"
+            "getElementById",
+            "getElementsByClassName",
+            "querySelector",
+            "querySelectorAll",
+            "createElement",
+            "appendChild",
+            "addEventListener",
         ];
 
         // Browser objects
         let browser_objects = vec![
-            "document", "window", "navigator", "localStorage", "sessionStorage",
-            "location", "history", "screen"
+            "document",
+            "window",
+            "navigator",
+            "localStorage",
+            "sessionStorage",
+            "location",
+            "history",
+            "screen",
         ];
 
         // React hooks
         let react_hooks = vec![
-            "useState", "useEffect", "useContext", "useReducer", "useMemo", "useCallback"
+            "useState",
+            "useEffect",
+            "useContext",
+            "useReducer",
+            "useMemo",
+            "useCallback",
         ];
 
         // Check for call expressions
         self.walk_tree(&root_node, &mut |node| {
             if node.kind() == "call_expression" {
                 let text = parser::get_node_text(&node, source);
-                
+
                 // Check for DOM methods
                 for method in &dom_methods {
                     if text.contains(method) {
@@ -364,7 +403,7 @@ impl CodeTypeDetector {
 
         // Node.js core modules
         let core_modules = vec![
-            "fs", "path", "http", "https", "crypto", "os", "util", "events"
+            "fs", "path", "http", "https", "crypto", "os", "util", "events",
         ];
 
         // Node.js globals
@@ -376,11 +415,13 @@ impl CodeTypeDetector {
         self.walk_tree(&root_node, &mut |node| {
             if node.kind() == "call_expression" {
                 let text = parser::get_node_text(&node, source);
-                
+
                 // Check for require calls with core modules
                 if text.starts_with("require(") {
                     for module in &core_modules {
-                        if text.contains(&format!("'{}'", module)) || text.contains(&format!("\"{}\"", module)) {
+                        if text.contains(&format!("'{}'", module))
+                            || text.contains(&format!("\"{}\"", module))
+                        {
                             score += 3;
                         }
                     }
@@ -412,11 +453,13 @@ impl CodeTypeDetector {
         let frontend_sigs = self.framework_registry.get_frontend_signatures();
         let backend_sigs = self.framework_registry.get_backend_signatures();
 
-        let frontend_matches = imports.iter()
+        let frontend_matches = imports
+            .iter()
             .filter(|imp| frontend_sigs.iter().any(|sig| imp.contains(sig)))
             .count();
 
-        let backend_matches = imports.iter()
+        let backend_matches = imports
+            .iter()
             .filter(|imp| backend_sigs.iter().any(|sig| imp.contains(sig)))
             .count();
 
@@ -431,12 +474,12 @@ impl CodeTypeDetector {
         }
     }
 
-    fn walk_tree<F>(&self, node: &Node, callback: &mut F) 
+    fn walk_tree<F>(&self, node: &Node, callback: &mut F)
     where
         F: FnMut(Node),
     {
         callback(*node);
-        
+
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             self.walk_tree(&child, callback);
@@ -448,4 +491,4 @@ impl Default for CodeTypeDetector {
     fn default() -> Self {
         Self::new()
     }
-} 
+}

--- a/src/common.rs
+++ b/src/common.rs
@@ -17,8 +17,8 @@ impl CommonUtils {
         }
 
         // Handle regex patterns (prefix or escaped chars)
-        if pattern.starts_with("regex:") {
-            return Self::matches_regex(&pattern[6..], text);
+        if let Some(stripped) = pattern.strip_prefix("regex:") {
+            return Self::matches_regex(stripped, text);
         }
         if pattern.contains("\\\\") || pattern.contains("\\.") {
             return Self::matches_regex(pattern, text);
@@ -58,15 +58,18 @@ impl CommonUtils {
     /// Specialized pattern matching for taint analysis with context awareness
     pub fn matches_taint_pattern(pattern: &str, text: &str) -> bool {
         // Skip string literals and metadata
-        if text.trim().starts_with('"') || text.trim().starts_with("'") ||
-           text.contains("__all__") || text.contains("__version__") {
+        if text.trim().starts_with('"')
+            || text.trim().starts_with("'")
+            || text.contains("__all__")
+            || text.contains("__version__")
+        {
             return false;
         }
 
         // Special handling for DOM property patterns like *.innerHTML
-        if pattern.starts_with("*.") {
-            let property = &pattern[2..]; // Remove "*."
-            
+        if let Some(property) = pattern.strip_prefix("*.") {
+            // Remove "*."
+
             // Handle TypeScript casting syntax: (element.innerHTML as Type) = value
             if text.contains(&format!(".{}", property)) {
                 // Check for assignment context
@@ -87,7 +90,11 @@ impl CommonUtils {
         _context: &str,
     ) -> bool {
         // Skip string literals in any context
-        if text.starts_with('"') || text.starts_with("'") || text.starts_with("b\"") || text.starts_with("b'") {
+        if text.starts_with('"')
+            || text.starts_with("'")
+            || text.starts_with("b\"")
+            || text.starts_with("b'")
+        {
             return false;
         }
 
@@ -155,7 +162,9 @@ impl CommonUtils {
             } else if suffix.is_empty() {
                 return text.starts_with(prefix);
             } else {
-                return text.starts_with(prefix) && text.ends_with(suffix) && text.len() >= prefix.len() + suffix.len();
+                return text.starts_with(prefix)
+                    && text.ends_with(suffix)
+                    && text.len() >= prefix.len() + suffix.len();
             }
         }
 
@@ -188,16 +197,10 @@ impl CommonUtils {
         true
     }
 
-    /// Check if pattern is a regex pattern
-    fn is_regex_pattern(pattern: &str) -> bool {
-        pattern.starts_with("regex:") ||
-        pattern.contains("\\\\") ||
-        pattern.contains("\\.")
-    }
-
     /// Match regex patterns with caching for performance
     fn matches_regex(pattern: &str, text: &str) -> bool {
-        static REGEX_CACHE: Lazy<Mutex<HashMap<String, regex::Regex>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+        static REGEX_CACHE: Lazy<Mutex<HashMap<String, regex::Regex>>> =
+            Lazy::new(|| Mutex::new(HashMap::new()));
 
         // Fast path: try cache first
         if let Some(re) = REGEX_CACHE.lock().unwrap().get(pattern) {
@@ -235,7 +238,7 @@ impl CommonUtils {
             if parts.len() == 2 {
                 let module_name = parts[0];
                 let func_name = parts[1];
-                
+
                 // Look for exact "module.function" pattern in text
                 let full_pattern = format!("{}.{}", module_name, func_name);
                 return text.contains(&full_pattern);
@@ -245,19 +248,19 @@ impl CommonUtils {
         // For function call patterns ending with '(', ensure exact function name match
         if cleaned_pattern.ends_with('(') {
             let func_name = &cleaned_pattern[..cleaned_pattern.len() - 1];
-            
+
             // Special handling for module.function( patterns
             if func_name.contains('.') {
                 return text.contains(&cleaned_pattern);
             }
-            
+
             // Look for the function name followed by '(' in the text
             if let Some(pos) = text.find(&format!("{}(", func_name)) {
                 // Ensure it's a word boundary (not part of a larger identifier)
                 let before_pos = if pos > 0 { pos - 1 } else { 0 };
                 let char_before = text.chars().nth(before_pos);
-                
-                return char_before.map_or(true, |c| !c.is_alphanumeric() && c != '_');
+
+                return char_before.is_none_or(|c| !c.is_alphanumeric() && c != '_');
             }
             return false;
         }
@@ -267,11 +270,16 @@ impl CommonUtils {
 
     /// Match any pattern from a list (common use case)
     pub fn matches_any_pattern(patterns: &[String], text: &str) -> bool {
-        patterns.iter().any(|pattern| Self::matches_unified_pattern(pattern, text))
+        patterns
+            .iter()
+            .any(|pattern| Self::matches_unified_pattern(pattern, text))
     }
 
     /// Extract variable name from assignment expression with configurable behavior
-    pub fn extract_variable_from_assignment(assignment_text: &str, return_empty_on_none: bool) -> Option<String> {
+    pub fn extract_variable_from_assignment(
+        assignment_text: &str,
+        return_empty_on_none: bool,
+    ) -> Option<String> {
         let eq_pos = assignment_text.find('=')?;
         let left_side = assignment_text[..eq_pos].trim();
 
@@ -318,7 +326,9 @@ impl CommonUtils {
     /// Extract all variable identifiers from code expression
     /// Extract simple variable identifiers from code expression (separator-based)
     pub fn extract_simple_variables(expr: &str) -> Vec<String> {
-        let separators = [' ', '+', '-', '*', '/', '(', ')', '[', ']', '{', '}', ',', '.', '='];
+        let separators = [
+            ' ', '+', '-', '*', '/', '(', ')', '[', ']', '{', '}', ',', '.', '=',
+        ];
 
         expr.split(&separators)
             .map(|s| s.trim())
@@ -370,7 +380,10 @@ impl CommonUtils {
         // Remove duplicates and invalid names
         variables.sort();
         variables.dedup();
-        variables.into_iter().filter(|v| Self::is_valid_variable_name(v)).collect()
+        variables
+            .into_iter()
+            .filter(|v| Self::is_valid_variable_name(v))
+            .collect()
     }
 
     /// Extract direct variable from simple expressions
@@ -394,7 +407,10 @@ impl CommonUtils {
         let mut i = 0;
         while i < chars.len() {
             // Skip escaped braces `{{` or `}}`
-            if i + 1 < chars.len() && ((chars[i] == '{' && chars[i + 1] == '{') || (chars[i] == '}' && chars[i + 1] == '}')) {
+            if i + 1 < chars.len()
+                && ((chars[i] == '{' && chars[i + 1] == '{')
+                    || (chars[i] == '}' && chars[i + 1] == '}'))
+            {
                 i += 2;
                 continue;
             }
@@ -415,7 +431,11 @@ impl CommonUtils {
                                 let raw_var: String = chars[start..i].iter().collect();
                                 let raw_var = raw_var.trim();
                                 // Strip format specifiers after ':' or '!'
-                                let clean_var = raw_var.split([':', '!'].as_ref()).next().unwrap_or("").trim();
+                                let clean_var = raw_var
+                                    .split([':', '!'].as_ref())
+                                    .next()
+                                    .unwrap_or("")
+                                    .trim();
                                 if Self::is_valid_variable_name(clean_var) {
                                     log::debug!("[F_STRING_EXTRACT] Found variable: {}", clean_var);
                                     variables.push(clean_var.to_string());
@@ -438,7 +458,7 @@ impl CommonUtils {
     /// Extract variables from JavaScript/TypeScript template literals
     pub fn extract_template_literal_variables(expr: &str) -> Vec<String> {
         log::debug!("[TEMPLATE_LITERAL_EXTRACT] Processing: '{}'", expr);
-        
+
         let mut variables = Vec::new();
         let mut dollar_brace_depth = 0usize;
         let mut current_start: Option<usize> = None;
@@ -465,15 +485,18 @@ impl CommonUtils {
                         // Extract the expression inside ${}
                         let raw_expr: String = chars[start..i].iter().collect();
                         let raw_expr = raw_expr.trim();
-                        
-                        log::debug!("[TEMPLATE_LITERAL_EXTRACT] Found expression: '{}'", raw_expr);
-                        
+
+                        log::debug!(
+                            "[TEMPLATE_LITERAL_EXTRACT] Found expression: '{}'",
+                            raw_expr
+                        );
+
                         // Extract variables from the expression
                         variables.extend(Self::extract_all_variables(raw_expr));
                     }
                 }
             }
-            
+
             i += 1;
         }
 
@@ -544,39 +567,43 @@ impl CommonUtils {
     pub fn extract_function_arguments(call_expr: &str) -> Option<Vec<String>> {
         let start = call_expr.find('(')?;
         let end = call_expr.rfind(')')?;
-        
+
         // Validate bounds before slicing to prevent panic
         if start + 1 >= end {
             return Some(Vec::new()); // Return empty args for malformed expressions
         }
-        
+
         let args_str = &call_expr[start + 1..end];
 
-        Some(args_str.split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty() && !s.starts_with('"') && !s.starts_with('\''))
-            .collect())
+        Some(
+            args_str
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty() && !s.starts_with('"') && !s.starts_with('\''))
+                .collect(),
+        )
     }
 
     /// Check if assignment text is valid (not comparison)
     pub fn is_valid_assignment_text(text: &str) -> bool {
-        text.contains('=') &&
-        !text.contains("==") &&
-        !text.contains("!=") &&
-        !text.contains("<=") &&
-        !text.contains(">=")
+        text.contains('=')
+            && !text.contains("==")
+            && !text.contains("!=")
+            && !text.contains("<=")
+            && !text.contains(">=")
     }
 
     /// Check if string is a valid variable name
     pub fn is_valid_variable_name(s: &str) -> bool {
-        !s.is_empty() &&
-        s.chars().all(|c| c.is_alphanumeric() || c == '_') &&
-        !s.chars().next().unwrap().is_ascii_digit()
+        !s.is_empty()
+            && s.chars().all(|c| c.is_alphanumeric() || c == '_')
+            && !s.chars().next().unwrap().is_ascii_digit()
     }
 
     /// Check if string is a keyword or builtin (consolidated from multiple implementations)
     pub fn is_keyword_or_builtin(s: &str) -> bool {
-        matches!(s,
+        matches!(
+            s,
             // Python keywords
             "and" | "as" | "assert" | "break" | "class" | "continue" | "def" | "del" | "elif" |
             "else" | "except" | "exec" | "finally" | "for" | "from" | "global" | "if" | "import" |
@@ -608,7 +635,10 @@ impl CommonUtils {
 
     /// Detect syntax for syntax highlighting (moved from core.rs)
     pub fn detect_syntax(file_path: &str) -> &'static str {
-        match std::path::Path::new(file_path).extension().and_then(|e| e.to_str()) {
+        match std::path::Path::new(file_path)
+            .extension()
+            .and_then(|e| e.to_str())
+        {
             Some("py") => "Python",
             Some("js") | Some("mjs") => "JavaScript",
             Some("ts") | Some("tsx") => "TypeScript",
@@ -706,15 +736,20 @@ impl CommonUtils {
         visitor(node);
 
         Self::for_each_child(node, |child| {
-            Self::traverse_recursive(&child, visitor, max_depth - 1);
+            Self::traverse_recursive(child, visitor, max_depth - 1);
         });
     }
 
     /// Validate required CLI parameter combination
-    pub fn validate_cli_params(language: &Option<String>, rules_path: &Option<String>, use_embedded_rules: bool, use_file_rules: bool) -> Result<()> {
+    pub fn validate_cli_params(
+        language: &Option<String>,
+        rules_path: &Option<String>,
+        use_embedded_rules: bool,
+        use_file_rules: bool,
+    ) -> Result<()> {
         // Resolve the actual embedded rules setting (use_file_rules overrides use_embedded_rules)
         let should_use_embedded = use_embedded_rules && !use_file_rules;
-        
+
         match (language, rules_path, should_use_embedded) {
             // Explicit mode with embedded rules
             (Some(_), None, true) => Ok(()),

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,19 +4,19 @@ pub struct ScanDefaults;
 impl ScanDefaults {
     /// Chunk size for parallel file processing (tuned for disk I/O)
     pub const CHUNK_SIZE: usize = 64;
-    
+
     /// Progress update interval in milliseconds
     pub const PROGRESS_INTERVAL_MS: u64 = 100;
-    
+
     /// Estimated files per language for capacity planning
     pub const ESTIMATED_FILES_PER_LANG: usize = 50;
-    
+
     /// Maximum AST traversal depth to prevent infinite recursion
     pub const MAX_AST_DEPTH: usize = 20;
-    
+
     /// Maximum file size to process (10MB)
     pub const MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
-    
+
     /// Estimated languages for HashMap capacity
     pub const ESTIMATED_LANGUAGES: usize = 6;
 }
@@ -25,31 +25,59 @@ impl ScanDefaults {
 pub mod filters {
     /// Directories to skip during file discovery
     pub const SKIP_DIRS: &[&str] = &[
-        "venv", "env", ".venv", ".env",
-        "node_modules", ".git",
-        "__pycache__", ".pytest_cache",
-        "target", "build", "dist",
-        ".idea", ".vscode",
-        "tests", "test", // Skip test directories
+        "venv",
+        "env",
+        ".venv",
+        ".env",
+        "node_modules",
+        ".git",
+        "__pycache__",
+        ".pytest_cache",
+        "target",
+        "build",
+        "dist",
+        ".idea",
+        ".vscode",
+        "tests",
+        "test",   // Skip test directories
         "vendor", // Composer/PHP and other third-party dependency trees
-        "wp-includes", "wp-admin", // WordPress core (third-party CMS code)
+        "wp-includes",
+        "wp-admin", // WordPress core (third-party CMS code)
     ];
 
     /// File patterns for minified/bundled JavaScript files
     pub const SKIP_MINIFIED_PATTERNS: &[&str] = &[
-        "*.min.js", "*.min.jsx", "*.min.ts", "*.min.tsx",
-        "*.bundle.js", "*.chunk.js", "*.vendor.js", "*.webpack.js",
-        "*-min.js", "*-bundle.js", "*-compiled.js", "*-uglified.js",
-        "*-compressed.js", "*.pack.js", "*.prod.js"
+        "*.min.js",
+        "*.min.jsx",
+        "*.min.ts",
+        "*.min.tsx",
+        "*.bundle.js",
+        "*.chunk.js",
+        "*.vendor.js",
+        "*.webpack.js",
+        "*-min.js",
+        "*-bundle.js",
+        "*-compiled.js",
+        "*-uglified.js",
+        "*-compressed.js",
+        "*.pack.js",
+        "*.prod.js",
     ];
 
     /// Test file patterns to skip during taint analysis
     /// NOTE: Currently unused - candidate for removal
     pub const SKIP_TEST_PATTERNS: &[&str] = &[
-        "test_*.py", "*_test.py", "test*.py",
-        "test_*.js", "*_test.js", "*.test.js",
-        "*.spec.js", "*.spec.py",
-        "conftest.py", "**/tests/**",
-        "**/test/**", "**/*test*/**",
+        "test_*.py",
+        "*_test.py",
+        "test*.py",
+        "test_*.js",
+        "*_test.js",
+        "*.test.js",
+        "*.spec.js",
+        "*.spec.py",
+        "conftest.py",
+        "**/tests/**",
+        "**/test/**",
+        "**/*test*/**",
     ];
-} 
+}

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,6 +1,6 @@
+use crate::parser::get_node_text_slice;
 use anyhow::Result;
 use tree_sitter::{Language, Node};
-use crate::parser::get_node_text_slice;
 
 pub trait LanguageSupport: Send + Sync {
     fn name(&self) -> &'static str;
@@ -75,10 +75,18 @@ pub struct PythonLanguage;
 
 #[cfg(feature = "python")]
 impl LanguageSupport for PythonLanguage {
-    fn name(&self) -> &'static str { "python" }
-    fn file_extension(&self) -> &'static str { ".py" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_python::LANGUAGE.into() }
-    fn call_node_types(&self) -> &[&'static str] { &["call"] }
+    fn name(&self) -> &'static str {
+        "python"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".py"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_python::LANGUAGE.into()
+    }
+    fn call_node_types(&self) -> &[&'static str] {
+        &["call"]
+    }
 
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
         node.child_by_field_name("function")
@@ -96,24 +104,28 @@ pub struct JavaLanguage;
 
 #[cfg(feature = "java")]
 impl LanguageSupport for JavaLanguage {
-    fn name(&self) -> &'static str { "java" }
-    fn file_extension(&self) -> &'static str { ".java" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_java::LANGUAGE.into() }
+    fn name(&self) -> &'static str {
+        "java"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".java"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_java::LANGUAGE.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
         &["method_invocation", "object_creation_expression"]
     }
 
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
         match node.kind() {
-            "method_invocation" => {
-                node.child_by_field_name("name")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "object_creation_expression" => {
-                node.child_by_field_name("type")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            _ => None
+            "method_invocation" => node
+                .child_by_field_name("name")
+                .map(|child| get_node_text_slice(&child, source)),
+            "object_creation_expression" => node
+                .child_by_field_name("type")
+                .map(|child| get_node_text_slice(&child, source)),
+            _ => None,
         }
     }
 
@@ -128,24 +140,28 @@ pub struct JavaScriptLanguage;
 
 #[cfg(feature = "javascript")]
 impl LanguageSupport for JavaScriptLanguage {
-    fn name(&self) -> &'static str { "javascript" }
-    fn file_extension(&self) -> &'static str { ".js" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_javascript::LANGUAGE.into() }
+    fn name(&self) -> &'static str {
+        "javascript"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".js"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_javascript::LANGUAGE.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
         &["call_expression", "new_expression"]
     }
 
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
         match node.kind() {
-            "call_expression" => {
-                node.child_by_field_name("function")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "new_expression" => {
-                node.child_by_field_name("constructor")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            _ => None
+            "call_expression" => node
+                .child_by_field_name("function")
+                .map(|child| get_node_text_slice(&child, source)),
+            "new_expression" => node
+                .child_by_field_name("constructor")
+                .map(|child| get_node_text_slice(&child, source)),
+            _ => None,
         }
     }
 
@@ -160,28 +176,36 @@ pub struct TSXLanguage;
 
 #[cfg(feature = "tsx")]
 impl LanguageSupport for TSXLanguage {
-    fn name(&self) -> &'static str { "tsx" }
-    fn file_extension(&self) -> &'static str { ".tsx" } // Primary extension, but handles both .ts and .tsx
-    fn tree_sitter_language(&self) -> Language { tree_sitter_typescript::LANGUAGE_TSX.into() }
+    fn name(&self) -> &'static str {
+        "tsx"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".tsx"
+    } // Primary extension, but handles both .ts and .tsx
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_typescript::LANGUAGE_TSX.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
-        &["call_expression", "new_expression", "jsx_expression", "jsx_attribute"]
+        &[
+            "call_expression",
+            "new_expression",
+            "jsx_expression",
+            "jsx_attribute",
+        ]
     }
 
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
         match node.kind() {
-            "jsx_attribute" => {
-                node.child_by_field_name("name")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "call_expression" => {
-                node.child_by_field_name("function")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "new_expression" => {
-                node.child_by_field_name("constructor")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            _ => None
+            "jsx_attribute" => node
+                .child_by_field_name("name")
+                .map(|child| get_node_text_slice(&child, source)),
+            "call_expression" => node
+                .child_by_field_name("function")
+                .map(|child| get_node_text_slice(&child, source)),
+            "new_expression" => node
+                .child_by_field_name("constructor")
+                .map(|child| get_node_text_slice(&child, source)),
+            _ => None,
         }
     }
 
@@ -197,24 +221,28 @@ pub struct TypeScriptLanguage;
 
 #[cfg(feature = "typescript")]
 impl LanguageSupport for TypeScriptLanguage {
-    fn name(&self) -> &'static str { "typescript" }
-    fn file_extension(&self) -> &'static str { ".ts" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into() }
+    fn name(&self) -> &'static str {
+        "typescript"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".ts"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
         &["call_expression", "new_expression"]
     }
 
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
         match node.kind() {
-            "call_expression" => {
-                node.child_by_field_name("function")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "new_expression" => {
-                node.child_by_field_name("constructor")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            _ => None
+            "call_expression" => node
+                .child_by_field_name("function")
+                .map(|child| get_node_text_slice(&child, source)),
+            "new_expression" => node
+                .child_by_field_name("constructor")
+                .map(|child| get_node_text_slice(&child, source)),
+            _ => None,
         }
     }
 
@@ -229,10 +257,18 @@ pub struct GoLanguage;
 
 #[cfg(feature = "go")]
 impl LanguageSupport for GoLanguage {
-    fn name(&self) -> &'static str { "go" }
-    fn file_extension(&self) -> &'static str { ".go" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_go::LANGUAGE.into() }
-    fn call_node_types(&self) -> &[&'static str] { &["call_expression"] }
+    fn name(&self) -> &'static str {
+        "go"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".go"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_go::LANGUAGE.into()
+    }
+    fn call_node_types(&self) -> &[&'static str] {
+        &["call_expression"]
+    }
 
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
         node.child_by_field_name("function").map(|function| {
@@ -258,18 +294,25 @@ pub struct RubyLanguage;
 
 #[cfg(feature = "ruby")]
 impl LanguageSupport for RubyLanguage {
-    fn name(&self) -> &'static str { "ruby" }
-    fn file_extension(&self) -> &'static str { ".rb" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_ruby::LANGUAGE.into() }
-    fn call_node_types(&self) -> &[&'static str] { &["method_call", "call"] }
+    fn name(&self) -> &'static str {
+        "ruby"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".rb"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_ruby::LANGUAGE.into()
+    }
+    fn call_node_types(&self) -> &[&'static str] {
+        &["method_call", "call"]
+    }
 
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
         match node.kind() {
-            "method_call" | "call" => {
-                node.child_by_field_name("method")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            _ => None
+            "method_call" | "call" => node
+                .child_by_field_name("method")
+                .map(|child| get_node_text_slice(&child, source)),
+            _ => None,
         }
     }
 
@@ -284,9 +327,15 @@ pub struct CSharpLanguage;
 
 #[cfg(feature = "csharp")]
 impl LanguageSupport for CSharpLanguage {
-    fn name(&self) -> &'static str { "csharp" }
-    fn file_extension(&self) -> &'static str { ".cs" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_c_sharp::LANGUAGE.into() }
+    fn name(&self) -> &'static str {
+        "csharp"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".cs"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_c_sharp::LANGUAGE.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
         &["invocation_expression", "object_creation_expression"]
     }
@@ -297,22 +346,19 @@ impl LanguageSupport for CSharpLanguage {
             // (there is no `name` field). For `obj.Method(...)` the function is a
             // `member_access_expression`; resolve its `name` child so method-name
             // rules match. Plain `Method(...)` has an identifier function.
-            "invocation_expression" => {
-                node.child_by_field_name("function").map(|func| {
-                    if func.kind() == "member_access_expression" {
-                        func.child_by_field_name("name")
-                            .map(|name| get_node_text_slice(&name, source))
-                            .unwrap_or_else(|| get_node_text_slice(&func, source))
-                    } else {
-                        get_node_text_slice(&func, source)
-                    }
-                })
-            }
-            "object_creation_expression" => {
-                node.child_by_field_name("type")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            _ => None
+            "invocation_expression" => node.child_by_field_name("function").map(|func| {
+                if func.kind() == "member_access_expression" {
+                    func.child_by_field_name("name")
+                        .map(|name| get_node_text_slice(&name, source))
+                        .unwrap_or_else(|| get_node_text_slice(&func, source))
+                } else {
+                    get_node_text_slice(&func, source)
+                }
+            }),
+            "object_creation_expression" => node
+                .child_by_field_name("type")
+                .map(|child| get_node_text_slice(&child, source)),
+            _ => None,
         }
     }
 
@@ -327,9 +373,15 @@ pub struct PHPLanguage;
 
 #[cfg(feature = "php")]
 impl LanguageSupport for PHPLanguage {
-    fn name(&self) -> &'static str { "php" }
-    fn file_extension(&self) -> &'static str { ".php" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_php::LANGUAGE_PHP.into() }
+    fn name(&self) -> &'static str {
+        "php"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".php"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_php::LANGUAGE_PHP.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
         &[
             "function_call_expression",
@@ -371,9 +423,15 @@ pub struct HTMLLanguage;
 
 #[cfg(feature = "html")]
 impl LanguageSupport for HTMLLanguage {
-    fn name(&self) -> &'static str { "html" }
-    fn file_extension(&self) -> &'static str { ".html" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_html::LANGUAGE.into() }
+    fn name(&self) -> &'static str {
+        "html"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".html"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_html::LANGUAGE.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
         &["attribute", "start_tag", "script_element", "element"]
     }
@@ -385,20 +443,20 @@ impl LanguageSupport for HTMLLanguage {
         // names like `th:utext`, `th:replace`, or tag names like `textarea`
         // resolve as the matchable "function" name for search rules.
         match node.kind() {
-            "attribute" => {
-                node.child_by_field_name("name")
-                    .or_else(|| crate::common::CommonUtils::find_child(node, |c| c.kind() == "attribute_name"))
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "start_tag" | "element" => {
-                node.child_by_field_name("name")
-                    .or_else(|| crate::common::CommonUtils::find_child(node, |c| c.kind() == "tag_name"))
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "script_element" => {
-                Some("script")
-            }
-            _ => None
+            "attribute" => node
+                .child_by_field_name("name")
+                .or_else(|| {
+                    crate::common::CommonUtils::find_child(node, |c| c.kind() == "attribute_name")
+                })
+                .map(|child| get_node_text_slice(&child, source)),
+            "start_tag" | "element" => node
+                .child_by_field_name("name")
+                .or_else(|| {
+                    crate::common::CommonUtils::find_child(node, |c| c.kind() == "tag_name")
+                })
+                .map(|child| get_node_text_slice(&child, source)),
+            "script_element" => Some("script"),
+            _ => None,
         }
     }
 
@@ -431,9 +489,15 @@ pub struct DjangoTemplateLanguage;
 
 #[cfg(feature = "django")]
 impl LanguageSupport for DjangoTemplateLanguage {
-    fn name(&self) -> &'static str { "django" }
-    fn file_extension(&self) -> &'static str { ".html" }
-    fn tree_sitter_language(&self) -> Language { tree_sitter_html::LANGUAGE.into() }
+    fn name(&self) -> &'static str {
+        "django"
+    }
+    fn file_extension(&self) -> &'static str {
+        ".html"
+    }
+    fn tree_sitter_language(&self) -> Language {
+        tree_sitter_html::LANGUAGE.into()
+    }
     fn call_node_types(&self) -> &[&'static str] {
         &["attribute", "text", "script_element"]
     }
@@ -451,8 +515,8 @@ impl LanguageSupport for DjangoTemplateLanguage {
                 } else if text.contains("{% autoescape off %}") {
                     Some("{% autoescape off %}")
                 } else if text.contains("{{") && text.contains("}}") {
-                    Some("{{")}
-                else if text.contains("{% include") {
+                    Some("{{")
+                } else if text.contains("{% include") {
                     Some("{% include")
                 } else if text.contains("{{") || text.contains("{%") {
                     Some("django_template")
@@ -460,14 +524,11 @@ impl LanguageSupport for DjangoTemplateLanguage {
                     None
                 }
             }
-            "attribute" => {
-                node.child_by_field_name("name")
-                    .map(|child| get_node_text_slice(&child, source))
-            }
-            "script_element" => {
-                Some("script")
-            }
-            _ => None
+            "attribute" => node
+                .child_by_field_name("name")
+                .map(|child| get_node_text_slice(&child, source)),
+            "script_element" => Some("script"),
+            _ => None,
         }
     }
 
@@ -490,7 +551,7 @@ impl LanguageSupport for DjangoTemplateLanguage {
                 }
                 None
             }
-            _ => node.child_by_field_name("value")
+            _ => node.child_by_field_name("value"),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,34 @@
+//! Sighthound — a fast, AST-based static analysis scanner for security
+//! vulnerabilities in source code.
+//!
+//! Sighthound parses source with [tree-sitter](https://tree-sitter.github.io/) and
+//! applies RON-encoded rules in two modes:
+//!
+//! - **Search rules** match dangerous patterns directly in the AST.
+//! - **Taint rules** track untrusted data from sources to sinks.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use anyhow::Result;
+//! use clap::Parser;
+//! use sighthound::{run_auto_detection_scan, Cli};
+//!
+//! fn scan(path: &str) -> Result<()> {
+//!     let cli = Cli::parse_from(["sighthound", path]);
+//!     let findings = run_auto_detection_scan(&cli, path, false)?;
+//!     println!("{} findings", findings.len());
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Stability
+//!
+//! The library API is **unstable** before v1.0. Minor releases may include
+//! breaking changes to public modules.
+
 pub mod cli;
+pub mod code_type_detector;
 pub mod common;
 pub mod config;
 pub mod language;
@@ -6,28 +36,23 @@ pub mod models;
 pub mod parser;
 pub mod rules;
 pub mod scanner;
-pub mod code_type_detector;
 pub mod ui;
 
-// Re-export the main types and functions that main.rs needs
-pub use scanner::{
-    VulnerabilityScanner, ScanningLogic, PreFilter, FilterStats, 
-    run_explicit_scan, run_auto_detection_scan, run_taint_analysis
-};
 pub use scanner::modes::run_taint_analysis_with_verbosity;
+pub use scanner::{
+    run_auto_detection_scan, run_explicit_scan, run_taint_analysis, FilterStats, PreFilter,
+    ScanningLogic, VulnerabilityScanner,
+};
 
-// Re-export types needed by tests and library users
 pub use common::CommonUtils;
 pub use config::ScanDefaults;
-pub use rules::{Rules, match_pattern, check_for_injection_pattern};
+pub use rules::{check_for_injection_pattern, match_pattern, Rules};
 
-// Re-export code type detection
-pub use code_type_detector::{CodeTypeDetector, CodeType};
+pub use code_type_detector::{CodeType, CodeTypeDetector};
 
-// Re-export commonly used items from models
 pub use models::{
-    Finding, TaintFlow, TaintSource, TaintSink, TaintTrace, TaintSummary,
-    UnifiedRule, FileTypes, Condition, Cli, LanguageInfo, FileInfo
+    Cli, Condition, FileInfo, FileTypes, Finding, LanguageInfo, TaintFlow, TaintSink, TaintSource,
+    TaintSummary, TaintTrace, UnifiedRule,
 };
 
 pub use parser::traverse_calls_only;

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,8 +104,8 @@ fn main() -> Result<()> {
     let duration = start_time.elapsed();
 
     match cli.output_format.as_str() {
-        "json" => print_findings_json(&findings),
-        "csv" => print_findings_csv(&findings),
+        "json" => print_findings_json(&findings)?,
+        "csv" => print_findings_csv(&findings)?,
         _ => print_findings_text(&findings, cli.verbose, cli.summary_only, duration),
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,19 +12,29 @@ fn main() -> Result<()> {
     // Handle version flag
     if cli.version {
         println!("sighthound {}", env!("CARGO_PKG_VERSION"));
-        println!("Built from commit: {}", option_env!("GIT_HASH").unwrap_or("unknown"));
-        println!("Build date: {}", option_env!("BUILD_DATE").unwrap_or("unknown"));
+        println!(
+            "Built from commit: {}",
+            option_env!("GIT_HASH").unwrap_or("unknown")
+        );
+        println!(
+            "Build date: {}",
+            option_env!("BUILD_DATE").unwrap_or("unknown")
+        );
         return Ok(());
     }
 
     // Check if root_dir is provided (required for actual scanning)
     let root_dir = cli.root_dir.as_ref().ok_or_else(|| {
-        anyhow::anyhow!("Root directory is required for scanning. Use --help for usage information.")
+        anyhow::anyhow!(
+            "Root directory is required for scanning. Use --help for usage information."
+        )
     })?;
 
     // Initialize logger (respect RUST_LOG or --verbose flag)
-    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or(if cli.verbose { "debug" } else { "info" }))
-        .init();
+    env_logger::Builder::from_env(
+        env_logger::Env::default().default_filter_or(if cli.verbose { "debug" } else { "info" }),
+    )
+    .init();
     // Configure threading if specified
     if let Some(threads) = cli.threads {
         rayon::ThreadPoolBuilder::new()
@@ -34,10 +44,10 @@ fn main() -> Result<()> {
     }
 
     let start_time = std::time::Instant::now();
-    
+
     // Determine if we should show progress (suppress for structured output formats)
     let show_progress = !matches!(cli.output_format.as_str(), "json" | "csv");
-    
+
     // Validate CLI parameters
     if cli.taint_analysis && cli.simple_analysis {
         return Err(anyhow::anyhow!("Cannot specify both --taint-analysis and --simple-analysis. Use one or neither (default: both modes)."));
@@ -45,7 +55,7 @@ fn main() -> Result<()> {
 
     // Resolve the actual embedded rules setting (use_file_rules overrides use_embedded_rules)
     let should_use_embedded = cli.use_embedded_rules && !cli.use_file_rules;
-    
+
     // Validate CLI parameters using CommonUtils
     CommonUtils::validate_cli_params(&cli.language, &cli.rules_path, cli.use_embedded_rules, cli.use_file_rules)
         .map_err(|e| anyhow::anyhow!(
@@ -61,36 +71,43 @@ fn main() -> Result<()> {
 
     // Handle all vulnerability scanning modes with unified flow
     let findings = if cli.taint_analysis {
+        // Only taint analysis
         run_taint_analysis(&cli, root_dir, show_progress)?
     } else if cli.simple_analysis {
+        // Only simple analysis
         match (&cli.language, &cli.rules_path, should_use_embedded) {
             (Some(_), Some(_), false) => run_explicit_scan(&cli, root_dir, show_progress)?,
             (Some(_), None, true) => run_explicit_scan(&cli, root_dir, show_progress)?,
             (None, None, _) => run_auto_detection_scan(&cli, root_dir, show_progress)?,
-            _ => unreachable!(),
+            _ => unreachable!(), // Validation above ensures this won't happen
         }
     } else {
+        // Default: Run both simple and taint analysis
+        // Run simple analysis first
         let mut simple_findings = match (&cli.language, &cli.rules_path, should_use_embedded) {
             (Some(_), Some(_), false) => run_explicit_scan(&cli, root_dir, show_progress)?,
             (Some(_), None, true) => run_explicit_scan(&cli, root_dir, show_progress)?,
             (None, None, _) => run_auto_detection_scan(&cli, root_dir, show_progress)?,
-            _ => unreachable!(),
+            _ => unreachable!(), // Validation above ensures this won't happen
         };
 
+        // Run taint analysis second (less verbose in combined mode)
         let mut taint_findings =
             run_taint_analysis_with_verbosity(&cli, root_dir, show_progress, false)?;
 
+        // Combine findings
         simple_findings.append(&mut taint_findings);
         simple_findings
     };
 
+    // Output results
     let duration = start_time.elapsed();
 
     match cli.output_format.as_str() {
         "json" => print_findings_json(&findings),
         "csv" => print_findings_csv(&findings),
-        "text" | _ => print_findings_text(&findings, cli.verbose, cli.summary_only, duration),
+        _ => print_findings_text(&findings, cli.verbose, cli.summary_only, duration),
     }
 
     Ok(())
-} 
+}

--- a/src/models.rs
+++ b/src/models.rs
@@ -52,8 +52,8 @@ pub struct TraceStep {
     pub line: usize,
     pub code: String,
     pub variable: String,
-    pub operation: String,   // "assignment", "parameter", "return", "method_call"
-    pub function: String,    // Containing function name
+    pub operation: String, // "assignment", "parameter", "return", "method_call"
+    pub function: String,  // Containing function name
 }
 
 /// Core taint flow data structure
@@ -71,7 +71,7 @@ pub struct TaintFlow {
     pub is_cross_file: bool,
     // Rule information for better reporting
     pub rule_id: Option<String>,
-    pub rule_name: Option<String>, 
+    pub rule_name: Option<String>,
     pub rule_description: Option<String>,
     pub rule_finding_type: Option<String>,
 }
@@ -98,7 +98,7 @@ pub struct TaintSink {
     pub variable: String,
     pub operation: String,
     pub code: String,
-    // Branch tracking for control flow awareness  
+    // Branch tracking for control flow awareness
     pub branch_id: Option<String>,
 }
 
@@ -156,80 +156,80 @@ pub struct UnifiedRule {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub id: Option<String>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub name: Option<String>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub description: Option<String>,
-    
+
     // Category field for organization
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub category: Option<String>,
-    
+
     // Analysis mode - determines how the rule is processed
     #[serde(default = "default_search_mode")]
     pub mode: String, // "search" (default) or "taint"
-    
+
     // Pattern matching (used in search mode)
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub pattern: Option<String>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub patterns: Option<Vec<String>>,
-    
+
     // Taint analysis fields (used when mode = "taint")
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub sources: Option<Vec<String>>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub sinks: Option<Vec<String>>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub propagators: Option<Vec<String>>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub sanitizers: Option<Vec<String>>,
-    
+
     // Metadata and configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub finding_type: Option<String>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub severity: Option<String>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub confidence: Option<String>,
-    
+
     // File filtering
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub file_types: Option<FileTypes>,
-    
+
     // Advanced conditions for pattern matching
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conditions: Option<Vec<Condition>>,
-    
+
     // Additional metadata
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tags: Option<Vec<String>>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub cwe_id: Option<String>,
-    
+
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(default)]
     pub message: Option<String>,
@@ -280,62 +280,88 @@ pub struct Condition {
     pub ancestor_types: Option<Vec<String>>,
 }
 
-
-
 /// CLI configuration structure
 #[derive(clap::Parser)]
 #[command(
     name = "sighthound",
     about = "A fast vulnerability scanner for source code",
-    long_about = "Corgea Greppy - A high-performance vulnerability scanner that uses tree-sitter for AST-based analysis with parallel processing support.\n\nBy default, runs both simple pattern-based analysis and taint analysis for comprehensive vulnerability detection. Use --simple-analysis or --taint-analysis to run only one mode.\n\nSupports both explicit mode (specify language and rules) and auto-detection mode (automatically detect file types and load appropriate rules). Rules must be in RON format."
+    long_about = "Sighthound - A high-performance vulnerability scanner that uses tree-sitter for AST-based analysis with parallel processing support.\n\nBy default, runs both simple pattern-based analysis and taint analysis for comprehensive vulnerability detection. Use --simple-analysis or --taint-analysis to run only one mode.\n\nSupports both explicit mode (specify language and rules) and auto-detection mode (automatically detect file types and load appropriate rules). Rules must be in RON format."
 )]
 pub struct Cli {
     /// Root directory to scan
     #[arg(help = "Root directory to scan for vulnerabilities")]
     pub root_dir: Option<String>,
-    
+
     /// Language to scan (optional - triggers explicit mode when used with rules_path)
     #[arg(help = "Programming language to scan (python, java, javascript, tsx, html, django)")]
     pub language: Option<String>,
-    
+
     /// Rules file or directory path (optional - triggers explicit mode when used with language)
     #[arg(help = "Path to rules file (.ron) or directory containing multiple .ron rule files")]
     pub rules_path: Option<String>,
-    
+
     /// Custom rules directory (overrides default 'rules' directory)
-    #[arg(long, help = "Custom rules directory to use instead of default 'rules' directory")]
+    #[arg(
+        long,
+        help = "Custom rules directory to use instead of default 'rules' directory"
+    )]
     pub rules_dir: Option<String>,
-    
+
     /// Use embedded rules instead of loading from files (default: true)
-    #[arg(long, default_value = "true", help = "Use rules embedded in the binary instead of loading from files (default: true)")]
+    #[arg(
+        long,
+        default_value = "true",
+        help = "Use rules embedded in the binary instead of loading from files (default: true)"
+    )]
     pub use_embedded_rules: bool,
-    
+
     /// Disable embedded rules and use file-based rules instead
-    #[arg(long, help = "Disable embedded rules and load rules from files (overrides --use-embedded-rules)")]
+    #[arg(
+        long,
+        help = "Disable embedded rules and load rules from files (overrides --use-embedded-rules)"
+    )]
     pub use_file_rules: bool,
-    
+
     /// Output format (text, json, csv)
-    #[arg(short, long, default_value = "text", help = "Output format: text, json, or csv")]
+    #[arg(
+        short,
+        long,
+        default_value = "text",
+        help = "Output format: text, json, or csv"
+    )]
     pub output_format: String,
-    
+
     /// Verbose output
     #[arg(short, long, help = "Enable verbose output showing more details")]
     pub verbose: bool,
-    
+
     /// Only show summary
-    #[arg(short, long, help = "Only show vulnerability summary without individual findings")]
+    #[arg(
+        short,
+        long,
+        help = "Only show vulnerability summary without individual findings"
+    )]
     pub summary_only: bool,
 
     /// Disable parallel processing (use single-threaded mode)
-    #[arg(long, help = "Disable parallel processing for debugging or specific use cases")]
+    #[arg(
+        long,
+        help = "Disable parallel processing for debugging or specific use cases"
+    )]
     pub single_threaded: bool,
 
     /// Number of threads to use for parallel processing (default: CPU cores)
-    #[arg(long, help = "Number of threads for parallel processing (default: auto-detect CPU cores)")]
+    #[arg(
+        long,
+        help = "Number of threads for parallel processing (default: auto-detect CPU cores)"
+    )]
     pub threads: Option<usize>,
 
     /// Enable taint analysis mode only (default: both search and taint)
-    #[arg(long, help = "Run only taint analysis (data flow tracking from sources to sinks)")]
+    #[arg(
+        long,
+        help = "Run only taint analysis (data flow tracking from sources to sinks)"
+    )]
     pub taint_analysis: bool,
 
     /// Enable simple analysis mode only (default: both search and taint)
@@ -347,11 +373,17 @@ pub struct Cli {
     pub skip_minified: Option<bool>,
 
     /// Filter by code type (frontend, backend, or both)
-    #[arg(long, help = "Filter by code type: frontend, backend, or both (default: both)")]
+    #[arg(
+        long,
+        help = "Filter by code type: frontend, backend, or both (default: both)"
+    )]
     pub code_type: Option<String>,
 
     /// Filter by programming language
-    #[arg(long, help = "Filter by programming language: javascript, typescript, python, java, etc.")]
+    #[arg(
+        long,
+        help = "Filter by programming language: javascript, typescript, python, java, etc."
+    )]
     pub language_filter: Option<String>,
 
     /// Print version information
@@ -369,23 +401,23 @@ impl UnifiedRule {
     pub fn is_taint_rule(&self) -> bool {
         self.mode == "taint"
     }
-    
+
     pub fn is_search_rule(&self) -> bool {
         self.mode == "search"
     }
-    
+
     pub fn get_category(&self) -> &str {
         self.category.as_deref().unwrap_or("unknown")
     }
-    
+
     pub fn get_finding_type(&self) -> &str {
         self.finding_type.as_deref().unwrap_or("vulnerability")
     }
-    
+
     pub fn get_severity(&self) -> &str {
         self.severity.as_deref().unwrap_or("Medium")
     }
-    
+
     pub fn get_confidence(&self) -> &str {
         self.confidence.as_deref().unwrap_or("Medium")
     }
@@ -413,11 +445,11 @@ impl Finding {
             tags: None,
         }
     }
-    
+
     pub fn is_critical(&self) -> bool {
         self.severity.to_lowercase() == "high" || self.severity.to_lowercase() == "critical"
     }
-    
+
     pub fn add_trace(&mut self, trace: TraceStep) {
         if let Some(ref mut traces) = self.traces {
             traces.push(trace);
@@ -425,7 +457,7 @@ impl Finding {
             self.traces = Some(vec![trace]);
         }
     }
-    
+
     /// Extract CWE ID from tags field and set the cwe_id field
     pub fn extract_cwe_id(&mut self) {
         if let Some(ref tags) = self.tags {
@@ -438,20 +470,20 @@ impl Finding {
             }
         }
     }
-    
+
     /// Extract CWE ID from tags if present
     pub fn extract_cwe_id_from_tags(tags: &Option<Vec<String>>) -> Option<String> {
-        tags.as_ref()
-            .and_then(|tag_list| {
-                tag_list.iter()
-                    .find(|tag| tag.starts_with("cwe-"))
-                    .map(|tag| tag.to_string())
-            })
+        tags.as_ref().and_then(|tag_list| {
+            tag_list
+                .iter()
+                .find(|tag| tag.starts_with("cwe-"))
+                .map(|tag| tag.to_string())
+        })
     }
-    
+
     /// Extract CWE ID from rule tags (kept for backward compatibility)
     pub fn extract_cwe_id_with_fallback(tags: &[String], _finding_type: &str) -> Option<String> {
         // Get CWE from rule tags only
         Finding::extract_cwe_id_from_tags(&Some(tags.to_vec()))
     }
-} 
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,6 @@
+use crate::language::{get_language_support, LanguageSupport};
 use anyhow::{Context, Result};
-use tree_sitter::{Parser as TSParser, Tree, Node};
-use crate::language::{LanguageSupport, get_language_support};
+use tree_sitter::{Node, Parser as TSParser, Tree};
 
 pub struct LanguageParser {
     parser: TSParser,
@@ -12,13 +12,20 @@ impl LanguageParser {
         let language_support = get_language_support(language_name)?;
         let language = language_support.tree_sitter_language();
         let mut parser = TSParser::new();
-        parser.set_language(&language).context("Failed to set language")?;
+        parser
+            .set_language(&language)
+            .context("Failed to set language")?;
 
-        Ok(Self { parser, language_support })
+        Ok(Self {
+            parser,
+            language_support,
+        })
     }
 
     pub fn parse(&mut self, source: &[u8]) -> Result<Tree> {
-        self.parser.parse(source, None).context("Failed to parse file")
+        self.parser
+            .parse(source, None)
+            .context("Failed to parse file")
     }
 
     pub fn file_extension(&self) -> &str {
@@ -46,8 +53,8 @@ pub fn get_node_text_slice<'a>(node: &Node, source: &'a [u8]) -> &'a str {
 
 // Language-agnostic tree traversal
 pub fn traverse_calls_only<'a>(
-    node: Node<'a>, 
-    language_support: &'a dyn LanguageSupport
+    node: Node<'a>,
+    language_support: &'a dyn LanguageSupport,
 ) -> impl Iterator<Item = Node<'a>> + 'a {
     let call_types = language_support.call_node_types();
     TreeCallIterator::new(node, call_types)
@@ -60,7 +67,10 @@ struct TreeCallIterator<'a> {
 
 impl<'a> TreeCallIterator<'a> {
     fn new(root: Node<'a>, call_types: &'a [&'static str]) -> Self {
-        Self { stack: vec![root], call_types }
+        Self {
+            stack: vec![root],
+            call_types,
+        }
     }
 }
 
@@ -79,7 +89,7 @@ impl<'a> Iterator for TreeCallIterator<'a> {
                     }
                 }
             }
-            
+
             // Return if this node type is a call node for the current language
             if self.call_types.contains(&node.kind()) {
                 return Some(node);

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -4,11 +4,11 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
 
-use crate::language::LanguageSupport;
 use crate::common::CommonUtils;
+use crate::language::LanguageSupport;
 
 // Re-export for backward compatibility
-pub use crate::models::{UnifiedRule, FileTypes, Condition};
+pub use crate::models::{Condition, FileTypes, UnifiedRule};
 
 // Embedded rules - rule files included at compile time, grouped per language.
 // Each entry must be a valid `Rules` RON document; exclusion-pattern files use a
@@ -30,9 +30,9 @@ const EMBEDDED_JAVASCRIPT: &[&str] = &[
 ];
 
 // Additional backend JS rules, loaded only when code_type is not "frontend".
-const EMBEDDED_JAVASCRIPT_BACKEND: &[&str] = &[
-    include_str!("../rules/backend_javascript/backend_security.ron"),
-];
+const EMBEDDED_JAVASCRIPT_BACKEND: &[&str] = &[include_str!(
+    "../rules/backend_javascript/backend_security.ron"
+)];
 
 const EMBEDDED_JAVA: &[&str] = &[
     include_str!("../rules/java/sql_injection.ron"),
@@ -114,12 +114,14 @@ pub struct ExclusionPatterns {
 
 impl ExclusionPatterns {
     pub fn load_from_file(file_path: &str) -> Result<Self> {
-        let content = fs::read_to_string(file_path)
-            .context(format!("Failed to read exclusion patterns file: {}", file_path))?;
-        
+        let content = fs::read_to_string(file_path).context(format!(
+            "Failed to read exclusion patterns file: {}",
+            file_path
+        ))?;
+
         ron::from_str(&content).context("Failed to parse exclusion patterns RON")
     }
-    
+
     pub fn get_patterns(&self, pattern_type: &str) -> Vec<String> {
         match pattern_type {
             "frontend" => {
@@ -142,10 +144,8 @@ impl ExclusionPatterns {
                 }
                 patterns
             }
-            "common" => {
-                self.common_exclusions.clone().unwrap_or_default()
-            }
-            _ => Vec::new()
+            "common" => self.common_exclusions.clone().unwrap_or_default(),
+            _ => Vec::new(),
         }
     }
 }
@@ -154,28 +154,28 @@ impl ExclusionPatterns {
 pub fn check_for_injection_pattern(text: &str, _language_support: &dyn LanguageSupport) -> bool {
     // Basic injection indicators that are language-agnostic
     let basic_patterns = [
-        ";", "&&", "||", "`", "$(",  // Command separators/chaining
-        "eval(", "exec(", "system(",  // Dangerous functions  
-        "{{", "{%",                   // Template injection
-        "javascript:", "data:",       // URL schemes
+        ";",
+        "&&",
+        "||",
+        "`",
+        "$(", // Command separators/chaining
+        "eval(",
+        "exec(",
+        "system(", // Dangerous functions
+        "{{",
+        "{%", // Template injection
+        "javascript:",
+        "data:", // URL schemes
     ];
-    
+
     basic_patterns.iter().any(|&pattern| text.contains(pattern))
 }
 
 // Simplified Rules structure - only unified rules
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize, Serialize, Default)]
 pub struct Rules {
     #[serde(default)]
     pub rules: Vec<UnifiedRule>,
-}
-
-impl Default for Rules {
-    fn default() -> Self {
-        Self {
-            rules: Vec::new(),
-        }
-    }
 }
 
 impl Rules {
@@ -201,7 +201,10 @@ impl Rules {
                 // Legacy backend JS rules load only when explicitly non-frontend,
                 // matching the file-rules auto-detect path the benchmark measured.
                 if code_type.is_some_and(|ct| ct != "frontend") {
-                    all_rules.extend(Self::parse_embedded(EMBEDDED_JAVASCRIPT_BACKEND, "JavaScript backend")?);
+                    all_rules.extend(Self::parse_embedded(
+                        EMBEDDED_JAVASCRIPT_BACKEND,
+                        "JavaScript backend",
+                    )?);
                 }
             }
             "java" => all_rules.extend(Self::parse_embedded(EMBEDDED_JAVA, "Java")?),
@@ -211,7 +214,10 @@ impl Rules {
             "html" | "django" => all_rules.extend(Self::parse_embedded(EMBEDDED_HTML, "HTML")?),
             "php" => all_rules.extend(Self::parse_embedded(EMBEDDED_PHP, "PHP")?),
             _ => {
-                return Err(anyhow::anyhow!("No embedded rules available for language: {}", language));
+                return Err(anyhow::anyhow!(
+                    "No embedded rules available for language: {}",
+                    language
+                ));
             }
         }
 
@@ -221,45 +227,49 @@ impl Rules {
 
         Self::merge_rules(all_rules)
     }
-    
+
     /// Load embedded rules for all detected languages
     pub fn load_all_embedded_rules(languages: &[String], code_type: Option<&str>) -> Result<Self> {
         let mut all_rules = Vec::new();
-        
+
         for language in languages {
             match Self::load_embedded_rules(language, code_type) {
                 Ok(rules) => all_rules.push(rules),
                 Err(e) => {
                     // Log warning but continue with other languages
-                    eprintln!("Warning: Failed to load embedded rules for {}: {}", language, e);
+                    eprintln!(
+                        "Warning: Failed to load embedded rules for {}: {}",
+                        language, e
+                    );
                 }
             }
         }
-        
+
         if all_rules.is_empty() {
-            return Err(anyhow::anyhow!("No embedded rules found for any of the detected languages"));
+            return Err(anyhow::anyhow!(
+                "No embedded rules found for any of the detected languages"
+            ));
         }
-        
+
         Self::merge_rules(all_rules)
     }
 
     pub fn load_from_file(rules_file: &str) -> Result<Self> {
         let content = fs::read_to_string(rules_file)
             .context(format!("Failed to read rules file: {}", rules_file))?;
-        
+
         let path = Path::new(rules_file);
-        let extension = path.extension()
+        let extension = path
+            .extension()
             .and_then(|ext| ext.to_str())
             .unwrap_or("")
             .to_lowercase();
 
         match extension.as_str() {
-            "ron" => {
-                ron::from_str(&content).context("Failed to parse rules RON")
-            },
-            _ => {
-                Err(anyhow::anyhow!("Unsupported file format. Only .ron files are supported for rules."))
-            }
+            "ron" => ron::from_str(&content).context("Failed to parse rules RON"),
+            _ => Err(anyhow::anyhow!(
+                "Unsupported file format. Only .ron files are supported for rules."
+            )),
         }
     }
 
@@ -268,26 +278,29 @@ impl Rules {
     /// If path is a directory, loads all .ron files and merges them
     pub fn load_from_path(rules_path: &str) -> Result<Self> {
         let path = Path::new(rules_path);
-        
+
         if path.is_file() {
             Self::load_from_file(rules_path)
         } else if path.is_dir() {
             Self::load_from_directory(rules_path)
         } else {
-            Err(anyhow::anyhow!("Rules path '{}' is neither a file nor a directory", rules_path))
+            Err(anyhow::anyhow!(
+                "Rules path '{}' is neither a file nor a directory",
+                rules_path
+            ))
         }
     }
 
     /// Load all .ron files from a directory and merge them
     pub fn load_from_directory(rules_dir: &str) -> Result<Self> {
         let dir_path = Path::new(rules_dir);
-        
+
         if !dir_path.is_dir() {
             return Err(anyhow::anyhow!("Path '{}' is not a directory", rules_dir));
         }
 
-        let entries = fs::read_dir(dir_path)
-            .context(format!("Failed to read directory: {}", rules_dir))?;
+        let entries =
+            fs::read_dir(dir_path).context(format!("Failed to read directory: {}", rules_dir))?;
 
         let mut all_rules = Vec::new();
         let mut loaded_files = Vec::new();
@@ -295,20 +308,23 @@ impl Rules {
         for entry in entries {
             let entry = entry.context("Failed to read directory entry")?;
             let file_path = entry.path();
-            
+
             // Only process .ron files
             if let Some(extension) = file_path.extension() {
                 let ext_str = extension.to_string_lossy().to_lowercase();
                 if ext_str == "ron" {
                     let file_path_str = file_path.to_string_lossy();
-                    
+
                     match Self::load_from_file(&file_path_str) {
                         Ok(rules) => {
                             all_rules.push(rules);
                             loaded_files.push(file_path_str.to_string());
                         }
                         Err(e) => {
-                            eprintln!("Warning: Failed to load rules from {}: {}", file_path_str, e);
+                            eprintln!(
+                                "Warning: Failed to load rules from {}: {}",
+                                file_path_str, e
+                            );
                         }
                     }
                 }
@@ -316,7 +332,10 @@ impl Rules {
         }
 
         if all_rules.is_empty() {
-            return Err(anyhow::anyhow!("No valid .ron rules files found in directory: {}", rules_dir));
+            return Err(anyhow::anyhow!(
+                "No valid .ron rules files found in directory: {}",
+                rules_dir
+            ));
         }
 
         // Merge all rules into a single Rules instance
@@ -340,12 +359,18 @@ impl Rules {
 
     /// Get all search mode rules
     pub fn get_search_rules(&self) -> Vec<&UnifiedRule> {
-        self.rules.iter().filter(|rule| rule.is_search_rule()).collect()
+        self.rules
+            .iter()
+            .filter(|rule| rule.is_search_rule())
+            .collect()
     }
 
     /// Get all taint mode rules
     pub fn get_taint_rules(&self) -> Vec<&UnifiedRule> {
-        self.rules.iter().filter(|rule| rule.is_taint_rule()).collect()
+        self.rules
+            .iter()
+            .filter(|rule| rule.is_taint_rule())
+            .collect()
     }
 
     /// Count total number of rules
@@ -355,15 +380,25 @@ impl Rules {
 
     /// Get rules by category
     pub fn get_rules_by_category(&self, category: &str) -> Vec<&UnifiedRule> {
-        self.rules.iter().filter(|rule| {
-            rule.category.as_ref().map(|c| c == category).unwrap_or(false)
-        }).collect()
+        self.rules
+            .iter()
+            .filter(|rule| {
+                rule.category
+                    .as_ref()
+                    .map(|c| c == category)
+                    .unwrap_or(false)
+            })
+            .collect()
     }
 
     /// Apply centralized exclusion patterns to all rules
-    pub fn apply_centralized_exclusions(&mut self, exclusion_patterns: &ExclusionPatterns, pattern_type: &str) {
+    pub fn apply_centralized_exclusions(
+        &mut self,
+        exclusion_patterns: &ExclusionPatterns,
+        pattern_type: &str,
+    ) {
         let patterns = exclusion_patterns.get_patterns(pattern_type);
-        
+
         for rule in &mut self.rules {
             if let Some(file_types) = &mut rule.file_types {
                 // If rule doesn't have exclusion patterns, add the centralized ones
@@ -385,7 +420,12 @@ impl Rules {
                     javascript: None,
                     tsx: None,
                     html: None,
-                    extensions: Some(vec![".js".to_string(), ".jsx".to_string(), ".ts".to_string(), ".tsx".to_string()]),
+                    extensions: Some(vec![
+                        ".js".to_string(),
+                        ".jsx".to_string(),
+                        ".ts".to_string(),
+                        ".tsx".to_string(),
+                    ]),
                     include_patterns: None,
                     exclude_patterns: Some(patterns.clone()),
                 });
@@ -394,9 +434,12 @@ impl Rules {
     }
 
     /// Load rules from directory with centralized exclusions applied
-    pub fn load_from_directory_with_exclusions(rules_dir: &str, pattern_type: &str) -> Result<Self> {
+    pub fn load_from_directory_with_exclusions(
+        rules_dir: &str,
+        pattern_type: &str,
+    ) -> Result<Self> {
         let mut rules = Self::load_from_directory(rules_dir)?;
-        
+
         // Try to load exclusion patterns from the same directory
         let exclusion_file = format!("{}/exclusion_patterns.ron", rules_dir);
         if Path::new(&exclusion_file).exists() {
@@ -405,11 +448,14 @@ impl Rules {
                     rules.apply_centralized_exclusions(&exclusion_patterns, pattern_type);
                 }
                 Err(e) => {
-                    eprintln!("Warning: Failed to load exclusion patterns from {}: {}", exclusion_file, e);
+                    eprintln!(
+                        "Warning: Failed to load exclusion patterns from {}: {}",
+                        exclusion_file, e
+                    );
                 }
             }
         }
-        
+
         Ok(rules)
     }
 }
@@ -429,7 +475,7 @@ pub fn rule_matches_pattern_unified(rule: &UnifiedRule, text: &str) -> bool {
             return true;
         }
     }
-    
+
     if let Some(patterns) = &rule.patterns {
         for pattern in patterns {
             if match_pattern(pattern, text) {
@@ -437,24 +483,24 @@ pub fn rule_matches_pattern_unified(rule: &UnifiedRule, text: &str) -> bool {
             }
         }
     }
-    
+
     false
 }
 
 pub fn validate_unified_rule_patterns(rule: &UnifiedRule) -> Result<(), String> {
     if rule.is_search_rule() {
         if let Some(pattern) = &rule.pattern {
-            if pattern.starts_with("regex:") {
-                let regex_pattern = &pattern[6..];
-                Regex::new(regex_pattern).map_err(|e| format!("Invalid regex pattern '{}': {}", regex_pattern, e))?;
+            if let Some(regex_pattern) = pattern.strip_prefix("regex:") {
+                Regex::new(regex_pattern)
+                    .map_err(|e| format!("Invalid regex pattern '{}': {}", regex_pattern, e))?;
             }
         }
-        
+
         if let Some(patterns) = &rule.patterns {
             for pattern in patterns {
-                if pattern.starts_with("regex:") {
-                    let regex_pattern = &pattern[6..];
-                    Regex::new(regex_pattern).map_err(|e| format!("Invalid regex pattern '{}': {}", regex_pattern, e))?;
+                if let Some(regex_pattern) = pattern.strip_prefix("regex:") {
+                    Regex::new(regex_pattern)
+                        .map_err(|e| format!("Invalid regex pattern '{}': {}", regex_pattern, e))?;
                 }
             }
         }
@@ -463,23 +509,31 @@ pub fn validate_unified_rule_patterns(rule: &UnifiedRule) -> Result<(), String> 
 }
 
 pub fn is_literal_node(node: &tree_sitter::Node) -> bool {
-    match node.kind() {
-        "string" | "string_literal" | "number" | "integer" | "float" | 
-        "boolean" | "true" | "false" | "null" | "none" => true,
-        _ => false,
-    }
+    matches!(
+        node.kind(),
+        "string"
+            | "string_literal"
+            | "number"
+            | "integer"
+            | "float"
+            | "boolean"
+            | "true"
+            | "false"
+            | "null"
+            | "none"
+    )
 }
 
 pub fn is_in_protective_context(node: &tree_sitter::Node) -> bool {
     let mut current = node.parent();
     let mut depth = 0;
     const MAX_DEPTH: usize = 10;
-    
+
     while let Some(parent) = current {
         if depth > MAX_DEPTH {
             break;
         }
-        
+
         match parent.kind() {
             "try_statement" | "except_clause" | "if_statement" | "conditional_expression" => {
                 return true;
@@ -494,10 +548,10 @@ pub fn is_in_protective_context(node: &tree_sitter::Node) -> bool {
             }
             _ => {}
         }
-        
+
         current = parent.parent();
         depth += 1;
     }
-    
+
     false
-} 
+}

--- a/src/scanner/conditions.rs
+++ b/src/scanner/conditions.rs
@@ -1,7 +1,7 @@
-use crate::rules::Condition;
 use crate::language::LanguageSupport;
-use crate::parser::{get_node_text};
-use crate::rules::{match_pattern, match_any_pattern, is_literal_node};
+use crate::parser::get_node_text;
+use crate::rules::Condition;
+use crate::rules::{is_literal_node, match_any_pattern, match_pattern};
 
 /// Check if all AST conditions are satisfied for a node
 pub fn check_ast_conditions(
@@ -10,9 +10,9 @@ pub fn check_ast_conditions(
     source: &[u8],
     language_support: &dyn LanguageSupport,
 ) -> bool {
-    conditions.iter().all(|condition| {
-        check_single_condition(node, source, condition, language_support)
-    })
+    conditions
+        .iter()
+        .all(|condition| check_single_condition(node, source, condition, language_support))
 }
 
 /// Check a single AST condition
@@ -22,13 +22,15 @@ pub fn check_single_condition(
     condition: &Condition,
     language_support: &dyn LanguageSupport,
 ) -> bool {
-    match condition.condition_type.as_ref().map(|s| s.as_str()).unwrap_or("") {
+    match condition.condition_type.as_deref().unwrap_or("") {
         "has_argument" => check_has_argument_condition(node, source, condition, language_support),
         "in_context" => check_in_context_condition(node, condition),
         "has_parent" => check_has_parent_condition(node, condition),
         "not_literal" => check_not_literal_condition(node, condition, language_support),
         "has_ancestor" => check_has_ancestor_condition(node, condition),
-        "argument_not_sanitized" => check_argument_not_sanitized_condition(node, source, condition, language_support),
+        "argument_not_sanitized" => {
+            check_argument_not_sanitized_condition(node, source, condition, language_support)
+        }
         "has_sibling_pattern" => check_has_sibling_pattern_condition(node, source, condition),
         _ => false,
     }
@@ -49,7 +51,7 @@ pub fn check_has_argument_condition(
             }
             return false;
         }
-        
+
         // Otherwise check all arguments
         for i in 0..args_node.named_child_count() {
             if let Some(arg) = args_node.named_child(i as u32) {
@@ -69,31 +71,28 @@ pub fn check_argument_matches(
     condition: &Condition,
 ) -> bool {
     let arg_text = get_node_text(&arg, source);
-    
+
     // Check node type if specified
     if let Some(expected_type) = &condition.node_type {
         if arg.kind() != expected_type {
             return false;
         }
     }
-    
+
     // Check pattern(s)
     if let Some(pattern) = &condition.pattern {
         return match_pattern(pattern, &arg_text);
     }
-    
+
     if let Some(patterns) = &condition.patterns {
         return match_any_pattern(patterns, &arg_text);
     }
-    
+
     true
 }
 
 /// Check if node is in a specific context (e.g., not in comments/strings)
-pub fn check_in_context_condition(
-    node: &tree_sitter::Node,
-    condition: &Condition,
-) -> bool {
+pub fn check_in_context_condition(node: &tree_sitter::Node, condition: &Condition) -> bool {
     if let Some(not_in) = &condition.not_in {
         if let Some(parent) = node.parent() {
             if not_in.contains(&"comment".to_string()) && parent.kind() == "comment" {
@@ -108,10 +107,7 @@ pub fn check_in_context_condition(
 }
 
 /// Check if node has a specific parent type
-pub fn check_has_parent_condition(
-    node: &tree_sitter::Node,
-    condition: &Condition,
-) -> bool {
+pub fn check_has_parent_condition(node: &tree_sitter::Node, condition: &Condition) -> bool {
     if let Some(parent_type) = &condition.parent_type {
         if let Some(parent) = node.parent() {
             return parent.kind() == parent_type;
@@ -147,23 +143,21 @@ pub fn check_not_literal_condition(
 }
 
 /// Check if node has specific ancestor types
-pub fn check_has_ancestor_condition(
-    node: &tree_sitter::Node,
-    condition: &Condition,
-) -> bool {
+pub fn check_has_ancestor_condition(node: &tree_sitter::Node, condition: &Condition) -> bool {
     if let Some(ancestor_types) = &condition.ancestor_types {
         let mut current = node.parent();
         let mut depth = 0;
-        
+
         while let Some(parent) = current {
-            if depth > 20 {  // Limit search depth
+            if depth > 20 {
+                // Limit search depth
                 break;
             }
-            
+
             if ancestor_types.contains(&parent.kind().to_string()) {
                 return true;
             }
-            
+
             current = parent.parent();
             depth += 1;
         }
@@ -183,17 +177,17 @@ pub fn check_argument_not_sanitized_condition(
             for i in 0..args_node.named_child_count() {
                 if let Some(arg) = args_node.named_child(i as u32) {
                     let arg_text = get_node_text(&arg, source);
-                    
+
                     // Check if argument contains any sanitization patterns
                     for sanitizer in sanitizer_patterns {
                         if match_pattern(sanitizer, &arg_text) {
-                            return false;  // Found sanitization, so condition fails
+                            return false; // Found sanitization, so condition fails
                         }
                     }
                 }
             }
         }
-        return true;  // No sanitization found
+        return true; // No sanitization found
     }
     true
 }
@@ -224,4 +218,4 @@ pub fn check_has_sibling_pattern_condition(
         }
     }
     false
-} 
+}

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -1,12 +1,18 @@
 //! Core vulnerability scanning engine
-//! 
+//!
 //! This module provides the main vulnerability scanning functionality including:
 //! - Pattern-based vulnerability detection
 //! - Taint flow analysis across single and multiple files
+#![allow(
+    dead_code,
+    clippy::too_many_arguments,
+    clippy::large_enum_variant,
+    clippy::needless_range_loop
+)]
 //! - Progress tracking and result reporting
 
 use anyhow::Result;
-use indicatif::{ProgressBar, ProgressStyle, ProgressDrawTarget};
+use indicatif::{ProgressBar, ProgressDrawTarget, ProgressStyle};
 use memmap2::Mmap;
 use rayon::prelude::*;
 use std::cell::RefCell;
@@ -29,7 +35,7 @@ use crate::parser::LanguageParser;
 use crate::rules::Rules;
 
 // ============================================================================
-// CORE SCANNING ENGINE - Rule matching and vulnerability detection  
+// CORE SCANNING ENGINE - Rule matching and vulnerability detection
 // ============================================================================
 
 /// Deduplicates taint rules to prevent cartesian product problems
@@ -77,10 +83,14 @@ impl TaintRuleDeduplicator {
     }
 
     /// Get the specific rule for a source-sink combination
-    fn get_rule_for_combination(&self, source_pattern: &str, sink_pattern: &str) -> Option<&crate::rules::UnifiedRule> {
+    fn get_rule_for_combination(
+        &self,
+        source_pattern: &str,
+        sink_pattern: &str,
+    ) -> Option<&crate::rules::UnifiedRule> {
         let key = (source_pattern.to_string(), sink_pattern.to_string());
         let result = self.rule_mapping.get(&key);
-        
+
         if let Some(rule) = result {
             log::debug!("[RULE_SELECTION] Found rule for source='{}' + sink='{}' -> rule_id={:?}, finding_type={:?}", 
                 source_pattern, sink_pattern, rule.id, rule.finding_type);
@@ -94,7 +104,7 @@ impl TaintRuleDeduplicator {
                 log::debug!("   ... and {} more mappings", self.rule_mapping.len() - 5);
             }
         }
-        
+
         result
     }
 
@@ -103,7 +113,11 @@ impl TaintRuleDeduplicator {
         log::debug!("[SOURCE_MATCH] Checking text: '{}'", text);
         for pattern in &self.source_patterns {
             if CommonUtils::matches_taint_pattern(pattern, text) {
-                log::debug!("[SOURCE_MATCH] Matched pattern: '{}' in text: '{}'", pattern, text);
+                log::debug!(
+                    "[SOURCE_MATCH] Matched pattern: '{}' in text: '{}'",
+                    pattern,
+                    text
+                );
                 return Some(pattern.clone());
             }
         }
@@ -116,15 +130,17 @@ impl TaintRuleDeduplicator {
         log::debug!("[SINK_MATCH] Checking text: '{}'", text);
         for pattern in &self.sink_patterns {
             if CommonUtils::matches_taint_pattern(pattern, text) {
-                log::debug!("[SINK_MATCH] Matched pattern: '{}' in text: '{}'", pattern, text);
+                log::debug!(
+                    "[SINK_MATCH] Matched pattern: '{}' in text: '{}'",
+                    pattern,
+                    text
+                );
                 return Some(pattern.clone());
             }
         }
         log::debug!("[SINK_MATCH] No patterns matched for text: '{}'", text);
         None
     }
-
-
 }
 
 pub struct ScanningLogic;
@@ -154,7 +170,12 @@ impl ScanningLogic {
         }
 
         if let Some(conditions) = &rule.conditions {
-            if !crate::scanner::conditions::check_ast_conditions(conditions, node, source, language_support) {
+            if !crate::scanner::conditions::check_ast_conditions(
+                conditions,
+                node,
+                source,
+                language_support,
+            ) {
                 return None;
             }
         }
@@ -166,14 +187,20 @@ impl ScanningLogic {
             }
         }
 
-        if Self::should_check_injection_patterns(rule) {
-            if !Self::has_injection_pattern(node, source, language_support) {
-                return None;
-            }
+        if Self::should_check_injection_patterns(rule)
+            && !Self::has_injection_pattern(node, source, language_support)
+        {
+            return None;
         }
 
         let mut finding = Self::create_finding_with_rule(
-            filepath, node, func_name, &rule.get_finding_type(), source, &rule.get_severity(), rule
+            filepath,
+            node,
+            func_name,
+            rule.get_finding_type(),
+            source,
+            rule.get_severity(),
+            rule,
         );
 
         Self::add_finding_metadata(&mut finding, rule, node);
@@ -182,7 +209,9 @@ impl ScanningLogic {
             finding.source_info = Some(source_info);
         }
 
-        if let Some(sink_info) = Self::detect_sink_pattern(node, source, func_name, &rule.get_finding_type()) {
+        if let Some(sink_info) =
+            Self::detect_sink_pattern(node, source, func_name, rule.get_finding_type())
+        {
             finding.sink_info = Some(sink_info);
         }
 
@@ -191,13 +220,33 @@ impl ScanningLogic {
 
     fn rule_needs_full_context(rule: &crate::rules::UnifiedRule) -> bool {
         const CONTEXT_INDICATORS: &[&str] = &[
-            "%", "+", "DROP", "DELETE", "UNION", "innerHTML", "outerHTML", "location", 
-            "postMessage", "localStorage", "sessionStorage", "console.log", "console.debug",
-            "fetch", "axios", "password", "token", "secret", "key", "http://", "="
+            "%",
+            "+",
+            "DROP",
+            "DELETE",
+            "UNION",
+            "innerHTML",
+            "outerHTML",
+            "location",
+            "postMessage",
+            "localStorage",
+            "sessionStorage",
+            "console.log",
+            "console.debug",
+            "fetch",
+            "axios",
+            "password",
+            "token",
+            "secret",
+            "key",
+            "http://",
+            "=",
         ];
 
         let check_pattern = |pattern: &str| {
-            CONTEXT_INDICATORS.iter().any(|indicator| pattern.contains(indicator))
+            CONTEXT_INDICATORS
+                .iter()
+                .any(|indicator| pattern.contains(indicator))
         };
 
         if let Some(patterns) = &rule.patterns {
@@ -222,12 +271,15 @@ impl ScanningLogic {
         let mut findings = Vec::new();
         let mut processed_lines = std::collections::HashSet::new();
 
-        let call_nodes: Vec<tree_sitter::Node> = crate::parser::traverse_calls_only(tree.root_node(), language_support).collect();
+        let call_nodes: Vec<tree_sitter::Node> =
+            crate::parser::traverse_calls_only(tree.root_node(), language_support).collect();
 
         for node in call_nodes.iter() {
             if let Some(func_name) = language_support.get_function_name(node, source) {
-                let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> = rules.iter().enumerate()
-                    .filter(|(_, rule)| Self::rule_might_match_function(*rule, &func_name))
+                let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> = rules
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, rule)| Self::rule_might_match_function(rule, func_name))
                     .map(|(idx, rule)| (idx, *rule))
                     .collect();
 
@@ -237,10 +289,14 @@ impl ScanningLogic {
                         node,
                         source,
                         filepath,
-                        &func_name,
+                        func_name,
                         language_support,
                     ) {
-                        let line_key = (finding.line, finding.function.clone(), finding.finding_type.clone());
+                        let line_key = (
+                            finding.line,
+                            finding.function.clone(),
+                            finding.finding_type.clone(),
+                        );
                         if !processed_lines.contains(&line_key) {
                             processed_lines.insert(line_key);
                             findings.push(finding);
@@ -250,9 +306,20 @@ impl ScanningLogic {
             }
         }
 
-        if language_support.name() == "javascript" || language_support.name() == "typescript" || language_support.name() == "tsx"
-            || language_support.name() == "php" {
-            Self::scan_assignments(tree.root_node(), source, filepath, rules, language_support, &mut findings, &mut processed_lines);
+        if language_support.name() == "javascript"
+            || language_support.name() == "typescript"
+            || language_support.name() == "tsx"
+            || language_support.name() == "php"
+        {
+            Self::scan_assignments(
+                tree.root_node(),
+                source,
+                filepath,
+                rules,
+                language_support,
+                &mut findings,
+                &mut processed_lines,
+            );
         }
 
         findings
@@ -267,13 +334,22 @@ impl ScanningLogic {
         findings: &mut Vec<crate::models::Finding>,
         processed_lines: &mut std::collections::HashSet<(usize, String, String)>,
     ) {
-        let assignment_rules: Vec<&crate::rules::UnifiedRule> = rules.iter()
+        let assignment_rules: Vec<&crate::rules::UnifiedRule> = rules
+            .iter()
             .filter(|rule| Self::rule_has_assignment_patterns(rule))
             .copied()
             .collect();
 
         if !assignment_rules.is_empty() {
-            Self::scan_node_for_assignments(node, source, filepath, &assignment_rules, language_support, findings, processed_lines);
+            Self::scan_node_for_assignments(
+                node,
+                source,
+                filepath,
+                &assignment_rules,
+                language_support,
+                findings,
+                processed_lines,
+            );
         }
     }
 
@@ -286,21 +362,52 @@ impl ScanningLogic {
         findings: &mut Vec<crate::models::Finding>,
         processed_lines: &mut std::collections::HashSet<(usize, String, String)>,
     ) {
-        if matches!(node.kind(), "assignment_expression" | "expression_statement" | "member_expression") {
+        // Python represents assignments as `assignment` / `augmented_assignment`
+        // nodes; matching them directly avoids the comparison-operator heuristic
+        // below (which would reject SQL strings containing `>=` / `<=`).
+        let is_definite_assignment = matches!(node.kind(), "assignment" | "augmented_assignment");
+
+        if is_definite_assignment
+            || matches!(
+                node.kind(),
+                "assignment_expression" | "expression_statement" | "member_expression"
+            )
+        {
             let node_text = crate::parser::get_node_text(&node, source);
 
             // Check for direct assignment patterns (e.g., element.innerHTML = value)
-            if CommonUtils::is_valid_assignment_text(&node_text) || Self::is_dom_assignment(&node_text) {
-                let assignment_target = CommonUtils::extract_variable_from_assignment(&node_text, true)
-                    .unwrap_or_else(|| Self::extract_assignment_target(&node_text));
+            if is_definite_assignment
+                || CommonUtils::is_valid_assignment_text(&node_text)
+                || Self::is_dom_assignment(&node_text)
+            {
+                let assignment_target =
+                    CommonUtils::extract_variable_from_assignment(&node_text, true)
+                        .unwrap_or_else(|| Self::extract_assignment_target(&node_text));
 
                 for rule in assignment_rules {
                     if Self::rule_might_match_assignment(rule, &node_text) {
                         if let Some(finding) = Self::check_rule_against_node(
-                            rule, &node, source, filepath, &assignment_target, language_support,
+                            rule,
+                            &node,
+                            source,
+                            filepath,
+                            &assignment_target,
+                            language_support,
                         ) {
-                            let line_key = (finding.line, finding.function.clone(), finding.finding_type.clone());
-                            if !processed_lines.contains(&line_key) {
+                            let line_key = (
+                                finding.line,
+                                finding.function.clone(),
+                                finding.finding_type.clone(),
+                            );
+                            // A call-shaped sink (e.g. subprocess.Popen(shell=True)) can be
+                            // matched both by the call pass and here via its `=`-bearing
+                            // pattern; the call pass records a different `function`, so also
+                            // guard on (line, finding_type) to avoid a duplicate finding.
+                            let already = processed_lines.contains(&line_key)
+                                || findings.iter().any(|f| {
+                                    f.line == finding.line && f.finding_type == finding.finding_type
+                                });
+                            if !already {
                                 processed_lines.insert(line_key);
                                 findings.push(finding);
                             }
@@ -313,7 +420,15 @@ impl ScanningLogic {
         let mut cursor = node.walk();
         if cursor.goto_first_child() {
             loop {
-                Self::scan_node_for_assignments(cursor.node(), source, filepath, assignment_rules, language_support, findings, processed_lines);
+                Self::scan_node_for_assignments(
+                    cursor.node(),
+                    source,
+                    filepath,
+                    assignment_rules,
+                    language_support,
+                    findings,
+                    processed_lines,
+                );
                 if !cursor.goto_next_sibling() {
                     break;
                 }
@@ -323,19 +438,31 @@ impl ScanningLogic {
 
     fn rule_has_assignment_patterns(rule: &crate::rules::UnifiedRule) -> bool {
         const ASSIGNMENT_INDICATORS: &[&str] = &[
-            "innerHTML", "outerHTML", "location", "localStorage", 
-            "sessionStorage", "__proto__", "=", "prototype",
-            "src", "href", "textContent", "setAttribute",
-            "document.write", "insertAdjacentHTML"
+            "innerHTML",
+            "outerHTML",
+            "location",
+            "localStorage",
+            "sessionStorage",
+            "__proto__",
+            "=",
+            "prototype",
+            "src",
+            "href",
+            "textContent",
+            "setAttribute",
+            "document.write",
+            "insertAdjacentHTML",
         ];
 
         let check_pattern = |pattern: &str| {
-            ASSIGNMENT_INDICATORS.iter().any(|indicator| pattern.contains(indicator))
+            ASSIGNMENT_INDICATORS
+                .iter()
+                .any(|indicator| pattern.contains(indicator))
         };
 
         // Also check if this is a taint rule with sinks
-        let has_taint_sinks = rule.sinks.as_ref().map_or(false, |sinks| !sinks.is_empty());
-        
+        let has_taint_sinks = rule.sinks.as_ref().is_some_and(|sinks| !sinks.is_empty());
+
         if let Some(patterns) = &rule.patterns {
             patterns.iter().any(|p| check_pattern(p)) || has_taint_sinks
         } else if let Some(pattern) = &rule.pattern {
@@ -347,14 +474,24 @@ impl ScanningLogic {
 
     fn rule_might_match_assignment(rule: &crate::rules::UnifiedRule, node_text: &str) -> bool {
         const ASSIGNMENT_INDICATORS: &[&str] = &[
-            "innerHTML", "outerHTML", "location", "localStorage", 
-            "sessionStorage", "__proto__", "=", "src", "href", 
-            "textContent", "setAttribute"
+            "innerHTML",
+            "outerHTML",
+            "location",
+            "localStorage",
+            "sessionStorage",
+            "__proto__",
+            "=",
+            "src",
+            "href",
+            "textContent",
+            "setAttribute",
         ];
 
         let check_and_match = |pattern: &str| {
-            ASSIGNMENT_INDICATORS.iter().any(|indicator| pattern.contains(indicator)) &&
-            CommonUtils::matches_rule_pattern(pattern, node_text)
+            ASSIGNMENT_INDICATORS
+                .iter()
+                .any(|indicator| pattern.contains(indicator))
+                && CommonUtils::matches_rule_pattern(pattern, node_text)
         };
 
         // Check if this is a taint rule with sinks that match the assignment
@@ -378,14 +515,22 @@ impl ScanningLogic {
     /// Check if the text represents a DOM assignment (innerHTML, outerHTML, etc.)
     fn is_dom_assignment(text: &str) -> bool {
         const DOM_ASSIGNMENT_PATTERNS: &[&str] = &[
-            ".innerHTML", ".outerHTML", ".textContent", ".innerText",
-            ".src", ".href", ".setAttribute", ".insertAdjacentHTML"
+            ".innerHTML",
+            ".outerHTML",
+            ".textContent",
+            ".innerText",
+            ".src",
+            ".href",
+            ".setAttribute",
+            ".insertAdjacentHTML",
         ];
-        
+
         // Check for direct assignment or TypeScript casting assignment
         let has_assignment = text.contains('=') && !text.contains("==") && !text.contains("!=");
-        let has_dom_property = DOM_ASSIGNMENT_PATTERNS.iter().any(|pattern| text.contains(pattern));
-        
+        let has_dom_property = DOM_ASSIGNMENT_PATTERNS
+            .iter()
+            .any(|pattern| text.contains(pattern));
+
         has_assignment && has_dom_property
     }
 
@@ -404,8 +549,6 @@ impl ScanningLogic {
         }
     }
 
-
-
     fn detect_source_pattern(
         node: &tree_sitter::Node,
         source: &[u8],
@@ -414,14 +557,25 @@ impl ScanningLogic {
         let node_text = crate::parser::get_node_text(node, source);
 
         const SOURCE_PATTERNS: &[(&str, &str)] = &[
-            ("request", "HTTP Request"), ("input", "User Input"), ("sys.argv", "Command Line"),
-            ("environ", "Environment Variable"), ("cookie", "HTTP Cookie"), ("header", "HTTP Header"),
-            ("form", "Form Data"), ("query", "Query Parameter"), ("file", "File Input"),
-            ("socket", "Network Socket"), ("subprocess", "External Process"), ("json.loads", "JSON Parsing"),
-            ("pickle.loads", "Pickle Deserialization"), ("eval", "Dynamic Evaluation"), ("exec", "Dynamic Execution")
+            ("request", "HTTP Request"),
+            ("input", "User Input"),
+            ("sys.argv", "Command Line"),
+            ("environ", "Environment Variable"),
+            ("cookie", "HTTP Cookie"),
+            ("header", "HTTP Header"),
+            ("form", "Form Data"),
+            ("query", "Query Parameter"),
+            ("file", "File Input"),
+            ("socket", "Network Socket"),
+            ("subprocess", "External Process"),
+            ("json.loads", "JSON Parsing"),
+            ("pickle.loads", "Pickle Deserialization"),
+            ("eval", "Dynamic Evaluation"),
+            ("exec", "Dynamic Execution"),
         ];
 
-        SOURCE_PATTERNS.iter()
+        SOURCE_PATTERNS
+            .iter()
             .find(|(pattern, _)| node_text.contains(pattern))
             .map(|(_, source_type)| crate::models::SourceInfo {
                 source_type: source_type.to_string(),
@@ -455,17 +609,18 @@ impl ScanningLogic {
         })
     }
 
-
-
-    fn should_apply_rule_with_sanitization(rule: &crate::rules::UnifiedRule, node_text: &str) -> bool {
+    fn should_apply_rule_with_sanitization(
+        rule: &crate::rules::UnifiedRule,
+        node_text: &str,
+    ) -> bool {
         let finding_type = rule.get_finding_type().to_lowercase();
 
         if finding_type.contains("xss") || finding_type.contains("dom") {
             !crate::scanner::utils::AstUtils::check_for_sanitization(node_text, "javascript")
         } else if finding_type.contains("prototype") {
-            node_text.contains("__proto__") || 
-            node_text.contains("['__proto__']") || 
-            node_text.contains("[\"__proto__\"]")
+            node_text.contains("__proto__")
+                || node_text.contains("['__proto__']")
+                || node_text.contains("[\"__proto__\"]")
         } else {
             true
         }
@@ -501,18 +656,32 @@ impl ScanningLogic {
 
         // Check specific pattern matches
         const EXACT_MATCHES: &[&str] = &[
-            "eval", "Function", "setTimeout", "setInterval", "fetch", 
-            "Math.random", "RegExp", "import", "require"
+            "eval",
+            "Function",
+            "setTimeout",
+            "setInterval",
+            "fetch",
+            "Math.random",
+            "RegExp",
+            "import",
+            "require",
         ];
 
         const CONTAINS_MATCHES: &[&str] = &[
-            "document.write", "console.", "localStorage", "sessionStorage", "postMessage", "axios"
+            "document.write",
+            "console.",
+            "localStorage",
+            "sessionStorage",
+            "postMessage",
+            "axios",
         ];
 
         if EXACT_MATCHES.contains(&pattern) {
             func_name == pattern
         } else if CONTAINS_MATCHES.iter().any(|p| pattern.contains(p)) {
-            CONTAINS_MATCHES.iter().any(|p| pattern.contains(p) && func_name.contains(p))
+            CONTAINS_MATCHES
+                .iter()
+                .any(|p| pattern.contains(p) && func_name.contains(p))
         } else {
             false
         }
@@ -520,7 +689,10 @@ impl ScanningLogic {
 
     // Public utility methods for rule access
     pub fn has_matching_rules(rules: &crate::rules::Rules, func_name: &str) -> bool {
-        rules.get_search_rules().iter().any(|rule| crate::rules::rule_matches_pattern_unified(rule, func_name))
+        rules
+            .get_search_rules()
+            .iter()
+            .any(|rule| crate::rules::rule_matches_pattern_unified(rule, func_name))
     }
 
     pub fn get_all_search_rules(rules: &crate::rules::Rules) -> Vec<&crate::rules::UnifiedRule> {
@@ -545,8 +717,9 @@ impl ScanningLogic {
             for i in 0..args_node.named_child_count() {
                 if let Some(arg) = args_node.named_child(i as u32) {
                     let arg_text = crate::parser::get_node_text(&arg, source);
-                    if !crate::rules::is_literal_node(&arg) && 
-                       crate::rules::check_for_injection_pattern(&arg_text, language_support) {
+                    if !crate::rules::is_literal_node(&arg)
+                        && crate::rules::check_for_injection_pattern(&arg_text, language_support)
+                    {
                         return true;
                     }
                 }
@@ -555,22 +728,25 @@ impl ScanningLogic {
         false
     }
 
-    pub fn add_finding_metadata(finding: &mut crate::models::Finding, rule: &crate::rules::UnifiedRule, _node: &tree_sitter::Node) {
+    pub fn add_finding_metadata(
+        finding: &mut crate::models::Finding,
+        rule: &crate::rules::UnifiedRule,
+        _node: &tree_sitter::Node,
+    ) {
         finding.severity = rule.get_severity().to_string();
         finding.confidence = rule.get_confidence().to_string();
         finding.description = rule.description.clone();
         finding.tags = rule.tags.clone();
-        
+
         // Use CWE ID directly from rule, with fallback to tags for backward compatibility
-        finding.cwe_id = rule.cwe_id.clone()
-            .or_else(|| {
-                // Fallback: extract from tags if rule doesn't have cwe_id field
-                if let Some(ref tags) = rule.tags {
-                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
-                } else {
-                    None
-                }
-            });
+        finding.cwe_id = rule.cwe_id.clone().or_else(|| {
+            // Fallback: extract from tags if rule doesn't have cwe_id field
+            if let Some(ref tags) = rule.tags {
+                crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+            } else {
+                None
+            }
+        });
     }
 
     pub fn create_finding(
@@ -583,7 +759,7 @@ impl ScanningLogic {
     ) -> crate::models::Finding {
         // Try to find the most specific vulnerable line within the node
         let vulnerable_line = Self::find_vulnerable_line_in_node(node, source, finding_type, None);
-        
+
         crate::models::Finding {
             file: file.to_string(),
             line: vulnerable_line,
@@ -614,8 +790,9 @@ impl ScanningLogic {
         rule: &crate::rules::UnifiedRule,
     ) -> crate::models::Finding {
         // Try to find the most specific vulnerable line within the node using rule sink patterns
-        let vulnerable_line = Self::find_vulnerable_line_in_node(node, source, finding_type, Some(rule));
-        
+        let vulnerable_line =
+            Self::find_vulnerable_line_in_node(node, source, finding_type, Some(rule));
+
         crate::models::Finding {
             file: file.to_string(),
             line: vulnerable_line,
@@ -646,7 +823,7 @@ impl ScanningLogic {
         let node_text = crate::parser::get_node_text(node, source);
         let lines: Vec<&str> = node_text.lines().collect();
         let start_line = node.start_position().row + 1;
-        
+
         // Get sink patterns from the rule if available
         let sink_patterns = if let Some(rule) = rule {
             if let Some(ref sinks) = rule.sinks {
@@ -665,23 +842,34 @@ impl ScanningLogic {
             // Fallback to hardcoded patterns if no rule provided such as for simple search rule cases.
             match finding_type.to_lowercase().as_str() {
                 s if s.contains("xss") || s.contains("cross-site") => vec![
-                    ".innerHTML".to_string(), ".outerHTML".to_string(), 
-                    "document.write".to_string(), ".insertAdjacentHTML".to_string()
+                    ".innerHTML".to_string(),
+                    ".outerHTML".to_string(),
+                    "document.write".to_string(),
+                    ".insertAdjacentHTML".to_string(),
                 ],
                 s if s.contains("redirect") || s.contains("open redirect") => vec![
-                    "window.location.href =".to_string(), "location.href =".to_string(), 
-                    "location.assign(".to_string(), "location.replace(".to_string(), 
-                    ".href =".to_string(), "window.open(".to_string(), ".setState(".to_string()
+                    "window.location.href =".to_string(),
+                    "location.href =".to_string(),
+                    "location.assign(".to_string(),
+                    "location.replace(".to_string(),
+                    ".href =".to_string(),
+                    "window.open(".to_string(),
+                    ".setState(".to_string(),
                 ],
                 s if s.contains("injection") || s.contains("command") => vec![
-                    "eval(".to_string(), "system(".to_string(), "exec(".to_string(), 
-                    "popen(".to_string(), "subprocess".to_string()
+                    "eval(".to_string(),
+                    "system(".to_string(),
+                    "exec(".to_string(),
+                    "popen(".to_string(),
+                    "subprocess".to_string(),
                 ],
                 s if s.contains("sql") => vec![
-                    "execute(".to_string(), "query(".to_string(), 
-                    "cursor.execute".to_string(), "db.query".to_string()
+                    "execute(".to_string(),
+                    "query(".to_string(),
+                    "cursor.execute".to_string(),
+                    "db.query".to_string(),
                 ],
-                _ => vec![]
+                _ => vec![],
             }
         };
         // Search for the actual vulnerable line within the node
@@ -700,10 +888,17 @@ impl ScanningLogic {
         }
         // If no specific sink pattern found, look for assignment operations (common vulnerability pattern)
         for (line_offset, line) in lines.iter().enumerate() {
-            if line.contains('=') && !line.trim().starts_with("//") && !line.trim().starts_with("/*") {
+            if line.contains('=')
+                && !line.trim().starts_with("//")
+                && !line.trim().starts_with("/*")
+            {
                 // Skip function declarations and variable declarations without assignment
-                if !line.contains("function") && !line.contains("def ") && 
-                   !line.contains("const ") && !line.contains("let ") && !line.contains("var ") {
+                if !line.contains("function")
+                    && !line.contains("def ")
+                    && !line.contains("const ")
+                    && !line.contains("let ")
+                    && !line.contains("var ")
+                {
                     return start_line + line_offset;
                 }
             }
@@ -718,13 +913,16 @@ impl ScanningLogic {
         source: &[u8],
         tree: &tree_sitter::Tree,
         taint_rules: &[&crate::rules::UnifiedRule],
-        language_support: &dyn crate::language::LanguageSupport,
+        _language_support: &dyn crate::language::LanguageSupport,
     ) -> Vec<crate::models::Finding> {
         let mut findings = Vec::new();
 
         // Filter out rules that don't apply to this file (same as search rules)
-        let applicable_rules: Vec<&crate::rules::UnifiedRule> = taint_rules.iter()
-            .filter(|rule| crate::scanner::utils::rule_applies_to_file(rule.file_types.as_ref(), filepath))
+        let applicable_rules: Vec<&crate::rules::UnifiedRule> = taint_rules
+            .iter()
+            .filter(|rule| {
+                crate::scanner::utils::rule_applies_to_file(rule.file_types.as_ref(), filepath)
+            })
             .copied()
             .collect();
 
@@ -743,8 +941,6 @@ impl ScanningLogic {
         let mut all_nodes = Vec::new();
         Self::collect_all_relevant_nodes(tree.root_node(), &mut all_nodes, None);
 
-
-
         // Phase 1: Track variable assignments from taint sources
         for node in all_nodes.iter() {
             let node_text = crate::parser::get_node_text(node, source);
@@ -752,18 +948,36 @@ impl ScanningLogic {
             let func_name = crate::scanner::utils::AstUtils::get_function_context(node, source);
 
             // Check for function definitions and mark parameters as potential taint sources
-            log::debug!("[FUNCTION_CHECK] Checking node kind '{}' for function definitions", node.kind());
-            if matches!(node.kind(), 
-                "function_definition" | "function_declaration" | "method_definition" |
-                "arrow_function" | "function_expression" | "generator_function" |
-                "async_function" | "constructor_definition") {
-                log::debug!("[FUNCTION_PARAM_ANALYSIS] Found function definition: {}", node.kind());
+            log::debug!(
+                "[FUNCTION_CHECK] Checking node kind '{}' for function definitions",
+                node.kind()
+            );
+            if matches!(
+                node.kind(),
+                "function_definition"
+                    | "function_declaration"
+                    | "method_definition"
+                    | "arrow_function"
+                    | "function_expression"
+                    | "generator_function"
+                    | "async_function"
+                    | "constructor_definition"
+            ) {
+                log::debug!(
+                    "[FUNCTION_PARAM_ANALYSIS] Found function definition: {}",
+                    node.kind()
+                );
                 if let Some(params) = Self::extract_function_parameters(node, source) {
-                    log::debug!("[FUNCTION_PARAM_ANALYSIS] Extracted parameters: {:?}", params);
+                    log::debug!(
+                        "[FUNCTION_PARAM_ANALYSIS] Extracted parameters: {:?}",
+                        params
+                    );
                     for param in params {
                         // Check if parameter name matches any taint source pattern
                         log::debug!("[FUNCTION_PARAM_ANALYSIS] Checking parameter '{}' against source patterns", param);
-                        if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(&param) {
+                        if let Some(source_pattern) =
+                            rule_deduplicator.matches_source_pattern(&param)
+                        {
                             log::debug!("[FUNCTION_PARAM_ANALYSIS] Function parameter '{}' matches source pattern '{}'", param, source_pattern);
                             flow_tracker.record_tainted_variable(
                                 param.clone(),
@@ -772,7 +986,7 @@ impl ScanningLogic {
                                     source_pattern,
                                     source_function: func_name.clone(),
                                     assignment_code: format!("function parameter: {}", param),
-                                }
+                                },
                             );
                         } else {
                             log::debug!("[FUNCTION_PARAM_ANALYSIS] Function parameter '{}' does not match any source pattern", param);
@@ -785,24 +999,28 @@ impl ScanningLogic {
 
             // Look for assignment patterns: var = source_call()
             if CommonUtils::is_valid_assignment_text(&node_text) {
-                if let Some(var_name) = CommonUtils::extract_variable_from_assignment(&node_text, false) {
+                if let Some(var_name) =
+                    CommonUtils::extract_variable_from_assignment(&node_text, false)
+                {
                     // Extract the right side of assignment for source matching
                     if let Some(eq_pos) = node_text.find('=') {
                         let assignment_value = &node_text[eq_pos + 1..].trim();
                         log::debug!("[ASSIGNMENT_ANALYSIS] Processing assignment '{}' -> checking value '{}'", node_text, assignment_value);
-                        
+
                         // Check if the assignment value matches any taint source
-                        if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(assignment_value) {
+                        if let Some(source_pattern) =
+                            rule_deduplicator.matches_source_pattern(assignment_value)
+                        {
                             log::debug!("[ASSIGNMENT_ANALYSIS] Assignment value '{}' matches source pattern '{}'", assignment_value, source_pattern);
-                                                    flow_tracker.record_tainted_variable(
-                            var_name,
-                            TaintVariableInfo {
-                                source_line: line,
-                                source_pattern,
-                                source_function: func_name.clone(),
-                                assignment_code: node_text.clone(),
-                            }
-                        );
+                            flow_tracker.record_tainted_variable(
+                                var_name,
+                                TaintVariableInfo {
+                                    source_line: line,
+                                    source_pattern,
+                                    source_function: func_name.clone(),
+                                    assignment_code: node_text.clone(),
+                                },
+                            );
                         } else {
                             log::debug!("[ASSIGNMENT_ANALYSIS] Assignment value '{}' does not match any source patterns", assignment_value);
                         }
@@ -812,21 +1030,40 @@ impl ScanningLogic {
 
             // Check for taint propagation through operations
             if let Some((target_var, dependent_vars)) = Self::detect_taint_propagation(&node_text) {
-                log::debug!("[TAINT_PROPAGATION] Detected propagation: '{}' depends on {:?} in '{}'", target_var, dependent_vars, node_text);
+                log::debug!(
+                    "[TAINT_PROPAGATION] Detected propagation: '{}' depends on {:?} in '{}'",
+                    target_var,
+                    dependent_vars,
+                    node_text
+                );
                 flow_tracker.record_taint_propagation(&target_var, &dependent_vars);
-                
+
                 // Check if any dependent variables are tainted and propagate to target
                 for dep_var in &dependent_vars {
-                    if let Some(taint_info) = flow_tracker.is_variable_tainted(dep_var, &func_name).cloned() {
-                        log::debug!("[TAINT_PROPAGATION] Propagating taint from '{}' to '{}' ({})", dep_var, target_var, taint_info.source_pattern);
-                        
+                    if let Some(taint_info) = flow_tracker
+                        .is_variable_tainted(dep_var, &func_name)
+                        .cloned()
+                    {
+                        log::debug!(
+                            "[TAINT_PROPAGATION] Propagating taint from '{}' to '{}' ({})",
+                            dep_var,
+                            target_var,
+                            taint_info.source_pattern
+                        );
+
                         // Mark target variable as tainted (inheriting from the dependent variable)
-                        flow_tracker.record_tainted_variable(target_var.clone(), TaintVariableInfo {
-                            source_line: taint_info.source_line,
-                            source_pattern: taint_info.source_pattern.clone(),
-                            source_function: taint_info.source_function.clone(),
-                            assignment_code: format!("Propagated from {} via: {}", dep_var, node_text),
-                        });
+                        flow_tracker.record_tainted_variable(
+                            target_var.clone(),
+                            TaintVariableInfo {
+                                source_line: taint_info.source_line,
+                                source_pattern: taint_info.source_pattern.clone(),
+                                source_function: taint_info.source_function.clone(),
+                                assignment_code: format!(
+                                    "Propagated from {} via: {}",
+                                    dep_var, node_text
+                                ),
+                            },
+                        );
                         break; // Only need one tainted dependency to taint the target
                     }
                 }
@@ -841,36 +1078,61 @@ impl ScanningLogic {
 
             // Check if this node matches any sink pattern
             if let Some(sink_pattern) = rule_deduplicator.matches_sink_pattern(&node_text) {
-                log::debug!("[SINK_ANALYSIS] Found sink '{}' with pattern '{}' at line {}", node_text, sink_pattern, line);
+                log::debug!(
+                    "[SINK_ANALYSIS] Found sink '{}' with pattern '{}' at line {}",
+                    node_text,
+                    sink_pattern,
+                    line
+                );
                 // Extract ALL variables used in this sink (enhanced extraction)
                 let used_variables = CommonUtils::extract_all_variables(&node_text);
-                log::debug!("[SINK_ANALYSIS] Extracted variables from sink: {:?}", used_variables);
+                log::debug!(
+                    "[SINK_ANALYSIS] Extracted variables from sink: {:?}",
+                    used_variables
+                );
 
                 // Check if ANY of these variables are tainted
                 for used_variable in used_variables.clone() {
-                    if let Some(taint_info) = flow_tracker.is_variable_tainted(&used_variable, &func_name).cloned() {
+                    if let Some(taint_info) = flow_tracker
+                        .is_variable_tainted(&used_variable, &func_name)
+                        .cloned()
+                    {
                         // Check if we have a legitimate rule for this source-sink combination
-                        if let Some(rule) = rule_deduplicator.get_rule_for_combination(&taint_info.source_pattern, &sink_pattern) {
+                        if let Some(rule) = rule_deduplicator
+                            .get_rule_for_combination(&taint_info.source_pattern, &sink_pattern)
+                        {
                             // Check if the sink expression contains sanitizers before creating finding
                             if let Some(sanitizers) = &rule.sanitizers {
                                 let mut is_sanitized = false;
                                 for sanitizer in sanitizers {
                                     if node_text.contains(sanitizer) {
-                                        log::debug!("[SANITIZER_CHECK] Found sanitizer '{}' in sink: '{}'", sanitizer, node_text);
+                                        log::debug!(
+                                            "[SANITIZER_CHECK] Found sanitizer '{}' in sink: '{}'",
+                                            sanitizer,
+                                            node_text
+                                        );
                                         is_sanitized = true;
                                         break;
                                     }
                                 }
-                                
+
                                 if is_sanitized {
                                     log::debug!("[SANITIZER_CHECK] Skipping finding due to sanitization: '{}'", node_text);
                                     continue; // Skip this finding as it's sanitized
                                 }
                             }
-                            
+
                             // Ensure we haven't already processed this exact flow
-                            if !flow_tracker.is_flow_processed(line, &taint_info.source_pattern, &sink_pattern) {
-                                flow_tracker.mark_flow_processed(line, &taint_info.source_pattern, &sink_pattern);
+                            if !flow_tracker.is_flow_processed(
+                                line,
+                                &taint_info.source_pattern,
+                                &sink_pattern,
+                            ) {
+                                flow_tracker.mark_flow_processed(
+                                    line,
+                                    &taint_info.source_pattern,
+                                    &sink_pattern,
+                                );
 
                                 // Create legitimate taint finding
                                 let taint_source = crate::models::TaintSource {
@@ -893,7 +1155,13 @@ impl ScanningLogic {
                                     branch_id: None,
                                 };
 
-                                findings.push(Self::create_taint_finding(&taint_source, &taint_sink, rule, tree, source));
+                                findings.push(Self::create_taint_finding(
+                                    &taint_source,
+                                    &taint_sink,
+                                    rule,
+                                    tree,
+                                    source,
+                                ));
                             }
                         }
                     }
@@ -903,57 +1171,71 @@ impl ScanningLogic {
         findings
     }
 
-
-
     /// Detect taint propagation in expressions
     fn detect_taint_propagation(node_text: &str) -> Option<(String, Vec<String>)> {
-        log::debug!("[PROPAGATION_CHECK] Checking for taint propagation in: '{}'", node_text);
-        
+        log::debug!(
+            "[PROPAGATION_CHECK] Checking for taint propagation in: '{}'",
+            node_text
+        );
+
         // Check for assignment-based propagation (e.g., query = f"SELECT {username}")
         if node_text.contains('=') && !node_text.contains("==") {
             if let Some(eq_pos) = node_text.find('=') {
                 let left_side = node_text[..eq_pos].trim();
                 let right_side = node_text[eq_pos + 1..].trim();
-                
+
                 log::debug!("   Found assignment: '{}' = '{}'", left_side, right_side);
-                
+
                 // Check if right side has F-string propagation
                 if right_side.contains('{') && right_side.contains('}') {
                     log::debug!("   Right side contains f-string braces");
                     let mut dependent_vars = CommonUtils::extract_f_string_variables(right_side);
-                    
+
                     // Also check for JavaScript/TypeScript template literals
                     if right_side.contains("${") {
                         log::debug!("   Right side contains template literal interpolation");
-                        dependent_vars.extend(CommonUtils::extract_template_literal_variables(right_side));
+                        dependent_vars
+                            .extend(CommonUtils::extract_template_literal_variables(right_side));
                     }
-                    
-                    log::debug!("   Extracted dependent_vars from interpolation: {:?}", dependent_vars);
-                    if !dependent_vars.is_empty() && CommonUtils::is_valid_variable_name(left_side) {
+
+                    log::debug!(
+                        "   Extracted dependent_vars from interpolation: {:?}",
+                        dependent_vars
+                    );
+                    if !dependent_vars.is_empty() && CommonUtils::is_valid_variable_name(left_side)
+                    {
                         log::debug!("[PROPAGATION_CHECK] Template/F-string assignment propagation detected: '{}' depends on {:?}", left_side, dependent_vars);
                         return Some((left_side.to_string(), dependent_vars));
                     }
                 }
-                
+
                 // Check if right side has format propagation
                 if right_side.contains(".format(") {
                     log::debug!("   Right side contains .format( pattern");
                     let dependent_vars = CommonUtils::extract_format_variables(right_side);
-                    log::debug!("   Extracted dependent_vars from format: {:?}", dependent_vars);
-                    if !dependent_vars.is_empty() && CommonUtils::is_valid_variable_name(left_side) {
+                    log::debug!(
+                        "   Extracted dependent_vars from format: {:?}",
+                        dependent_vars
+                    );
+                    if !dependent_vars.is_empty() && CommonUtils::is_valid_variable_name(left_side)
+                    {
                         log::debug!("[PROPAGATION_CHECK] Format assignment propagation detected: '{}' depends on {:?}", left_side, dependent_vars);
                         return Some((left_side.to_string(), dependent_vars));
                     }
                 }
             }
         }
-        
+
         // Check for simple F-string propagation (non-assignment)
         if node_text.contains('{') && node_text.contains('}') {
             log::debug!("   Found f-string pattern with braces (non-assignment)");
             if let Some(source_var) = Self::extract_direct_variable(node_text) {
                 let dependent_vars = CommonUtils::extract_f_string_variables(node_text);
-                log::debug!("   Extracted source_var: '{}', dependent_vars: {:?}", source_var, dependent_vars);
+                log::debug!(
+                    "   Extracted source_var: '{}', dependent_vars: {:?}",
+                    source_var,
+                    dependent_vars
+                );
                 if !dependent_vars.is_empty() {
                     log::debug!("[PROPAGATION_CHECK] F-string propagation detected");
                     return Some((source_var, dependent_vars));
@@ -966,7 +1248,11 @@ impl ScanningLogic {
             log::debug!("   Found .format( pattern (non-assignment)");
             if let Some(source_var) = Self::extract_direct_variable(node_text) {
                 let dependent_vars = CommonUtils::extract_format_variables(node_text);
-                log::debug!("   Extracted source_var: '{}', dependent_vars: {:?}", source_var, dependent_vars);
+                log::debug!(
+                    "   Extracted source_var: '{}', dependent_vars: {:?}",
+                    source_var,
+                    dependent_vars
+                );
                 if !dependent_vars.is_empty() {
                     log::debug!("[PROPAGATION_CHECK] Format propagation detected");
                     return Some((source_var, dependent_vars));
@@ -981,7 +1267,10 @@ impl ScanningLogic {
     /// Extract direct variable from simple expressions
     fn extract_direct_variable(expr: &str) -> Option<String> {
         let trimmed = expr.trim();
-        log::debug!("[EXTRACT_DIRECT] Checking if '{}' is a valid variable name", trimmed);
+        log::debug!(
+            "[EXTRACT_DIRECT] Checking if '{}' is a valid variable name",
+            trimmed
+        );
         if CommonUtils::is_valid_variable_name(trimmed) {
             log::debug!("[EXTRACT_DIRECT] Valid variable: '{}'", trimmed);
             return Some(trimmed.to_string());
@@ -991,24 +1280,33 @@ impl ScanningLogic {
     }
 
     /// Extract function parameters from function definition node
-    fn extract_function_parameters(func_node: &tree_sitter::Node, source: &[u8]) -> Option<Vec<String>> {
+    fn extract_function_parameters(
+        func_node: &tree_sitter::Node,
+        source: &[u8],
+    ) -> Option<Vec<String>> {
         let mut parameters = Vec::new();
         let mut cursor = func_node.walk();
-        
+
         // Look for parameter list in function definition
         if cursor.goto_first_child() {
             loop {
                 let node = cursor.node();
-                
+
                 // Check for formal_parameters, parameter_list, or arguments
-                if node.kind() == "formal_parameters" || node.kind() == "parameter_list" || node.kind() == "arguments" {
+                if node.kind() == "formal_parameters"
+                    || node.kind() == "parameter_list"
+                    || node.kind() == "arguments"
+                {
                     let mut param_cursor = node.walk();
                     if param_cursor.goto_first_child() {
                         loop {
                             let param_node = param_cursor.node();
-                            
+
                             // Skip punctuation like parentheses and commas
-                            if param_node.kind() != "(" && param_node.kind() != ")" && param_node.kind() != "," {
+                            if param_node.kind() != "("
+                                && param_node.kind() != ")"
+                                && param_node.kind() != ","
+                            {
                                 // Handle different parameter node types
                                 let param_text = match param_node.kind() {
                                     "identifier" => {
@@ -1028,12 +1326,14 @@ impl ScanningLogic {
                                         Self::extract_parameter_name(&param_node, source)
                                     }
                                 };
-                                
-                                if !param_text.is_empty() && CommonUtils::is_valid_variable_name(&param_text) {
+
+                                if !param_text.is_empty()
+                                    && CommonUtils::is_valid_variable_name(&param_text)
+                                {
                                     parameters.push(param_text);
                                 }
                             }
-                            
+
                             if !param_cursor.goto_next_sibling() {
                                 break;
                             }
@@ -1041,13 +1341,13 @@ impl ScanningLogic {
                     }
                     break;
                 }
-                
+
                 if !cursor.goto_next_sibling() {
                     break;
                 }
             }
         }
-        
+
         if parameters.is_empty() {
             None
         } else {
@@ -1058,7 +1358,7 @@ impl ScanningLogic {
     /// Extract parameter name from complex parameter node
     fn extract_parameter_name(param_node: &tree_sitter::Node, source: &[u8]) -> String {
         let mut cursor = param_node.walk();
-        
+
         // Look for identifier child node
         if cursor.goto_first_child() {
             loop {
@@ -1066,13 +1366,13 @@ impl ScanningLogic {
                 if node.kind() == "identifier" {
                     return crate::parser::get_node_text(&node, source);
                 }
-                
+
                 if !cursor.goto_next_sibling() {
                     break;
                 }
             }
         }
-        
+
         // Fallback: use the whole node text and try to extract identifier
         let full_text = crate::parser::get_node_text(param_node, source);
         if let Some(colon_pos) = full_text.find(':') {
@@ -1086,45 +1386,60 @@ impl ScanningLogic {
         }
     }
 
-
-
-
-
-
-
     /// Collect all relevant nodes for taint analysis (assignments and calls)
     /// Unified version that supports optional source filtering
-    fn collect_all_relevant_nodes<'a>(node: tree_sitter::Node<'a>, nodes: &mut Vec<tree_sitter::Node<'a>>, source: Option<&[u8]>) {
+    fn collect_all_relevant_nodes<'a>(
+        node: tree_sitter::Node<'a>,
+        nodes: &mut Vec<tree_sitter::Node<'a>>,
+        source: Option<&[u8]>,
+    ) {
         // Include assignment and call nodes
         match node.kind() {
-            "assignment" | "call" | "expression_statement" | "assignment_expression" |
-            "variable_declaration" | "lexical_declaration" | "variable_declarator" |
-            "function_definition" | "function_declaration" | "method_definition" |
-            "arrow_function" | "function_expression" | "generator_function" |
-            "async_function" | "constructor_definition" | "template_literal" | 
-            "template_string" | "template_substitution" => {
+            "assignment"
+            | "call"
+            | "expression_statement"
+            | "assignment_expression"
+            | "variable_declaration"
+            | "lexical_declaration"
+            | "variable_declarator"
+            | "function_definition"
+            | "function_declaration"
+            | "method_definition"
+            | "arrow_function"
+            | "function_expression"
+            | "generator_function"
+            | "async_function"
+            | "constructor_definition"
+            | "template_literal"
+            | "template_string"
+            | "template_substitution" => {
                 // Apply source filtering if provided
                 if let Some(source_bytes) = source {
                     let node_text = crate::parser::get_node_text(&node, source_bytes);
-                    if !node_text.trim().is_empty() &&
-                       !node_text.starts_with('"') &&
-                       !node_text.starts_with("'") &&
-                       !node_text.contains("__all__") {
+                    if !node_text.trim().is_empty()
+                        && !node_text.starts_with('"')
+                        && !node_text.starts_with("'")
+                        && !node_text.contains("__all__")
+                    {
                         nodes.push(node);
                     }
                 } else {
                     nodes.push(node);
                 }
             }
-            "import_statement" | "import_from_statement" | "return_statement" | 
-            "binary_expression" | "identifier" => {
-                if source.is_some() {
+            "import_statement"
+            | "import_from_statement"
+            | "return_statement"
+            | "binary_expression"
+            | "identifier" => {
+                if let Some(source) = source {
                     // Only collect these additional types when doing source filtering
-                    let node_text = crate::parser::get_node_text(&node, source.unwrap());
-                    if !node_text.trim().is_empty() &&
-                       !node_text.starts_with('"') &&
-                       !node_text.starts_with("'") &&
-                       !node_text.contains("__all__") {
+                    let node_text = crate::parser::get_node_text(&node, source);
+                    if !node_text.trim().is_empty()
+                        && !node_text.starts_with('"')
+                        && !node_text.starts_with("'")
+                        && !node_text.contains("__all__")
+                    {
                         nodes.push(node);
                     }
                 }
@@ -1137,10 +1452,11 @@ impl ScanningLogic {
                 // For other node types, check if they contain actual code when source filtering is enabled
                 if let Some(source_bytes) = source {
                     let node_text = crate::parser::get_node_text(&node, source_bytes);
-                    if !node_text.trim().is_empty() &&
-                       !node_text.starts_with('"') &&
-                       !node_text.starts_with("'") &&
-                       !node_text.contains("__all__") {
+                    if !node_text.trim().is_empty()
+                        && !node_text.starts_with('"')
+                        && !node_text.starts_with("'")
+                        && !node_text.contains("__all__")
+                    {
                         nodes.push(node);
                     }
                 }
@@ -1174,14 +1490,22 @@ impl ScanningLogic {
             end_line: sink.line,
             end_column: 0,
             function: sink.function.clone(),
-            finding_type: rule.finding_type.clone().unwrap_or_else(|| "Taint Flow".to_string()),
+            finding_type: rule
+                .finding_type
+                .clone()
+                .unwrap_or_else(|| "Taint Flow".to_string()),
             snippet: sink.code.clone(),
             severity: rule.severity.clone().unwrap_or_else(|| "High".to_string()),
-            confidence: rule.confidence.clone().unwrap_or_else(|| "Medium".to_string()),
-            description: rule.description.clone().or_else(|| Some(format!(
-                "Taint flow detected from {} (line {}) to {} (line {})",
-                source.operation, source.line, sink.operation, sink.line
-            ))),
+            confidence: rule
+                .confidence
+                .clone()
+                .unwrap_or_else(|| "Medium".to_string()),
+            description: rule.description.clone().or_else(|| {
+                Some(format!(
+                    "Taint flow detected from {} (line {}) to {} (line {})",
+                    source.operation, source.line, sink.operation, sink.line
+                ))
+            }),
             cwe_id: None,
             source_info: Some(crate::models::SourceInfo {
                 source_type: source.operation.clone(),
@@ -1198,33 +1522,32 @@ impl ScanningLogic {
             tags: Some(vec![
                 "taint_analysis".to_string(),
                 "data_flow".to_string(),
-                rule.category.clone().unwrap_or_else(|| "injection".to_string()),
+                rule.category
+                    .clone()
+                    .unwrap_or_else(|| "injection".to_string()),
             ]),
         };
 
         // Use CWE ID directly from rule, with fallback to tags for backward compatibility
-        finding.cwe_id = rule.cwe_id.clone()
-            .or_else(|| {
-                // Fallback: extract from tags if rule doesn't have cwe_id field
-                if let Some(ref tags) = rule.tags {
-                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
-                } else {
-                    None
-                }
-            });
+        finding.cwe_id = rule.cwe_id.clone().or_else(|| {
+            // Fallback: extract from tags if rule doesn't have cwe_id field
+            if let Some(ref tags) = rule.tags {
+                crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+            } else {
+                None
+            }
+        });
 
         finding
     }
-
-
 }
 
 // ============================================================================
-// INTERNAL UTILITIES - Parser management and helper functions  
+// INTERNAL UTILITIES - Parser management and helper functions
 // ============================================================================
 
 thread_local! {
-    static TLS_PARSER: RefCell<Option<(String, LanguageParser)>> = RefCell::new(None);
+    static TLS_PARSER: RefCell<Option<(String, LanguageParser)>> = const { RefCell::new(None) };
 }
 
 fn with_local_parser<F, R>(language: &str, f: F) -> Result<R>
@@ -1265,7 +1588,11 @@ impl VulnerabilityScanner {
         })
     }
 
-    pub fn with_skip_minified(language_name: &str, rules: Rules, skip_minified: bool) -> Result<Self> {
+    pub fn with_skip_minified(
+        language_name: &str,
+        rules: Rules,
+        skip_minified: bool,
+    ) -> Result<Self> {
         Ok(Self {
             language: language_name.to_string(),
             rules,
@@ -1298,29 +1625,61 @@ impl VulnerabilityScanner {
                 if crate::scanner::utils::is_git_ignored(path) {
                     continue;
                 }
-                
+
                 if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
                     let file_extension = format!(".{}", ext);
                     let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
-                    
+
                     // Enhanced extension matching for each language
                     let should_include = match self.language.as_str() {
-                        "python" => matches!(ext, "py" | "pyw" | "pyi" | "pyx") ||
-                                   (file_name.ends_with("file") && (file_name.contains("requirements") || file_name.contains("Pipfile"))),
+                        "python" => {
+                            matches!(ext, "py" | "pyw" | "pyi" | "pyx")
+                                || (file_name.ends_with("file")
+                                    && (file_name.contains("requirements")
+                                        || file_name.contains("Pipfile")))
+                        }
                         "java" => matches!(ext, "java" | "jav"),
-                        "javascript" => matches!(ext, "js" | "mjs" | "cjs" | "jsx") ||
-                                       matches!(ext, "vue" | "svelte") ||
-                                       (file_name.contains("webpack") || file_name.contains("rollup") || file_name.contains("vite")) &&
-                                       (file_name.ends_with(".config.js") || file_name.ends_with(".config.mjs") || file_name.ends_with(".config.cjs")),
-                        "tsx" => matches!(ext, "ts" | "tsx" | "mts" | "cts") ||
-                                file_name.ends_with(".d.ts") || file_name.ends_with(".d.mts") || file_name.ends_with(".d.cts") ||
-                                ((file_name.contains("webpack") || file_name.contains("rollup") || file_name.contains("vite")) &&
-                                 (file_name.ends_with(".config.ts"))),
-                        "html" => matches!(ext, "html" | "htm" | "xhtml" | "shtml" | "dhtml" | "hbs" | "handlebars" | "mustache" | "twig" | "njk" | "nunjucks" | "ejs" | "pug" | "jade"),
+                        "javascript" => {
+                            matches!(ext, "js" | "mjs" | "cjs" | "jsx")
+                                || matches!(ext, "vue" | "svelte")
+                                || (file_name.contains("webpack")
+                                    || file_name.contains("rollup")
+                                    || file_name.contains("vite"))
+                                    && (file_name.ends_with(".config.js")
+                                        || file_name.ends_with(".config.mjs")
+                                        || file_name.ends_with(".config.cjs"))
+                        }
+                        "tsx" => {
+                            matches!(ext, "ts" | "tsx" | "mts" | "cts")
+                                || file_name.ends_with(".d.ts")
+                                || file_name.ends_with(".d.mts")
+                                || file_name.ends_with(".d.cts")
+                                || ((file_name.contains("webpack")
+                                    || file_name.contains("rollup")
+                                    || file_name.contains("vite"))
+                                    && (file_name.ends_with(".config.ts")))
+                        }
+                        "html" => matches!(
+                            ext,
+                            "html"
+                                | "htm"
+                                | "xhtml"
+                                | "shtml"
+                                | "dhtml"
+                                | "hbs"
+                                | "handlebars"
+                                | "mustache"
+                                | "twig"
+                                | "njk"
+                                | "nunjucks"
+                                | "ejs"
+                                | "pug"
+                                | "jade"
+                        ),
                         "django" => matches!(ext, "html" | "htm"),
                         _ => file_extension == target_extension,
                     };
-                    
+
                     if should_include {
                         files.push(path.to_path_buf());
                     }
@@ -1330,7 +1689,12 @@ impl VulnerabilityScanner {
         Ok(files)
     }
 
-    pub fn find_vulnerabilities_parallel(&self, root_dir: &str, language_name: &str, show_progress: bool) -> Result<Vec<Finding>> {
+    pub fn find_vulnerabilities_parallel(
+        &self,
+        root_dir: &str,
+        language_name: &str,
+        show_progress: bool,
+    ) -> Result<Vec<Finding>> {
         let files = self.discover_files(root_dir)?;
         if files.is_empty() {
             println!("No {} files found in {}", language_name, root_dir);
@@ -1342,7 +1706,7 @@ impl VulnerabilityScanner {
             &self.rules,
             language_name,
             self.skip_minified,
-            Vec::new() // No custom patterns in simplified version
+            Vec::new(), // No custom patterns in simplified version
         );
         let (filtered_files, filter_stats) = prefilter.filter_files(files);
 
@@ -1379,33 +1743,32 @@ impl VulnerabilityScanner {
                 let mut local_vec = Vec::new();
                 for path in chunk {
                     let filepath_str = path.to_string_lossy().to_string();
-                    match File::open(&path) {
-                        Ok(file) => {
-                            match unsafe { Mmap::map(&file) } {
-                                Ok(mmap) => {
-                                    let source: &[u8] = &mmap;
-                                    match with_local_parser(&self.language, |parser| {
-                                        let tree = parser.parse(source)?;
-                                        Ok(ScanningLogic::scan_file_with_rules(
-                                            &filepath_str,
-                                            source,
-                                            &tree,
-                                            &all_rules,
-                                            parser.language_support(),
-                                        ))
-                                    }) {
-                                        Ok(file_findings) => {
-                                            if !file_findings.is_empty() {
-                                                total_findings.fetch_add(file_findings.len(), Ordering::Relaxed);
-                                            }
-                                            local_vec.extend(file_findings);
+                    match File::open(path) {
+                        Ok(file) => match unsafe { Mmap::map(&file) } {
+                            Ok(mmap) => {
+                                let source: &[u8] = &mmap;
+                                match with_local_parser(&self.language, |parser| {
+                                    let tree = parser.parse(source)?;
+                                    Ok(ScanningLogic::scan_file_with_rules(
+                                        &filepath_str,
+                                        source,
+                                        &tree,
+                                        &all_rules,
+                                        parser.language_support(),
+                                    ))
+                                }) {
+                                    Ok(file_findings) => {
+                                        if !file_findings.is_empty() {
+                                            total_findings
+                                                .fetch_add(file_findings.len(), Ordering::Relaxed);
                                         }
-                                        Err(e) => eprintln!("Failed to parse {}: {}", filepath_str, e),
+                                        local_vec.extend(file_findings);
                                     }
+                                    Err(e) => eprintln!("Failed to parse {}: {}", filepath_str, e),
                                 }
-                                Err(e) => eprintln!("Failed to mmap file {}: {}", filepath_str, e),
                             }
-                        }
+                            Err(e) => eprintln!("Failed to mmap file {}: {}", filepath_str, e),
+                        },
                         Err(err) => eprintln!("Failed to open file {}: {}", filepath_str, err),
                     }
                 }
@@ -1419,34 +1782,56 @@ impl VulnerabilityScanner {
             progress.stop();
         }
         if show_progress {
-            println!("Found {} vulnerabilities", total_findings.load(Ordering::Relaxed));
+            println!(
+                "Found {} vulnerabilities",
+                total_findings.load(Ordering::Relaxed)
+            );
         }
         Ok(findings)
     }
 
-    pub fn find_vulnerabilities_single_threaded(&self, root_dir: &str, language_name: &str) -> Result<Vec<Finding>> {
+    pub fn find_vulnerabilities_single_threaded(
+        &self,
+        root_dir: &str,
+        language_name: &str,
+    ) -> Result<Vec<Finding>> {
         // Reuse the parallel scanner with a single-thread rayon pool.
-        rayon::ThreadPoolBuilder::new().num_threads(1).build_global().ok();
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(1)
+            .build_global()
+            .ok();
         self.find_vulnerabilities_parallel(root_dir, language_name, true)
     }
 
-    pub fn find_vulnerabilities_unified(&self, root_dir: &str, language_name: &str, show_progress: bool) -> Result<Vec<Finding>> {
-        self.find_vulnerabilities_unified_with_filters(root_dir, language_name, show_progress, None, None)
+    pub fn find_vulnerabilities_unified(
+        &self,
+        root_dir: &str,
+        language_name: &str,
+        show_progress: bool,
+    ) -> Result<Vec<Finding>> {
+        self.find_vulnerabilities_unified_with_filters(
+            root_dir,
+            language_name,
+            show_progress,
+            None,
+            None,
+        )
     }
 
     pub fn find_vulnerabilities_unified_with_filters(
-        &self, 
-        root_dir: &str, 
-        language_name: &str, 
+        &self,
+        root_dir: &str,
+        language_name: &str,
         show_progress: bool,
         code_type_filter: Option<&str>,
-        language_filter: Option<&str>
+        language_filter: Option<&str>,
     ) -> Result<Vec<Finding>> {
-        if show_progress {
-            println!("running find_vulnerabilities_unified");
-        }
         let files_by_language = if self.language.is_empty() {
-            crate::scanner::utils::discover_files_by_language_with_progress(root_dir, true, show_progress)?
+            crate::scanner::utils::discover_files_by_language_with_progress(
+                root_dir,
+                true,
+                show_progress,
+            )?
         } else {
             let files = self.discover_files(root_dir)?;
             let mut result = std::collections::BTreeMap::new();
@@ -1463,7 +1848,8 @@ impl VulnerabilityScanner {
             return Ok(Vec::new());
         }
 
-        let all_files: Vec<std::path::PathBuf> = files_by_language.values().flatten().cloned().collect();
+        let all_files: Vec<std::path::PathBuf> =
+            files_by_language.values().flatten().cloned().collect();
 
         if all_files.is_empty() {
             if show_progress {
@@ -1473,7 +1859,10 @@ impl VulnerabilityScanner {
         }
 
         let prefilter = crate::scanner::prefilter::PreFilter::with_options(
-            &self.rules, language_name, self.skip_minified, Vec::new()
+            &self.rules,
+            language_name,
+            self.skip_minified,
+            Vec::new(),
         );
         let (mut filtered_files, filter_stats) = prefilter.filter_files(all_files);
 
@@ -1484,38 +1873,54 @@ impl VulnerabilityScanner {
         // Apply additional filters if specified
         if code_type_filter.is_some() || language_filter.is_some() {
             let code_type_detector = crate::code_type_detector::CodeTypeDetector::new();
-            let target_code_type = code_type_filter.and_then(|ct| crate::code_type_detector::CodeType::from_string(ct));
+            let target_code_type =
+                code_type_filter.and_then(crate::code_type_detector::CodeType::from_string);
             let original_count = filtered_files.len();
-            
-            filtered_files = filtered_files.into_iter().filter(|path| {
+
+            filtered_files.retain(|path| {
                 let path_str = path.to_string_lossy();
-                
+
                 // Language filter
                 if let Some(lang_filter) = language_filter {
-                    if let Some(detected_lang) = crate::scanner::utils::detect_language_from_path(path) {
-                        if !detected_lang.to_lowercase().contains(&lang_filter.to_lowercase()) {
+                    if let Some(detected_lang) =
+                        crate::scanner::utils::detect_language_from_path(path)
+                    {
+                        if !detected_lang
+                            .to_lowercase()
+                            .contains(&lang_filter.to_lowercase())
+                        {
                             return false;
                         }
                     }
                 }
-                
+
                 // Code type filter
                 if let Some(target_type) = &target_code_type {
                     if let Ok(content) = std::fs::read_to_string(path) {
-                        if let Some(detected_lang) = crate::scanner::utils::detect_language_from_path(path) {
-                            let detected_type = code_type_detector.detect_code_type(&path_str, &content, &detected_lang);
+                        if let Some(detected_lang) =
+                            crate::scanner::utils::detect_language_from_path(path)
+                        {
+                            let detected_type = code_type_detector.detect_code_type(
+                                &path_str,
+                                &content,
+                                detected_lang,
+                            );
                             if !detected_type.matches_filter(target_type) {
                                 return false;
                             }
                         }
                     }
                 }
-                
+
                 true
-            }).collect();
-            
+            });
+
             if show_progress && filtered_files.len() != original_count {
-                println!("Additional filtering reduced files from {} to {}", original_count, filtered_files.len());
+                println!(
+                    "Additional filtering reduced files from {} to {}",
+                    original_count,
+                    filtered_files.len()
+                );
             }
         }
 
@@ -1561,7 +1966,7 @@ impl VulnerabilityScanner {
 
                     // Auto-detect language for each file
                     if let Some(detected_language) = crate::scanner::utils::detect_language_from_path(path) {
-                        match File::open(&path) {
+                        match File::open(path) {
                             Ok(file) => {
                                 match unsafe { Mmap::map(&file) } {
                                     Ok(mmap) => {
@@ -1613,14 +2018,18 @@ impl VulnerabilityScanner {
         // FIXED: Skip cross-file analysis for frontend scans as it's primarily designed for Backend projects
         // and causes major performance issues with JavaScript/TypeScript projects
         let should_skip_cross_file = code_type_filter == Some("frontend");
-        
+
         if has_taint_rules && filtered_files.len() > 1 && !should_skip_cross_file {
             if show_progress {
                 log::info!("Performing cross-file taint analysis...");
             }
 
             let mut multi_file_analyzer = MultiFileTaintAnalyzer::new();
-            match multi_file_analyzer.analyze_cross_file_flows(&files_by_language, &taint_rules, language_filter) {
+            match multi_file_analyzer.analyze_cross_file_flows(
+                &files_by_language,
+                &taint_rules,
+                language_filter,
+            ) {
                 Ok(findings) => {
                     cross_file_findings = findings;
                     if show_progress && !cross_file_findings.is_empty() {
@@ -1634,7 +2043,9 @@ impl VulnerabilityScanner {
                 }
             }
         } else if should_skip_cross_file && show_progress {
-            log::info!("Skipping cross-file taint analysis for frontend scan (performance optimization)");
+            log::info!(
+                "Skipping cross-file taint analysis for frontend scan (performance optimization)"
+            );
         }
 
         // Stop progress tracking (reuse existing infrastructure)
@@ -1647,26 +2058,44 @@ impl VulnerabilityScanner {
         all_findings.extend(cross_file_findings);
 
         if show_progress {
-            let search_count = all_findings.iter().filter(|f| {
-                f.tags.as_ref().map_or(true, |tags| !tags.contains(&"taint_analysis".to_string()))
-            }).count();
-            let single_file_taint_count = all_findings.iter().filter(|f| {
-                f.tags.as_ref().map_or(false, |tags|
-                    tags.contains(&"taint_analysis".to_string()) && !tags.contains(&"cross_file".to_string())
-                )
-            }).count();
-            let cross_file_taint_count = all_findings.iter().filter(|f| {
-                f.tags.as_ref().map_or(false, |tags| tags.contains(&"cross_file".to_string()))
-            }).count();
+            let search_count = all_findings
+                .iter()
+                .filter(|f| {
+                    f.tags
+                        .as_ref()
+                        .is_none_or(|tags| !tags.contains(&"taint_analysis".to_string()))
+                })
+                .count();
+            let single_file_taint_count = all_findings
+                .iter()
+                .filter(|f| {
+                    f.tags.as_ref().is_some_and(|tags| {
+                        tags.contains(&"taint_analysis".to_string())
+                            && !tags.contains(&"cross_file".to_string())
+                    })
+                })
+                .count();
+            let cross_file_taint_count = all_findings
+                .iter()
+                .filter(|f| {
+                    f.tags
+                        .as_ref()
+                        .is_some_and(|tags| tags.contains(&"cross_file".to_string()))
+                })
+                .count();
 
             if has_search_rules && has_taint_rules {
-                println!("Found {} search findings, {} single-file taint flows, {} cross-file taint flows",
-                        search_count, single_file_taint_count, cross_file_taint_count);
+                crate::ui::note(&format!(
+                    "{} pattern matches \u{b7} {} single-file flows \u{b7} {} cross-file flows",
+                    search_count, single_file_taint_count, cross_file_taint_count
+                ));
             } else if has_search_rules {
-                println!("Found {} search findings", search_count);
+                crate::ui::note(&format!("{} pattern matches", search_count));
             } else {
-                println!("Found {} single-file taint flows, {} cross-file taint flows",
-                        single_file_taint_count, cross_file_taint_count);
+                crate::ui::note(&format!(
+                    "{} single-file flows \u{b7} {} cross-file flows",
+                    single_file_taint_count, cross_file_taint_count
+                ));
             }
         }
 
@@ -1693,8 +2122,11 @@ impl ScanningLogic {
         let mut processed_lines = std::collections::HashSet::new();
 
         // Filter search rules that don't apply to this file (same as taint rules)
-        let applicable_search_rules: Vec<&crate::rules::UnifiedRule> = search_rules.iter()
-            .filter(|rule| crate::scanner::utils::rule_applies_to_file(rule.file_types.as_ref(), filepath))
+        let applicable_search_rules: Vec<&crate::rules::UnifiedRule> = search_rules
+            .iter()
+            .filter(|rule| {
+                crate::scanner::utils::rule_applies_to_file(rule.file_types.as_ref(), filepath)
+            })
             .copied()
             .collect();
 
@@ -1715,7 +2147,7 @@ impl ScanningLogic {
 
         // Phase 1: Build taint context by tracking variable assignments from taint sources (only if taint rules exist)
         let has_taint_rules = !taint_rules.is_empty();
-        
+
         if has_taint_rules {
             for node in all_nodes.iter() {
                 let node_text = crate::parser::get_node_text(node, source);
@@ -1724,13 +2156,17 @@ impl ScanningLogic {
 
                 // Look for assignment patterns: var = source_call()
                 if CommonUtils::is_valid_assignment_text(&node_text) {
-                    if let Some(var_name) = CommonUtils::extract_variable_from_assignment(&node_text, false) {
+                    if let Some(var_name) =
+                        CommonUtils::extract_variable_from_assignment(&node_text, false)
+                    {
                         // Extract the right side of assignment for source matching
                         if let Some(eq_pos) = node_text.find('=') {
                             let assignment_value = &node_text[eq_pos + 1..].trim();
-                            
+
                             // Check if the assignment value matches any taint source
-                            if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(assignment_value) {
+                            if let Some(source_pattern) =
+                                rule_deduplicator.matches_source_pattern(assignment_value)
+                            {
                                 flow_tracker.record_tainted_variable(
                                     var_name,
                                     TaintVariableInfo {
@@ -1738,7 +2174,7 @@ impl ScanningLogic {
                                         source_pattern,
                                         source_function: func_name.clone(),
                                         assignment_code: node_text.clone(),
-                                    }
+                                    },
                                 );
                             }
                         }
@@ -1746,19 +2182,30 @@ impl ScanningLogic {
                 }
 
                 // Check for taint propagation through operations
-                if let Some((target_var, dependent_vars)) = ScanningLogic::detect_taint_propagation(&node_text) {
+                if let Some((target_var, dependent_vars)) =
+                    ScanningLogic::detect_taint_propagation(&node_text)
+                {
                     flow_tracker.record_taint_propagation(&target_var, &dependent_vars);
-                    
+
                     // Check if any dependent variables are tainted and propagate to target
                     for dep_var in &dependent_vars {
-                        if let Some(taint_info) = flow_tracker.is_variable_tainted(dep_var, &func_name).cloned() {
+                        if let Some(taint_info) = flow_tracker
+                            .is_variable_tainted(dep_var, &func_name)
+                            .cloned()
+                        {
                             // Mark target variable as tainted (inheriting from the dependent variable)
-                            flow_tracker.record_tainted_variable(target_var.to_string(), TaintVariableInfo {
-                                source_line: taint_info.source_line,
-                                source_pattern: taint_info.source_pattern.clone(),
-                                source_function: taint_info.source_function.clone(),
-                                assignment_code: format!("Propagated from {} via: {}", dep_var, node_text),
-                            });
+                            flow_tracker.record_tainted_variable(
+                                target_var.to_string(),
+                                TaintVariableInfo {
+                                    source_line: taint_info.source_line,
+                                    source_pattern: taint_info.source_pattern.clone(),
+                                    source_function: taint_info.source_function.clone(),
+                                    assignment_code: format!(
+                                        "Propagated from {} via: {}",
+                                        dep_var, node_text
+                                    ),
+                                },
+                            );
                             break; // Only need one tainted dependency to taint the target
                         }
                     }
@@ -1767,31 +2214,43 @@ impl ScanningLogic {
         }
 
         // Phase 2: Apply search rules with enhanced context awareness
-        let call_nodes: Vec<tree_sitter::Node> = crate::parser::traverse_calls_only(tree.root_node(), language_support).collect();
+        let call_nodes: Vec<tree_sitter::Node> =
+            crate::parser::traverse_calls_only(tree.root_node(), language_support).collect();
 
         for node in call_nodes.iter() {
             if let Some(func_name) = language_support.get_function_name(node, source) {
-                let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> = applicable_search_rules.iter().enumerate()
-                    .filter(|(_, rule)| ScanningLogic::rule_might_match_function(*rule, &func_name))
-                    .map(|(idx, rule)| (idx, *rule))
-                    .collect();
+                let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> =
+                    applicable_search_rules
+                        .iter()
+                        .enumerate()
+                        .filter(|(_, rule)| {
+                            ScanningLogic::rule_might_match_function(rule, func_name)
+                        })
+                        .map(|(idx, rule)| (idx, *rule))
+                        .collect();
 
                 for (_, rule) in relevant_rules {
                     // Enhanced rule checking with taint context
-                    if let Some(mut finding) = ScanningLogic::check_rule_against_node_with_taint_context(
-                        rule,
-                        node,
-                        source,
-                        filepath,
-                        &func_name,
-                        language_support,
-                        &flow_tracker,
-                        &rule_deduplicator,
-                    ) {
-                        let line_key = (finding.line, finding.function.clone(), finding.finding_type.clone());
+                    if let Some(mut finding) =
+                        ScanningLogic::check_rule_against_node_with_taint_context(
+                            rule,
+                            node,
+                            source,
+                            filepath,
+                            func_name,
+                            language_support,
+                            &flow_tracker,
+                            &rule_deduplicator,
+                        )
+                    {
+                        let line_key = (
+                            finding.line,
+                            finding.function.clone(),
+                            finding.finding_type.clone(),
+                        );
                         if !processed_lines.contains(&line_key) {
                             processed_lines.insert(line_key);
-                            
+
                             // Add taint context tags to distinguish from basic search findings
                             if finding.tags.is_none() {
                                 finding.tags = Some(Vec::new());
@@ -1804,7 +2263,7 @@ impl ScanningLogic {
                                     tags.push("taint_context_unavailable".to_string());
                                 }
                             }
-                            
+
                             findings.push(finding);
                         }
                     }
@@ -1824,13 +2283,15 @@ impl ScanningLogic {
         func_name: &str,
         language_support: &dyn crate::language::LanguageSupport,
         flow_tracker: &VariableFlowTracker,
-        rule_deduplicator: &TaintRuleDeduplicator,
+        _rule_deduplicator: &TaintRuleDeduplicator,
     ) -> Option<crate::models::Finding> {
         let node_text = crate::parser::get_node_text(node, source);
-        
+
         // First check if the rule pattern matches
         let pattern_matches = if let Some(patterns) = &rule.patterns {
-            patterns.iter().any(|pattern| CommonUtils::matches_rule_pattern(pattern, &node_text))
+            patterns
+                .iter()
+                .any(|pattern| CommonUtils::matches_rule_pattern(pattern, &node_text))
         } else if let Some(pattern) = &rule.pattern {
             CommonUtils::matches_rule_pattern(pattern, &node_text)
         } else {
@@ -1856,7 +2317,8 @@ impl ScanningLogic {
         }
 
         // Create enhanced finding with taint context - always point to the sink line
-        let vulnerable_line = Self::find_vulnerable_line_in_node(node, source, &rule.get_finding_type(), Some(rule));
+        let vulnerable_line =
+            Self::find_vulnerable_line_in_node(node, source, rule.get_finding_type(), Some(rule));
         let mut finding = crate::models::Finding {
             file: filepath.to_string(),
             line: vulnerable_line,
@@ -1877,21 +2339,23 @@ impl ScanningLogic {
         };
 
         // Use CWE ID directly from rule, with fallback to tags for backward compatibility
-        finding.cwe_id = rule.cwe_id.clone()
-            .or_else(|| {
-                // Fallback: extract from tags if rule doesn't have cwe_id field
-                if let Some(ref tags) = rule.tags {
-                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
-                } else {
-                    None
-                }
-            });
+        finding.cwe_id = rule.cwe_id.clone().or_else(|| {
+            // Fallback: extract from tags if rule doesn't have cwe_id field
+            if let Some(ref tags) = rule.tags {
+                crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+            } else {
+                None
+            }
+        });
 
         // Add enhanced source and sink information if taint context is available
         if let Some((tainted_var, taint_info)) = taint_context_info {
             finding.source_info = Some(crate::models::SourceInfo {
                 source_type: format!("{} (Taint Context)", taint_info.source_pattern),
-                location: format!("Line {} ({})", taint_info.source_line, taint_info.source_function),
+                location: format!(
+                    "Line {} ({})",
+                    taint_info.source_line, taint_info.source_function
+                ),
                 context: taint_info.assignment_code.clone(),
             });
 
@@ -1906,8 +2370,14 @@ impl ScanningLogic {
             finding.confidence = "High".to_string();
         } else {
             // Regular source/sink detection for non-taint context
-            finding.source_info = ScanningLogic::detect_source_pattern(node, source, language_support);
-            finding.sink_info = ScanningLogic::detect_sink_pattern(node, source, func_name, &rule.get_finding_type());
+            finding.source_info =
+                ScanningLogic::detect_source_pattern(node, source, language_support);
+            finding.sink_info = ScanningLogic::detect_sink_pattern(
+                node,
+                source,
+                func_name,
+                rule.get_finding_type(),
+            );
         }
 
         Some(finding)
@@ -1927,6 +2397,7 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
         return;
     }
 
+    // Group findings by severity - use BTreeMap for deterministic iteration
     let mut severity_counts: BTreeMap<String, usize> = BTreeMap::new();
     let mut finding_types: BTreeMap<String, usize> = BTreeMap::new();
     let mut file_counts: BTreeMap<String, usize> = BTreeMap::new();
@@ -1941,6 +2412,7 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
         *file_counts.entry(finding.file.clone()).or_insert(0) += 1;
     }
 
+    // Severity breakdown, on a single line in fixed order
     let severity_order = ["critical", "high", "medium", "low"];
     let parts: Vec<String> = severity_order
         .iter()
@@ -1955,6 +2427,7 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
         println!("  {}", parts.join("   "));
     }
 
+    // Top finding types
     let mut sorted_types: Vec<_> = finding_types.iter().collect();
     sorted_types.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
     println!();
@@ -1962,6 +2435,7 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
         println!("  {:>4}  {}", count, finding_type);
     }
 
+    // Most affected files
     let mut sorted_files: Vec<_> = file_counts.iter().collect();
     sorted_files.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
     if sorted_files.len() > 1 {
@@ -1988,9 +2462,11 @@ pub struct ProgressManager {
 }
 
 impl ProgressManager {
+    /// Spinner frames used for all progress indicators (Braille, not emoji).
     const TICK_CHARS: &'static str =
         "\u{280b}\u{2819}\u{2839}\u{2838}\u{283c}\u{2834}\u{2826}\u{2827}\u{2807}\u{280f} ";
 
+    /// Create a determinate progress bar tracking `total` files.
     pub fn new(total: usize) -> Self {
         let bar = ProgressBar::new(total as u64);
         if let Ok(style) = ProgressStyle::with_template(
@@ -1999,6 +2475,8 @@ impl ProgressManager {
             bar.set_style(style.progress_chars("=> ").tick_chars(Self::TICK_CHARS));
         }
         bar.set_draw_target(ProgressDrawTarget::stderr());
+        // Keep the spinner animating even while the file counter is unchanged,
+        // so a long-running pass never looks frozen.
         bar.enable_steady_tick(Duration::from_millis(100));
 
         Self {
@@ -2008,6 +2486,8 @@ impl ProgressManager {
         }
     }
 
+    /// Create an indeterminate spinner with a static `message`, for phases whose
+    /// total work is unknown (e.g. data-flow analysis).
     pub fn new_spinner(message: &str) -> Self {
         let bar = ProgressBar::new_spinner();
         if let Ok(style) =
@@ -2037,7 +2517,9 @@ impl ProgressManager {
                 bar_clone.set_position(val);
                 let vulns = findings.load(Ordering::Relaxed);
                 bar_clone.set_message(format!("{} findings", vulns));
-                std::thread::sleep(Duration::from_millis(crate::config::ScanDefaults::PROGRESS_INTERVAL_MS));
+                std::thread::sleep(Duration::from_millis(
+                    crate::config::ScanDefaults::PROGRESS_INTERVAL_MS,
+                ));
             }
         }));
     }
@@ -2070,14 +2552,31 @@ pub fn print_findings_csv(findings: &[Finding]) {
     println!("file,line,function,finding_type,code,severity,confidence,cwe_id,source_type,source_context,sink_type,sink_function,traces");
     for finding in findings {
         let code = finding.snippet.replace('"', "\"\"");
-        let source_type = finding.source_info.as_ref().map(|s| s.source_type.as_str()).unwrap_or("");
-        let source_context = finding.source_info.as_ref().map(|s| s.context.as_str()).unwrap_or("");
-        let sink_type = finding.sink_info.as_ref().map(|s| s.sink_type.as_str()).unwrap_or("");
-        let sink_function = finding.sink_info.as_ref().map(|s| s.function_name.as_str()).unwrap_or("");
+        let source_type = finding
+            .source_info
+            .as_ref()
+            .map(|s| s.source_type.as_str())
+            .unwrap_or("");
+        let source_context = finding
+            .source_info
+            .as_ref()
+            .map(|s| s.context.as_str())
+            .unwrap_or("");
+        let sink_type = finding
+            .sink_info
+            .as_ref()
+            .map(|s| s.sink_type.as_str())
+            .unwrap_or("");
+        let sink_function = finding
+            .sink_info
+            .as_ref()
+            .map(|s| s.function_name.as_str())
+            .unwrap_or("");
         let cwe_id = finding.cwe_id.as_deref().unwrap_or("");
 
         let traces = if let Some(traces) = &finding.traces {
-            traces.iter()
+            traces
+                .iter()
                 .map(|t| format!("{}:{}:{}", t.line, t.variable, t.operation))
                 .collect::<Vec<_>>()
                 .join(";")
@@ -2085,21 +2584,41 @@ pub fn print_findings_csv(findings: &[Finding]) {
             String::new()
         };
 
-        println!("{},{},{},{},\"{}\",{},{},{},{},{},{},{},\"{}\"",
-                finding.file, finding.line, finding.function, finding.finding_type,
-                code, finding.severity, finding.confidence, cwe_id, source_type, source_context, sink_type, sink_function, traces);
+        println!(
+            "{},{},{},{},\"{}\",{},{},{},{},{},{},{},\"{}\"",
+            finding.file,
+            finding.line,
+            finding.function,
+            finding.finding_type,
+            code,
+            finding.severity,
+            finding.confidence,
+            cwe_id,
+            source_type,
+            source_context,
+            sink_type,
+            sink_function,
+            traces
+        );
     }
 }
 
 /// Print findings in text format with syntax highlighting
-pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: bool, duration: std::time::Duration) {
+pub fn print_findings_text(
+    findings: &[Finding],
+    _verbose: bool,
+    summary_only: bool,
+    duration: std::time::Duration,
+) {
     if !summary_only && !findings.is_empty() {
         crate::ui::section("Findings");
 
+        // Initialize syntax highlighting
         let ps = SyntaxSet::load_defaults_newlines();
         let ts = ThemeSet::load_defaults();
         let theme = &ts.themes["base16-ocean.dark"];
 
+        // Pre-sort findings by file and severity for better grouping
         let mut sorted_findings: Vec<_> = findings.iter().collect();
         sorted_findings.sort_by(|a, b| {
             a.file
@@ -2108,12 +2627,14 @@ pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: b
                 .then(a.line.cmp(&b.line))
         });
 
+        // Group findings by file
         let mut current_file = None;
         let mut file_contents: String;
         let mut lines = Vec::new();
         let mut syntax = None;
 
         for finding in sorted_findings {
+            // Only read file when it changes
             if current_file != Some(&finding.file) {
                 current_file = Some(&finding.file);
                 file_contents = match fs::read_to_string(&finding.file) {
@@ -2122,6 +2643,7 @@ pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: b
                 };
                 lines = file_contents.lines().collect();
 
+                // Set up syntax highlighting for the new file
                 let syntax_name = CommonUtils::detect_syntax(&finding.file);
                 syntax = ps.find_syntax_by_name(syntax_name);
 
@@ -2148,6 +2670,7 @@ pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: b
                 crate::ui::dim(&format!("line {}", line_num))
             );
 
+            // Display source and sink information if available
             if let Some(source_info) = &finding.source_info {
                 println!(
                     "    {} {} ({})",
@@ -2169,6 +2692,7 @@ pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: b
                 }
             }
 
+            // Display traces if available
             if let Some(traces) = &finding.traces {
                 if !traces.is_empty() {
                     println!("    {}", crate::ui::dim("flow"));
@@ -2188,6 +2712,7 @@ pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: b
 
             println!();
 
+            // Print surrounding context with syntax highlighting
             let color = crate::ui::color_enabled();
             let marker = |is_hit: bool| -> &'static str {
                 if !is_hit {
@@ -2213,6 +2738,7 @@ pub fn print_findings_text(findings: &[Finding], _verbose: bool, summary_only: b
                     println!();
                 }
             } else {
+                // Plain text when highlighting is unavailable or color is disabled
                 for i in start_line..end_line {
                     println!(
                         "    {}{:4} | {}",
@@ -2267,47 +2793,63 @@ impl VariableFlowTracker {
     fn record_tainted_variable(&mut self, var_name: String, source_info: TaintVariableInfo) {
         log::debug!("[RECORD_TAINT] Recording tainted variable: '{}' from pattern '{}' at line {} in function '{}'", 
             var_name, source_info.source_pattern, source_info.source_line, source_info.source_function);
-        
-        self.tainted_variables.insert(var_name.clone(), source_info.clone());
+
+        self.tainted_variables
+            .insert(var_name.clone(), source_info.clone());
 
         // Add to function scope
         self.function_scopes
             .entry(source_info.source_function.clone())
-            .or_insert_with(std::collections::BTreeSet::new)
+            .or_default()
             .insert(var_name);
     }
 
     /// Check if a variable is tainted
     fn is_variable_tainted(&self, var_name: &str, function: &str) -> Option<&TaintVariableInfo> {
-        log::debug!("[CHECK_TAINT] Checking if variable '{}' is tainted in function '{}'", var_name, function);
-        
+        log::debug!(
+            "[CHECK_TAINT] Checking if variable '{}' is tainted in function '{}'",
+            var_name,
+            function
+        );
+
         // Check direct variable
         if let Some(info) = self.tainted_variables.get(var_name) {
-            log::debug!("[CHECK_TAINT] Found taint info: source_function='{}', source_pattern='{}'", 
-                info.source_function, info.source_pattern);
-            
+            log::debug!(
+                "[CHECK_TAINT] Found taint info: source_function='{}', source_pattern='{}'",
+                info.source_function,
+                info.source_pattern
+            );
+
             // Same function or global variable
             if info.source_function == function || Self::is_global_variable(var_name) {
-                log::debug!("[CHECK_TAINT] Variable '{}' is tainted (function match or global)", var_name);
+                log::debug!(
+                    "[CHECK_TAINT] Variable '{}' is tainted (function match or global)",
+                    var_name
+                );
                 return Some(info);
             } else {
                 log::debug!("[CHECK_TAINT] Variable '{}' found but function mismatch: source='{}' vs current='{}'", 
                     var_name, info.source_function, function);
             }
         } else {
-            log::debug!("[CHECK_TAINT] Variable '{}' not found in tainted variables", var_name);
+            log::debug!(
+                "[CHECK_TAINT] Variable '{}' not found in tainted variables",
+                var_name
+            );
         }
         None
     }
 
     /// Check if we've already processed this flow to prevent duplicates
     fn is_flow_processed(&self, line: usize, source_pattern: &str, sink_pattern: &str) -> bool {
-        self.processed_flows.contains(&(line, source_pattern.to_string(), sink_pattern.to_string()))
+        self.processed_flows
+            .contains(&(line, source_pattern.to_string(), sink_pattern.to_string()))
     }
 
     /// Mark a flow as processed
     fn mark_flow_processed(&mut self, line: usize, source_pattern: &str, sink_pattern: &str) {
-        self.processed_flows.insert((line, source_pattern.to_string(), sink_pattern.to_string()));
+        self.processed_flows
+            .insert((line, source_pattern.to_string(), sink_pattern.to_string()));
     }
 
     /// Record taint propagation through operations
@@ -2315,13 +2857,17 @@ impl VariableFlowTracker {
         for dep_var in dependent_vars {
             self.taint_propagations
                 .entry(source_var.to_string())
-                .or_insert_with(Vec::new)
+                .or_default()
                 .push(dep_var.clone());
         }
     }
 
     /// Check if any variable in a list is tainted
-    fn is_any_variable_tainted(&self, variables: &[String], function: &str) -> Option<&TaintVariableInfo> {
+    fn is_any_variable_tainted(
+        &self,
+        variables: &[String],
+        function: &str,
+    ) -> Option<&TaintVariableInfo> {
         for var in variables {
             if let Some(info) = self.is_variable_tainted(var, function) {
                 return Some(info);
@@ -2336,7 +2882,7 @@ impl VariableFlowTracker {
         var_name.to_uppercase() == var_name || // ALL_CAPS
         var_name.starts_with("app.") ||        // app.something
         var_name.contains("_DIR") ||           // paths
-        var_name.contains("_PATH")             // paths
+        var_name.contains("_PATH") // paths
     }
 }
 
@@ -2404,8 +2950,8 @@ struct FunctionTaintBehavior {
 #[derive(Debug, Clone)]
 struct DataFlowEvidence {
     variable_assignments: Vec<(String, String, usize)>, // (var, source_expr, line)
-    function_calls: Vec<(String, String, usize)>, // (func, args, line)  
-    return_statements: Vec<(String, usize)>, // (expr, line)
+    function_calls: Vec<(String, String, usize)>,       // (func, args, line)
+    return_statements: Vec<(String, usize)>,            // (expr, line)
 }
 
 /// A verified taint flow with complete evidence chain
@@ -2415,13 +2961,13 @@ struct VerifiedTaintFlow {
     source_function: String,
     source_pattern: String,
     source_line: usize,
-    
+
     sink_file: String,
     sink_function: String,
     sink_pattern: String,
     sink_line: usize,
     sink_variable: String,
-    
+
     call_chain: Vec<FunctionCallNode>,
     data_flow_evidence: DataFlowEvidence,
 }
@@ -2429,10 +2975,20 @@ struct VerifiedTaintFlow {
 /// Classification of how a variable gets its value
 #[derive(Debug, Clone)]
 enum VariableSource {
-    LocalAssignment { source_expression: String, line: usize },
-    FunctionParameter { parameter_index: usize },
-    ImportedFunction { import_info: FunctionImport },
-    DirectTaintSource { pattern: String, line: usize },
+    LocalAssignment {
+        source_expression: String,
+        line: usize,
+    },
+    FunctionParameter {
+        parameter_index: usize,
+    },
+    ImportedFunction {
+        import_info: FunctionImport,
+    },
+    DirectTaintSource {
+        pattern: String,
+        line: usize,
+    },
 }
 
 /// Analysis result enumeration for conservative approach
@@ -2527,23 +3083,24 @@ impl MultiFileTaintAnalyzer {
         // UPDATED: Check language_filter first, then fall back to original logic
         let mut target_files = Vec::new();
         let mut target_language = None;
-        
+
         // If language_filter is specified, use that language exclusively
         if let Some(filter_lang) = language_filter {
             if let Some(filtered_files) = files_by_language.get(filter_lang) {
                 if !filtered_files.is_empty() {
                     target_files.extend(filtered_files.clone());
                     target_language = Some(filter_lang);
-                    log::debug!("[CROSS_FILE_NEW] Using language_filter: {} ({} files)", filter_lang, filtered_files.len());
+                    log::debug!(
+                        "[CROSS_FILE_NEW] Using language_filter: {} ({} files)",
+                        filter_lang,
+                        filtered_files.len()
+                    );
                 }
             }
-        } else {
-            
-            if let Some(python_files) = files_by_language.get("python") {
-                if !python_files.is_empty() {
-                    target_files.extend(python_files.clone());
-                    target_language = Some("python");
-                }
+        } else if let Some(python_files) = files_by_language.get("python") {
+            if !python_files.is_empty() {
+                target_files.extend(python_files.clone());
+                target_language = Some("python");
             }
         }
         // If still no files, skip cross-file analysis
@@ -2551,11 +3108,14 @@ impl MultiFileTaintAnalyzer {
             log::debug!("[CROSS_FILE_NEW] No suitable files found for cross-file analysis");
             return Ok(Vec::new());
         }
-        
+
         let language = target_language.unwrap();
-        log::debug!("[CROSS_FILE_NEW] Analyzing {} {} files for cross-file taint flows", 
-            target_files.len(), language);
-        
+        log::debug!(
+            "[CROSS_FILE_NEW] Analyzing {} {} files for cross-file taint flows",
+            target_files.len(),
+            language
+        );
+
         // Initialize the new DataFlowTracer with the appropriate language files
         let mut data_flow_tracer = DataFlowTracer::new();
         data_flow_tracer.initialize(&target_files, taint_rules)?;
@@ -2566,13 +3126,20 @@ impl MultiFileTaintAnalyzer {
         // Build legacy import/export maps for sink discovery (temporary)
         self.build_import_export_maps(files_by_language, taint_rules, language_filter)?;
 
-        log::debug!("[CROSS_FILE_NEW] Analyzing {} files with sinks", self.file_imports.len());
+        log::debug!(
+            "[CROSS_FILE_NEW] Analyzing {} files with sinks",
+            self.file_imports.len()
+        );
 
         // For each file with sinks, use the new precise analysis
         for (sink_file, imports) in &self.file_imports {
             for sink_info in &imports.taint_sinks {
-                log::debug!("[CROSS_FILE_NEW] Analyzing sink: {} in {}::{}", 
-                    sink_info.used_variable, sink_file, sink_info.function);
+                log::debug!(
+                    "[CROSS_FILE_NEW] Analyzing sink: {} in {}::{}",
+                    sink_info.used_variable,
+                    sink_file,
+                    sink_info.function
+                );
 
                 // Use the new DataFlowTracer for precise analysis
                 let analysis_result = data_flow_tracer.analyze_sink_variable(
@@ -2586,21 +3153,33 @@ impl MultiFileTaintAnalyzer {
 
                 match analysis_result {
                     AnalysisResult::DefinitelyTainted { flow } => {
-                        log::debug!("[CROSS_FILE_NEW] VERIFIED taint flow: {} -> {}", 
-                            flow.source_pattern, flow.sink_pattern);
+                        log::debug!(
+                            "[CROSS_FILE_NEW] VERIFIED taint flow: {} -> {}",
+                            flow.source_pattern,
+                            flow.sink_pattern
+                        );
 
                         // Get the appropriate rule for this flow
-                        if let Some(rule) = rule_deduplicator.get_rule_for_combination(&flow.source_pattern, &flow.sink_pattern) {
+                        if let Some(rule) = rule_deduplicator
+                            .get_rule_for_combination(&flow.source_pattern, &flow.sink_pattern)
+                        {
                             let finding = self.create_finding_from_verified_flow(&flow, rule);
                             findings.push(finding);
                         }
                     }
                     AnalysisResult::DefinitelySafe => {
-                        log::debug!("[CROSS_FILE_NEW] SAFE: No taint flow to {}", sink_info.used_variable);
+                        log::debug!(
+                            "[CROSS_FILE_NEW] SAFE: No taint flow to {}",
+                            sink_info.used_variable
+                        );
                         // Don't create any finding - this is definitely safe
                     }
                     AnalysisResult::Unknown { reason } => {
-                        log::debug!("[CROSS_FILE_NEW] UNKNOWN: {} for {}", reason, sink_info.used_variable);
+                        log::debug!(
+                            "[CROSS_FILE_NEW] UNKNOWN: {} for {}",
+                            reason,
+                            sink_info.used_variable
+                        );
                         // For now, don't create findings for unknown cases to reduce false positives
                         // Could add a flag to include these if needed
                     }
@@ -2608,7 +3187,10 @@ impl MultiFileTaintAnalyzer {
             }
         }
 
-        log::debug!("[CROSS_FILE_NEW] Enhanced analysis complete. Found {} verified flows", findings.len());
+        log::debug!(
+            "[CROSS_FILE_NEW] Enhanced analysis complete. Found {} verified flows",
+            findings.len()
+        );
         Ok(findings)
     }
 
@@ -2619,13 +3201,19 @@ impl MultiFileTaintAnalyzer {
         rule: &crate::rules::UnifiedRule,
     ) -> crate::models::Finding {
         let description = if flow.source_file == flow.sink_file {
-            format!("Verified taint flow: {} -> {} within {}", 
-                flow.source_pattern, flow.sink_pattern, flow.source_file)
+            format!(
+                "Verified taint flow: {} -> {} within {}",
+                flow.source_pattern, flow.sink_pattern, flow.source_file
+            )
         } else {
-            format!("Verified cross-file taint flow: {} in {} -> {} in {} via {} call(s)", 
-                flow.source_pattern, flow.source_file, 
-                flow.sink_pattern, flow.sink_file,
-                flow.call_chain.len())
+            format!(
+                "Verified cross-file taint flow: {} in {} -> {} in {} via {} call(s)",
+                flow.source_pattern,
+                flow.source_file,
+                flow.sink_pattern,
+                flow.sink_file,
+                flow.call_chain.len()
+            )
         };
 
         let mut finding = crate::models::Finding {
@@ -2635,10 +3223,19 @@ impl MultiFileTaintAnalyzer {
             end_line: flow.sink_line,
             end_column: 0,
             function: flow.sink_function.clone(),
-            finding_type: rule.finding_type.clone().unwrap_or_else(|| "Unknown".to_string()),
+            finding_type: rule
+                .finding_type
+                .clone()
+                .unwrap_or_else(|| "Unknown".to_string()),
             snippet: format!("Sink: {}", flow.sink_pattern),
-            severity: rule.severity.clone().unwrap_or_else(|| "Medium".to_string()),
-            confidence: rule.confidence.clone().unwrap_or_else(|| "High".to_string()),
+            severity: rule
+                .severity
+                .clone()
+                .unwrap_or_else(|| "Medium".to_string()),
+            confidence: rule
+                .confidence
+                .clone()
+                .unwrap_or_else(|| "High".to_string()),
             description: Some(description),
             cwe_id: None,
             source_info: Some(crate::models::SourceInfo {
@@ -2657,15 +3254,14 @@ impl MultiFileTaintAnalyzer {
         };
 
         // Use CWE ID directly from rule, with fallback to tags for backward compatibility
-        finding.cwe_id = rule.cwe_id.clone()
-            .or_else(|| {
-                // Fallback: extract from tags if rule doesn't have cwe_id field
-                if let Some(ref tags) = rule.tags {
-                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
-                } else {
-                    None
-                }
-            });
+        finding.cwe_id = rule.cwe_id.clone().or_else(|| {
+            // Fallback: extract from tags if rule doesn't have cwe_id field
+            if let Some(ref tags) = rule.tags {
+                crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+            } else {
+                None
+            }
+        });
 
         finding
     }
@@ -2766,14 +3362,19 @@ impl MultiFileTaintAnalyzer {
             let func_name = crate::scanner::utils::AstUtils::get_function_context(&node, source);
 
             // Skip string literals and metadata
-            if node_text.trim().starts_with('"') || node_text.trim().starts_with("'") ||
-               node_text.contains("__all__") || node_text.contains("__version__") {
+            if node_text.trim().starts_with('"')
+                || node_text.trim().starts_with("'")
+                || node_text.contains("__all__")
+                || node_text.contains("__version__")
+            {
                 continue;
             }
 
             // Check for function definitions
             if crate::scanner::utils::AstUtils::is_function_node(&node) {
-                if let Some(function_name) = crate::scanner::utils::AstUtils::extract_function_name(&node, source) {
+                if let Some(function_name) =
+                    crate::scanner::utils::AstUtils::extract_function_name(&node, source)
+                {
                     exports.functions.insert(function_name);
                 }
             }
@@ -2786,7 +3387,9 @@ impl MultiFileTaintAnalyzer {
                         module_name
                     } else {
                         // Convert module_a -> tests/test_files/accuracy_tests/cross_file/module_a.py
-                        let base_dir = std::path::Path::new(filepath).parent().unwrap_or(std::path::Path::new(""));
+                        let base_dir = std::path::Path::new(filepath)
+                            .parent()
+                            .unwrap_or(std::path::Path::new(""));
                         let module_file = format!("{}.py", module_name);
                         base_dir.join(module_file).to_string_lossy().to_string()
                     };
@@ -2796,7 +3399,9 @@ impl MultiFileTaintAnalyzer {
             }
 
             // Check for taint sources (environment variables, command line args, etc.)
-            if let Some(source_pattern) = Self::extract_taint_source_pattern(&node, source, rule_deduplicator) {
+            if let Some(source_pattern) =
+                Self::extract_taint_source_pattern(&node, source, rule_deduplicator)
+            {
                 exports.taint_sources.push(TaintSourceInfo {
                     function: func_name.clone(),
                     line,
@@ -2806,20 +3411,24 @@ impl MultiFileTaintAnalyzer {
             }
 
             // ENHANCED: Check if this is a function definition that contains taint sources
-            if node.kind() == "function_definition" {
-                if Self::function_contains_taint_sources(&node, source, rule_deduplicator) {
-                    let function_name = crate::scanner::utils::AstUtils::extract_function_name(&node, source).unwrap_or("unknown".to_string());
-                    exports.taint_sources.push(TaintSourceInfo {
-                        function: function_name,
-                        line,
-                        pattern: "function_with_taint_sources".to_string(),
-                        code: node_text.clone(),
-                    });
-                }
+            if node.kind() == "function_definition"
+                && Self::function_contains_taint_sources(&node, source, rule_deduplicator)
+            {
+                let function_name =
+                    crate::scanner::utils::AstUtils::extract_function_name(&node, source)
+                        .unwrap_or("unknown".to_string());
+                exports.taint_sources.push(TaintSourceInfo {
+                    function: function_name,
+                    line,
+                    pattern: "function_with_taint_sources".to_string(),
+                    code: node_text.clone(),
+                });
             }
 
             // Check for taint sinks (eval, exec, os.system, etc.)
-            if let Some(sink_pattern) = Self::extract_taint_sink_pattern(&node, source, rule_deduplicator) {
+            if let Some(sink_pattern) =
+                Self::extract_taint_sink_pattern(&node, source, rule_deduplicator)
+            {
                 // Extract variables from function call arguments
                 let used_variables = CommonUtils::extract_all_variables(&node_text);
                 if let Some(first_var) = used_variables.first() {
@@ -2867,8 +3476,6 @@ impl MultiFileTaintAnalyzer {
         None
     }
 
-
-
     /// Enhanced taint source matching for complex expressions - NEW function
     fn enhanced_taint_source_matching(
         pattern: &str,
@@ -2877,37 +3484,35 @@ impl MultiFileTaintAnalyzer {
         source: &[u8],
     ) -> bool {
         // Handle os.environ patterns
-        if pattern.contains("os.environ") || pattern.contains("os\\.environ") {
-            if node_text.contains("os.environ") ||
-               node_text.contains("os.getenv") ||
-               Self::contains_os_environ_call(node, source) {
-                return true;
-            }
+        if (pattern.contains("os.environ") || pattern.contains("os\\.environ"))
+            && (node_text.contains("os.environ")
+                || node_text.contains("os.getenv")
+                || Self::contains_os_environ_call(node, source))
+        {
+            return true;
         }
 
         // Handle sys.argv patterns
-        if pattern.contains("sys.argv") || pattern.contains("sys\\.argv") {
-            if node_text.contains("sys.argv") ||
-               Self::contains_sys_argv_access(node, source) {
-                return true;
-            }
+        if (pattern.contains("sys.argv") || pattern.contains("sys\\.argv"))
+            && (node_text.contains("sys.argv") || Self::contains_sys_argv_access(node, source))
+        {
+            return true;
         }
 
         // Handle request patterns (web frameworks)
-        if pattern.contains("request") {
-            if node_text.contains("request.") ||
-               node_text.contains("flask.request") ||
-               node_text.contains("django.request") {
-                return true;
-            }
+        if pattern.contains("request")
+            && (node_text.contains("request.")
+                || node_text.contains("flask.request")
+                || node_text.contains("django.request"))
+        {
+            return true;
         }
 
         // Handle input patterns
-        if pattern.contains("input(") || pattern.contains("input\\(") {
-            if node_text.contains("input(") ||
-               node_text.contains("raw_input(") {
-                return true;
-            }
+        if (pattern.contains("input(") || pattern.contains("input\\("))
+            && (node_text.contains("input(") || node_text.contains("raw_input("))
+        {
+            return true;
         }
 
         false
@@ -2927,9 +3532,10 @@ impl MultiFileTaintAnalyzer {
         if node.kind() == "call" {
             if let Some(func_node) = node.child_by_field_name("function") {
                 let func_text = crate::parser::get_node_text(&func_node, source);
-                if func_text.contains("os.environ") ||
-                   func_text.contains("os.getenv") ||
-                   func_text == "getenv" {
+                if func_text.contains("os.environ")
+                    || func_text.contains("os.getenv")
+                    || func_text == "getenv"
+                {
                     return true;
                 }
             }
@@ -2984,7 +3590,11 @@ impl MultiFileTaintAnalyzer {
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> Option<String> {
         let node_text = crate::parser::get_node_text(node, source);
-        log::debug!("[EXTRACT_SINK] Node kind: '{}', text: '{}'", node.kind(), node_text);
+        log::debug!(
+            "[EXTRACT_SINK] Node kind: '{}', text: '{}'",
+            node.kind(),
+            node_text
+        );
 
         // Skip string literals and other non-code nodes
         if node.kind() == "string" || node.kind() == "string_literal" {
@@ -2994,16 +3604,25 @@ impl MultiFileTaintAnalyzer {
 
         // For call nodes, extract the function name
         if node.kind() == "call" {
-            if let Some(func_name) = crate::scanner::utils::AstUtils::extract_function_name(node, source) {
+            if let Some(func_name) =
+                crate::scanner::utils::AstUtils::extract_function_name(node, source)
+            {
                 log::debug!("[EXTRACT_SINK] Call node with function: '{}'", func_name);
                 // Check if this function name matches any taint sink patterns
                 for pattern in &rule_deduplicator.sink_patterns {
                     if Self::function_matches_pattern(&func_name, pattern) {
-                        log::debug!("[EXTRACT_SINK] Function '{}' matched sink pattern: '{}'", func_name, pattern);
+                        log::debug!(
+                            "[EXTRACT_SINK] Function '{}' matched sink pattern: '{}'",
+                            func_name,
+                            pattern
+                        );
                         return Some(pattern.clone());
                     }
                 }
-                log::debug!("[EXTRACT_SINK] Function '{}' matched no sink patterns", func_name);
+                log::debug!(
+                    "[EXTRACT_SINK] Function '{}' matched no sink patterns",
+                    func_name
+                );
             } else {
                 log::debug!("[EXTRACT_SINK] Could not extract function name from call node");
             }
@@ -3011,23 +3630,34 @@ impl MultiFileTaintAnalyzer {
 
         // For expression nodes, check the full expression
         if node.kind() == "expression_statement" || node.kind() == "binary_expression" {
-            log::debug!("[EXTRACT_SINK] Checking expression node against {} patterns", rule_deduplicator.sink_patterns.len());
+            log::debug!(
+                "[EXTRACT_SINK] Checking expression node against {} patterns",
+                rule_deduplicator.sink_patterns.len()
+            );
             for pattern in &rule_deduplicator.sink_patterns {
-                if CommonUtils::matches_taint_pattern_in_context(pattern, &node_text, node.kind(), "expression") {
-                    log::debug!("[EXTRACT_SINK] Expression '{}' matched sink pattern: '{}'", node_text, pattern);
+                if CommonUtils::matches_taint_pattern_in_context(
+                    pattern,
+                    &node_text,
+                    node.kind(),
+                    "expression",
+                ) {
+                    log::debug!(
+                        "[EXTRACT_SINK] Expression '{}' matched sink pattern: '{}'",
+                        node_text,
+                        pattern
+                    );
                     return Some(pattern.clone());
                 }
             }
-            log::debug!("[EXTRACT_SINK] Expression '{}' matched no sink patterns", node_text);
+            log::debug!(
+                "[EXTRACT_SINK] Expression '{}' matched no sink patterns",
+                node_text
+            );
         }
 
         log::debug!("[EXTRACT_SINK] No patterns matched for node");
         None
     }
-
-
-
-
 
     /// Check if a function name matches a taint pattern
     fn function_matches_pattern(func_name: &str, pattern: &str) -> bool {
@@ -3038,38 +3668,55 @@ impl MultiFileTaintAnalyzer {
             .replace("\\.", ".")
             .replace("\\\\", "\\");
 
-        log::debug!("[FUNC_MATCH] Checking function '{}' against pattern '{}' (clean: '{}')", 
-            func_name, pattern, clean_pattern);
+        log::debug!(
+            "[FUNC_MATCH] Checking function '{}' against pattern '{}' (clean: '{}')",
+            func_name,
+            pattern,
+            clean_pattern
+        );
 
         // Check if the function name matches the pattern
         if clean_pattern.contains(func_name) {
-            log::debug!("[FUNC_MATCH] Match via contains: '{}' contains '{}'", clean_pattern, func_name);
+            log::debug!(
+                "[FUNC_MATCH] Match via contains: '{}' contains '{}'",
+                clean_pattern,
+                func_name
+            );
             return true;
         }
 
         // Handle patterns like "os\\.system" -> "os.system"
-        if clean_pattern.contains(".") && func_name.contains(".") {
-            if clean_pattern == func_name {
-                log::debug!("[FUNC_MATCH] Match via exact dot notation: '{}' == '{}'", clean_pattern, func_name);
-                return true;
-            }
+        if clean_pattern.contains(".") && func_name.contains(".") && clean_pattern == func_name {
+            log::debug!(
+                "[FUNC_MATCH] Match via exact dot notation: '{}' == '{}'",
+                clean_pattern,
+                func_name
+            );
+            return true;
         }
 
         // Handle patterns like "eval\\(" -> "eval"
         if clean_pattern.ends_with(func_name) {
-            log::debug!("[FUNC_MATCH] Match via ends_with: '{}' ends with '{}'", clean_pattern, func_name);
+            log::debug!(
+                "[FUNC_MATCH] Match via ends_with: '{}' ends with '{}'",
+                clean_pattern,
+                func_name
+            );
             return true;
         }
 
-        log::debug!("[FUNC_MATCH] No match: '{}' vs pattern '{}' (clean: '{}')", func_name, pattern, clean_pattern);
+        log::debug!(
+            "[FUNC_MATCH] No match: '{}' vs pattern '{}' (clean: '{}')",
+            func_name,
+            pattern,
+            clean_pattern
+        );
         false
     }
 
-
-
     /// Create a finding from a cross-file taint flow
     fn create_cross_file_finding(&self, flow: &CrossFileTaintFlow) -> crate::models::Finding {
-        let taint_source = crate::models::TaintSource {
+        let _taint_source = crate::models::TaintSource {
             file: flow.source_file.clone(),
             line: flow.source_line,
             function: flow.source_function.clone(),
@@ -3079,7 +3726,7 @@ impl MultiFileTaintAnalyzer {
             branch_id: None,
         };
 
-        let taint_sink = crate::models::TaintSink {
+        let _taint_sink = crate::models::TaintSink {
             file: flow.sink_file.clone(),
             line: flow.sink_line,
             function: flow.sink_function.clone(),
@@ -3096,14 +3743,31 @@ impl MultiFileTaintAnalyzer {
             end_line: flow.sink_line,
             end_column: 0,
             function: flow.sink_function.clone(),
-            finding_type: flow.rule.finding_type.clone().unwrap_or_else(|| "Cross-File Taint Flow".to_string()),
-            snippet: format!("Cross-file flow: {} -> {}", flow.source_file, flow.sink_file),
-            severity: flow.rule.severity.clone().unwrap_or_else(|| "High".to_string()),
-            confidence: flow.rule.confidence.clone().unwrap_or_else(|| "Medium".to_string()),
-            description: flow.rule.description.clone().or_else(|| Some(format!(
-                "Cross-file taint flow detected from {} (line {}) to {} (line {})",
-                flow.source_function, flow.source_line, flow.sink_function, flow.sink_line
-            ))),
+            finding_type: flow
+                .rule
+                .finding_type
+                .clone()
+                .unwrap_or_else(|| "Cross-File Taint Flow".to_string()),
+            snippet: format!(
+                "Cross-file flow: {} -> {}",
+                flow.source_file, flow.sink_file
+            ),
+            severity: flow
+                .rule
+                .severity
+                .clone()
+                .unwrap_or_else(|| "High".to_string()),
+            confidence: flow
+                .rule
+                .confidence
+                .clone()
+                .unwrap_or_else(|| "Medium".to_string()),
+            description: flow.rule.description.clone().or_else(|| {
+                Some(format!(
+                    "Cross-file taint flow detected from {} (line {}) to {} (line {})",
+                    flow.source_function, flow.source_line, flow.sink_function, flow.sink_line
+                ))
+            }),
             cwe_id: None,
             source_info: Some(crate::models::SourceInfo {
                 source_type: "cross_file_import".to_string(),
@@ -3121,20 +3785,22 @@ impl MultiFileTaintAnalyzer {
                 "taint_analysis".to_string(),
                 "cross_file".to_string(),
                 "data_flow".to_string(),
-                flow.rule.category.clone().unwrap_or_else(|| "injection".to_string()),
+                flow.rule
+                    .category
+                    .clone()
+                    .unwrap_or_else(|| "injection".to_string()),
             ]),
         };
 
         // Use CWE ID directly from rule, with fallback to tags for backward compatibility
-        finding.cwe_id = flow.rule.cwe_id.clone()
-            .or_else(|| {
-                // Fallback: extract from tags if rule doesn't have cwe_id field
-                if let Some(ref tags) = flow.rule.tags {
-                    crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
-                } else {
-                    None
-                }
-            });
+        finding.cwe_id = flow.rule.cwe_id.clone().or_else(|| {
+            // Fallback: extract from tags if rule doesn't have cwe_id field
+            if let Some(ref tags) = flow.rule.tags {
+                crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
+            } else {
+                None
+            }
+        });
 
         finding
     }
@@ -3153,18 +3819,18 @@ impl MultiFileTaintAnalyzer {
 
                     // Clean up import part - remove parentheses and newlines
                     let cleaned_import_part = import_part
-                        .replace('(', "")
-                        .replace(')', "")
-                        .replace('\n', " ")
-                        .replace('\r', " ");
+                        .replace(['(', ')'], "")
+                        .replace(['\n', '\r'], " ");
 
                     // Handle multiple imports: "from module import func1, func2"
                     for import in cleaned_import_part.split(',') {
                         let func_name = import.trim();
-                        if !func_name.is_empty() &&
-                           !func_name.starts_with('"') &&
-                           !func_name.starts_with("'") &&
-                           !func_name.contains("__") { // Skip __all__ etc
+                        if !func_name.is_empty()
+                            && !func_name.starts_with('"')
+                            && !func_name.starts_with("'")
+                            && !func_name.contains("__")
+                        {
+                            // Skip __all__ etc
                             imports.push((func_name.to_string(), module_part.to_string()));
                         }
                     }
@@ -3175,7 +3841,10 @@ impl MultiFileTaintAnalyzer {
         // Handle "import module" pattern (for module-level imports)
         if trimmed_text.starts_with("import ") && !trimmed_text.contains(" from ") {
             let module_part = &trimmed_text[7..].trim();
-            if !module_part.is_empty() && !module_part.starts_with('"') && !module_part.starts_with("'") {
+            if !module_part.is_empty()
+                && !module_part.starts_with('"')
+                && !module_part.starts_with("'")
+            {
                 // For module imports, we'll track the module name itself
                 imports.push((module_part.to_string(), module_part.to_string()));
             }
@@ -3187,10 +3856,6 @@ impl MultiFileTaintAnalyzer {
             Some(imports)
         }
     }
-
-
-
-
 
     /// Recursively trace taint from a sink variable/function back to sources across files - COMPLETELY REWRITTEN
     fn trace_taint_to_source(
@@ -3211,13 +3876,22 @@ impl MultiFileTaintAnalyzer {
         if let Some(exports) = self.file_exports.get(start_file) {
             for source_info in &exports.taint_sources {
                 // Check if the function name matches
-                if &source_info.function == start_var {
-                    return Some((start_file.to_string(), source_info.clone(), vec![start_file.to_string()]));
+                if source_info.function == start_var {
+                    return Some((
+                        start_file.to_string(),
+                        source_info.clone(),
+                        vec![start_file.to_string()],
+                    ));
                 }
 
                 // Check if the variable might be related to this taint source
-                if source_info.code.contains(start_var) || source_info.function.contains(start_var) {
-                    return Some((start_file.to_string(), source_info.clone(), vec![start_file.to_string()]));
+                if source_info.code.contains(start_var) || source_info.function.contains(start_var)
+                {
+                    return Some((
+                        start_file.to_string(),
+                        source_info.clone(),
+                        vec![start_file.to_string()],
+                    ));
                 }
             }
         }
@@ -3230,11 +3904,20 @@ impl MultiFileTaintAnalyzer {
                 if imported_func == start_var ||
                    start_var.contains(imported_func) ||
                    imported_func.contains("get_") ||  // Common taint source pattern
-                   imported_func.contains("propagate_") {  // Common propagation pattern
+                   imported_func.contains("propagate_")
+                {
+                    // Common propagation pattern
 
                     // Recursively trace in the source file
-                    if let Some((final_source_file, final_source_info, mut path)) =
-                        self.trace_taint_to_source(source_file, imported_func, visited, max_hops, current_hops + 1) {
+                    if let Some((final_source_file, final_source_info, mut path)) = self
+                        .trace_taint_to_source(
+                            source_file,
+                            imported_func,
+                            visited,
+                            max_hops,
+                            current_hops + 1,
+                        )
+                    {
                         path.push(start_file.to_string());
                         return Some((final_source_file, final_source_info, path));
                     }
@@ -3249,11 +3932,11 @@ impl MultiFileTaintAnalyzer {
                 if let Some(source_exports) = self.file_exports.get(source_file) {
                     for source_info in &source_exports.taint_sources {
                         // If this imported function contains taint sources, trace it
-                        if &source_info.function == imported_func ||
-                           source_info.function.contains("get_") ||
-                           source_info.function.contains("env") ||
-                           source_info.function.contains("arg") {
-
+                        if &source_info.function == imported_func
+                            || source_info.function.contains("get_")
+                            || source_info.function.contains("env")
+                            || source_info.function.contains("arg")
+                        {
                             let path = vec![source_file.to_string(), start_file.to_string()];
                             return Some((source_file.to_string(), source_info.clone(), path));
                         }
@@ -3266,29 +3949,34 @@ impl MultiFileTaintAnalyzer {
         if let Some(imports) = self.file_imports.get(start_file) {
             for (imported_func, source_file) in &imports.functions {
                 // For functions that might be propagating taint
-                if imported_func.starts_with("propagate_") ||
-                   imported_func.starts_with("get_") ||
-                   imported_func.contains("config") ||
-                   imported_func.contains("data") ||
-                   imported_func.contains("env") {
-
+                if imported_func.starts_with("propagate_")
+                    || imported_func.starts_with("get_")
+                    || imported_func.contains("config")
+                    || imported_func.contains("data")
+                    || imported_func.contains("env")
+                {
                     // Check if the source file has taint sources
                     if let Some(source_exports) = self.file_exports.get(source_file) {
                         if !source_exports.taint_sources.is_empty() {
                             // Find the most relevant taint source
                             for source_info in &source_exports.taint_sources {
                                 // Match by function name or by pattern relevance
-                                if &source_info.function == imported_func ||
-                                   source_info.function.contains("get_") ||
-                                   source_info.function.contains("database") ||
-                                   source_info.function.contains("config") ||
-                                   source_info.function.contains("env") ||
-                                   source_info.function.contains("arg") ||
-                                   source_info.pattern.contains("os.environ") ||
-                                   source_info.pattern.contains("sys.argv") {
-
-                                    let path = vec![source_file.to_string(), start_file.to_string()];
-                                    return Some((source_file.to_string(), source_info.clone(), path));
+                                if &source_info.function == imported_func
+                                    || source_info.function.contains("get_")
+                                    || source_info.function.contains("database")
+                                    || source_info.function.contains("config")
+                                    || source_info.function.contains("env")
+                                    || source_info.function.contains("arg")
+                                    || source_info.pattern.contains("os.environ")
+                                    || source_info.pattern.contains("sys.argv")
+                                {
+                                    let path =
+                                        vec![source_file.to_string(), start_file.to_string()];
+                                    return Some((
+                                        source_file.to_string(),
+                                        source_info.clone(),
+                                        path,
+                                    ));
                                 }
                             }
                         }
@@ -3299,7 +3987,7 @@ impl MultiFileTaintAnalyzer {
 
         // Strategy 5: Last resort - if we have any taint sources in imported files, use them
         if let Some(imports) = self.file_imports.get(start_file) {
-            for (imported_func, source_file) in &imports.functions {
+            for source_file in imports.functions.values() {
                 if let Some(source_exports) = self.file_exports.get(source_file) {
                     if !source_exports.taint_sources.is_empty() {
                         // Use the first available taint source as a potential match
@@ -3354,7 +4042,8 @@ impl MultiFileTaintAnalyzer {
 #[derive(Debug)]
 struct ImportResolver {
     /// Bidirectional import mapping: file -> imported functions
-    import_graph: std::collections::HashMap<String, std::collections::HashMap<String, FunctionImport>>,
+    import_graph:
+        std::collections::HashMap<String, std::collections::HashMap<String, FunctionImport>>,
     /// Reverse mapping: file -> files that import from it
     reverse_import_graph: std::collections::HashMap<String, std::collections::HashSet<String>>,
     /// Cache for resolved file paths
@@ -3371,16 +4060,21 @@ impl ImportResolver {
     }
 
     /// Convert relative imports to absolute file paths
-    fn resolve_import_path(&mut self, importing_file: &str, imported_module: &str) -> Option<String> {
+    fn resolve_import_path(
+        &mut self,
+        importing_file: &str,
+        imported_module: &str,
+    ) -> Option<String> {
         let cache_key = (importing_file.to_string(), imported_module.to_string());
-        
+
         // Check cache first
         if let Some(cached_result) = self.path_resolution_cache.get(&cache_key) {
             return cached_result.clone();
         }
 
         let resolved_path = self.compute_import_path(importing_file, imported_module);
-        self.path_resolution_cache.insert(cache_key, resolved_path.clone());
+        self.path_resolution_cache
+            .insert(cache_key, resolved_path.clone());
         resolved_path
     }
 
@@ -3410,18 +4104,25 @@ impl ImportResolver {
         }
 
         // Try with __init__.py
-        let package_path = importing_dir.join(&imported_module).join("__init__.py");
+        let package_path = importing_dir.join(imported_module).join("__init__.py");
         if package_path.exists() {
             return Some(package_path.to_string_lossy().to_string());
         }
 
-        log::debug!("[IMPORT_RESOLVER] Could not resolve import '{}' from '{}'", imported_module, importing_file);
+        log::debug!(
+            "[IMPORT_RESOLVER] Could not resolve import '{}' from '{}'",
+            imported_module,
+            importing_file
+        );
         None
     }
 
     /// Build bidirectional import mapping for all files
     fn build_import_graph(&mut self, files: &[std::path::PathBuf]) -> Result<()> {
-        log::debug!("[IMPORT_RESOLVER] Building import graph for {} files", files.len());
+        log::debug!(
+            "[IMPORT_RESOLVER] Building import graph for {} files",
+            files.len()
+        );
 
         for file_path in files {
             self.analyze_file_imports(file_path)?;
@@ -3429,8 +4130,11 @@ impl ImportResolver {
 
         // Build reverse mapping
         self.build_reverse_import_graph();
-        
-        log::debug!("[IMPORT_RESOLVER] Import graph built: {} files with imports", self.import_graph.len());
+
+        log::debug!(
+            "[IMPORT_RESOLVER] Import graph built: {} files with imports",
+            self.import_graph.len()
+        );
         Ok(())
     }
 
@@ -3446,15 +4150,21 @@ impl ImportResolver {
 
             // Collect all nodes to find import statements
             let mut all_nodes = Vec::new();
-            ScanningLogic::collect_all_relevant_nodes(tree.root_node(), &mut all_nodes, Some(&source));
+            ScanningLogic::collect_all_relevant_nodes(
+                tree.root_node(),
+                &mut all_nodes,
+                Some(&source),
+            );
 
             for node in all_nodes {
                 let node_text = crate::parser::get_node_text(&node, &source);
-                
+
                 // Extract import information using existing logic
                 if let Some(import_list) = MultiFileTaintAnalyzer::extract_import_info(&node_text) {
                     for (func_name, module_name) in import_list {
-                        if let Some(resolved_path) = self.resolve_import_path(&filepath_str, &module_name) {
+                        if let Some(resolved_path) =
+                            self.resolve_import_path(&filepath_str, &module_name)
+                        {
                             let function_import = FunctionImport {
                                 local_name: func_name.clone(),
                                 source_file: resolved_path,
@@ -3483,7 +4193,7 @@ impl ImportResolver {
             for import in imports.values() {
                 self.reverse_import_graph
                     .entry(import.source_file.clone())
-                    .or_insert_with(std::collections::HashSet::new)
+                    .or_default()
                     .insert(importing_file.clone());
             }
         }
@@ -3499,12 +4209,15 @@ impl ImportResolver {
         // TODO: Could add more sophisticated validation here
         // - Check if the function is actually exported
         // - Verify function signature compatibility
-        
+
         true
     }
 
     /// Get all imports for a specific file
-    fn get_file_imports(&self, file_path: &str) -> Option<&std::collections::HashMap<String, FunctionImport>> {
+    fn get_file_imports(
+        &self,
+        file_path: &str,
+    ) -> Option<&std::collections::HashMap<String, FunctionImport>> {
         self.import_graph.get(file_path)
     }
 
@@ -3514,7 +4227,11 @@ impl ImportResolver {
     }
 
     /// Resolve function location (file and function name) for a given function call
-    fn resolve_function_location(&self, function_name: &str, calling_file: &str) -> Option<(String, String)> {
+    fn resolve_function_location(
+        &self,
+        function_name: &str,
+        calling_file: &str,
+    ) -> Option<(String, String)> {
         // Check if it's an imported function
         if let Some(imports) = self.get_file_imports(calling_file) {
             if let Some(import) = imports.get(function_name) {
@@ -3561,7 +4278,7 @@ impl FunctionBodyAnalyzer {
         // Find all function definitions (collect them first to avoid borrow conflicts)
         let function_nodes = self.extract_function_definitions(tree.root_node());
         let mut function_data = Vec::new();
-        
+
         // Extract function names and analyze behaviors
         for func_node in function_nodes {
             let func_name = self.extract_function_name(&func_node, source);
@@ -3573,33 +4290,37 @@ impl FunctionBodyAnalyzer {
                     source,
                     rule_deduplicator,
                 )?;
-                
+
                 function_data.push((function_name, behavior));
             }
         }
-        
+
         // Now insert all the function behaviors
         for (function_name, behavior) in function_data {
-            self.function_behaviors.insert(
-                (file_path.to_string(), function_name),
-                behavior,
-            );
+            self.function_behaviors
+                .insert((file_path.to_string(), function_name), behavior);
         }
 
-        log::debug!("[FUNCTION_ANALYZER] Analyzed {} functions in {}", 
-            self.function_behaviors.len(), file_path);
+        log::debug!(
+            "[FUNCTION_ANALYZER] Analyzed {} functions in {}",
+            self.function_behaviors.len(),
+            file_path
+        );
         Ok(())
     }
 
     /// Extract all function definition nodes from the AST
-    fn extract_function_definitions<'a>(&self, root: tree_sitter::Node<'a>) -> Vec<tree_sitter::Node<'a>> {
+    fn extract_function_definitions<'a>(
+        &self,
+        root: tree_sitter::Node<'a>,
+    ) -> Vec<tree_sitter::Node<'a>> {
         let mut functions = Vec::new();
         let mut cursor = root.walk();
 
         if cursor.goto_first_child() {
             loop {
                 let node = cursor.node();
-                
+
                 // Check if this is a function definition
                 if node.kind() == "function_definition" {
                     functions.push(node);
@@ -3618,9 +4339,13 @@ impl FunctionBodyAnalyzer {
     }
 
     /// Extract function name from a function definition node
-    fn extract_function_name(&self, func_node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    fn extract_function_name(
+        &self,
+        func_node: &tree_sitter::Node,
+        source: &[u8],
+    ) -> Option<String> {
         let mut cursor = func_node.walk();
-        
+
         if cursor.goto_first_child() {
             loop {
                 let node = cursor.node();
@@ -3628,26 +4353,29 @@ impl FunctionBodyAnalyzer {
                     let name = crate::parser::get_node_text(&node, source);
                     return Some(name);
                 }
-                
+
                 if !cursor.goto_next_sibling() {
                     break;
                 }
             }
         }
-        
+
         None
     }
 
     /// Analyze a single function for taint behavior
     fn analyze_function_body(
         &self,
-        file_path: &str,
+        _file_path: &str,
         function_name: &str,
         func_node: &tree_sitter::Node,
         source: &[u8],
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> Result<FunctionTaintBehavior> {
-        log::debug!("  [FUNCTION_ANALYZER] Analyzing function: {}", function_name);
+        log::debug!(
+            "  [FUNCTION_ANALYZER] Analyzing function: {}",
+            function_name
+        );
 
         let mut behavior = FunctionTaintBehavior {
             returns_tainted_data: false,
@@ -3667,14 +4395,20 @@ impl FunctionBodyAnalyzer {
 
             // Check for taint sources
             if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(&node_text) {
-                log::debug!("    [FUNCTION_ANALYZER] Found taint source: {} -> {}", source_pattern, node_text);
+                log::debug!(
+                    "    [FUNCTION_ANALYZER] Found taint source: {} -> {}",
+                    source_pattern,
+                    node_text
+                );
                 behavior.taint_sources_used.push(source_pattern);
                 behavior.returns_tainted_data = true; // Assume function returns tainted if it accesses sources
             }
 
             // Check for function calls (potential imports)
             if node.kind() == "call" {
-                if let Some(called_func) = crate::scanner::utils::AstUtils::extract_function_name(&node, source) {
+                if let Some(called_func) =
+                    crate::scanner::utils::AstUtils::extract_function_name(&node, source)
+                {
                     let func_call = FunctionCall {
                         target_function: called_func,
                         target_file: None, // Will be resolved later by ImportResolver
@@ -3687,7 +4421,8 @@ impl FunctionBodyAnalyzer {
 
             // Check for return statements that might propagate taint
             if node.kind() == "return_statement" {
-                behavior.returns_tainted_data = self.return_statement_uses_tainted_data(&node, source, &behavior);
+                behavior.returns_tainted_data =
+                    self.return_statement_uses_tainted_data(&node, source, &behavior);
             }
 
             // Check for argument propagation patterns
@@ -3696,32 +4431,43 @@ impl FunctionBodyAnalyzer {
             }
         }
 
-        log::debug!("    [FUNCTION_ANALYZER] Function {} behavior: returns_tainted={}, sources={:?}", 
-            function_name, behavior.returns_tainted_data, behavior.taint_sources_used);
+        log::debug!(
+            "    [FUNCTION_ANALYZER] Function {} behavior: returns_tainted={}, sources={:?}",
+            function_name,
+            behavior.returns_tainted_data,
+            behavior.taint_sources_used
+        );
 
         Ok(behavior)
     }
 
     /// Extract function arguments from a call node
-    fn extract_function_arguments(&self, call_node: &tree_sitter::Node, source: &[u8]) -> Vec<String> {
+    fn extract_function_arguments(
+        &self,
+        call_node: &tree_sitter::Node,
+        source: &[u8],
+    ) -> Vec<String> {
         let mut arguments = Vec::new();
         let mut cursor = call_node.walk();
 
         if cursor.goto_first_child() {
             loop {
                 let node = cursor.node();
-                
+
                 // Look for argument_list node
                 if node.kind() == "argument_list" {
                     let mut arg_cursor = node.walk();
                     if arg_cursor.goto_first_child() {
                         loop {
                             let arg_node = arg_cursor.node();
-                            if arg_node.kind() != "(" && arg_node.kind() != ")" && arg_node.kind() != "," {
+                            if arg_node.kind() != "("
+                                && arg_node.kind() != ")"
+                                && arg_node.kind() != ","
+                            {
                                 let arg_text = crate::parser::get_node_text(&arg_node, source);
                                 arguments.push(arg_text);
                             }
-                            
+
                             if !arg_cursor.goto_next_sibling() {
                                 break;
                             }
@@ -3729,7 +4475,7 @@ impl FunctionBodyAnalyzer {
                     }
                     break;
                 }
-                
+
                 if !cursor.goto_next_sibling() {
                     break;
                 }
@@ -3747,7 +4493,7 @@ impl FunctionBodyAnalyzer {
         function_behavior: &FunctionTaintBehavior,
     ) -> bool {
         let return_text = crate::parser::get_node_text(return_node, source);
-        
+
         // Check if return statement mentions any variables that could be tainted
         for taint_source in &function_behavior.taint_sources_used {
             if return_text.contains(taint_source) {
@@ -3756,20 +4502,24 @@ impl FunctionBodyAnalyzer {
         }
 
         // Check for common patterns that propagate taint
-        return_text.contains("request.") ||
-        return_text.contains("input(") ||
-        return_text.contains("os.environ") ||
-        return_text.contains("sys.argv")
+        return_text.contains("request.")
+            || return_text.contains("input(")
+            || return_text.contains("os.environ")
+            || return_text.contains("sys.argv")
     }
 
     /// Detect which argument positions get propagated to return value
-    fn detect_argument_propagation(&self, node: &tree_sitter::Node, source: &[u8]) -> Option<Vec<usize>> {
+    fn detect_argument_propagation(
+        &self,
+        node: &tree_sitter::Node,
+        source: &[u8],
+    ) -> Option<Vec<usize>> {
         let node_text = crate::parser::get_node_text(node, source);
-        
+
         // Simple heuristic: if return statement mentions parameter names
         if node.kind() == "return_statement" {
             let mut propagated_args = Vec::new();
-            
+
             // Look for common parameter names that get returned
             if node_text.contains("data") {
                 propagated_args.push(0); // Assume first parameter
@@ -3780,36 +4530,41 @@ impl FunctionBodyAnalyzer {
             if node_text.contains("value") {
                 propagated_args.push(0);
             }
-            
+
             if !propagated_args.is_empty() {
                 return Some(propagated_args);
             }
         }
-        
+
         None
     }
 
     /// Get analyzed behavior for a specific function
-    fn get_function_behavior(&self, file_path: &str, function_name: &str) -> Option<&FunctionTaintBehavior> {
-        self.function_behaviors.get(&(file_path.to_string(), function_name.to_string()))
+    fn get_function_behavior(
+        &self,
+        file_path: &str,
+        function_name: &str,
+    ) -> Option<&FunctionTaintBehavior> {
+        self.function_behaviors
+            .get(&(file_path.to_string(), function_name.to_string()))
     }
 
     /// Check if a function definitely returns tainted data
     fn function_returns_tainted_data(&self, file_path: &str, function_name: &str) -> TaintStatus {
         if let Some(behavior) = self.get_function_behavior(file_path, function_name) {
             if behavior.returns_tainted_data {
-                return TaintStatus::Tainted { 
-                    patterns: behavior.taint_sources_used.clone() 
+                return TaintStatus::Tainted {
+                    patterns: behavior.taint_sources_used.clone(),
                 };
             } else if !behavior.taint_sources_used.is_empty() {
-                return TaintStatus::Conditional { 
-                    conditions: behavior.taint_sources_used.clone() 
+                return TaintStatus::Conditional {
+                    conditions: behavior.taint_sources_used.clone(),
                 };
             } else {
                 return TaintStatus::Safe;
             }
         }
-        
+
         TaintStatus::Unknown
     }
 
@@ -3823,7 +4578,7 @@ impl FunctionBodyAnalyzer {
     ) -> Vec<FunctionCallNode> {
         let mut call_chain = Vec::new();
         let mut visited = std::collections::HashSet::new();
-        
+
         self.trace_function_calls_recursive(
             start_file,
             start_function,
@@ -3833,7 +4588,7 @@ impl FunctionBodyAnalyzer {
             max_depth,
             0,
         );
-        
+
         call_chain
     }
 
@@ -3863,7 +4618,9 @@ impl FunctionBodyAnalyzer {
                 arguments: Vec::new(),
                 return_value: None,
                 calls_made: behavior.imported_functions_called.clone(),
-                taint_sources_accessed: behavior.taint_sources_used.iter()
+                taint_sources_accessed: behavior
+                    .taint_sources_used
+                    .iter()
                     .map(|pattern| TaintSourceAccess {
                         pattern: pattern.clone(),
                         line: 0, // TODO: Extract actual line
@@ -3874,7 +4631,9 @@ impl FunctionBodyAnalyzer {
 
             // For each function this one calls, resolve location and recurse
             for func_call in &behavior.imported_functions_called {
-                if let Some((target_file, target_func)) = import_resolver.resolve_function_location(&func_call.target_function, file_path) {
+                if let Some((target_file, target_func)) =
+                    import_resolver.resolve_function_location(&func_call.target_function, file_path)
+                {
                     self.trace_function_calls_recursive(
                         &target_file,
                         &target_func,
@@ -3974,8 +4733,12 @@ impl DataFlowTracer {
         sink_line: usize,
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> AnalysisResult {
-        log::debug!("[DATA_FLOW_TRACER] Analyzing sink variable '{}' in {}::{}", 
-            sink_variable, sink_file, sink_function);
+        log::debug!(
+            "[DATA_FLOW_TRACER] Analyzing sink variable '{}' in {}::{}",
+            sink_variable,
+            sink_file,
+            sink_function
+        );
 
         // Step 1: Determine how this variable gets its value
         let variable_source = self.analyze_variable_source(
@@ -3987,57 +4750,99 @@ impl DataFlowTracer {
 
         match variable_source {
             VariableSource::DirectTaintSource { pattern, line } => {
-                log::debug!("[DATA_FLOW_TRACER] Direct taint source found: {} at line {}", pattern, line);
+                log::debug!(
+                    "[DATA_FLOW_TRACER] Direct taint source found: {} at line {}",
+                    pattern,
+                    line
+                );
                 self.create_verified_flow(
-                    sink_file, sink_function, &pattern, line,
-                    sink_file, sink_function, sink_pattern, sink_line, sink_variable,
+                    sink_file,
+                    sink_function,
+                    &pattern,
+                    line,
+                    sink_file,
+                    sink_function,
+                    sink_pattern,
+                    sink_line,
+                    sink_variable,
                     Vec::new(),
                 )
             }
-            
+
             VariableSource::ImportedFunction { import_info } => {
-                log::debug!("[DATA_FLOW_TRACER] Variable from imported function: {} from {}", 
-                    import_info.local_name, import_info.source_file);
+                log::debug!(
+                    "[DATA_FLOW_TRACER] Variable from imported function: {} from {}",
+                    import_info.local_name,
+                    import_info.source_file
+                );
                 self.trace_imported_function_taint(
                     import_info,
-                    sink_file, sink_function, sink_pattern, sink_line, sink_variable,
+                    sink_file,
+                    sink_function,
+                    sink_pattern,
+                    sink_line,
+                    sink_variable,
                     rule_deduplicator,
                 )
             }
-            
-            VariableSource::LocalAssignment { source_expression, line } => {
-                log::debug!("[DATA_FLOW_TRACER] Variable from local assignment: '{}' at line {}", 
-                    source_expression, line);
+
+            VariableSource::LocalAssignment {
+                source_expression,
+                line,
+            } => {
+                log::debug!(
+                    "[DATA_FLOW_TRACER] Variable from local assignment: '{}' at line {}",
+                    source_expression,
+                    line
+                );
                 self.trace_local_assignment_taint(
-                    sink_file, sink_function, &source_expression, line,
-                    sink_pattern, sink_line, sink_variable,
+                    sink_file,
+                    sink_function,
+                    &source_expression,
+                    line,
+                    sink_pattern,
+                    sink_line,
+                    sink_variable,
                     rule_deduplicator,
                 )
             }
-            
+
             VariableSource::FunctionParameter { parameter_index } => {
-                log::debug!("[DATA_FLOW_TRACER] Variable from function parameter {}", parameter_index);
-                
+                log::debug!(
+                    "[DATA_FLOW_TRACER] Variable from function parameter {}",
+                    parameter_index
+                );
+
                 // Check if the parameter name matches any taint source patterns
-                if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(sink_variable) {
-                    log::debug!("[DATA_FLOW_TRACER] Function parameter '{}' matches source pattern '{}'", sink_variable, source_pattern);
-                    
+                if let Some(source_pattern) =
+                    rule_deduplicator.matches_source_pattern(sink_variable)
+                {
+                    log::debug!(
+                        "[DATA_FLOW_TRACER] Function parameter '{}' matches source pattern '{}'",
+                        sink_variable,
+                        source_pattern
+                    );
+
                     // Treat function parameters that match source patterns as taint sources
                     let flow = VerifiedTaintFlow {
                         source_file: sink_file.to_string(),
                         source_function: sink_function.to_string(),
                         source_pattern: source_pattern.clone(),
                         source_line: 1, // Function definition line (approximate)
-                        
+
                         sink_file: sink_file.to_string(),
                         sink_function: sink_function.to_string(),
                         sink_pattern: sink_pattern.to_string(),
                         sink_line,
                         sink_variable: sink_variable.to_string(),
-                        
+
                         call_chain: Vec::new(),
                         data_flow_evidence: DataFlowEvidence {
-                            variable_assignments: vec![(sink_variable.to_string(), format!("function parameter {}", parameter_index), 1)],
+                            variable_assignments: vec![(
+                                sink_variable.to_string(),
+                                format!("function parameter {}", parameter_index),
+                                1,
+                            )],
                             function_calls: Vec::new(),
                             return_statements: Vec::new(),
                         },
@@ -4046,9 +4851,12 @@ impl DataFlowTracer {
                     self.verified_flows.push(flow.clone());
                     return AnalysisResult::DefinitelyTainted { flow };
                 }
-                
-                AnalysisResult::Unknown { 
-                    reason: format!("Function parameter {} - requires caller analysis", parameter_index) 
+
+                AnalysisResult::Unknown {
+                    reason: format!(
+                        "Function parameter {} - requires caller analysis",
+                        parameter_index
+                    ),
                 }
             }
         }
@@ -4062,14 +4870,23 @@ impl DataFlowTracer {
         variable_name: &str,
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> VariableSource {
-        let cache_key = (file_path.to_string(), function_name.to_string(), variable_name.to_string());
-        
+        let cache_key = (
+            file_path.to_string(),
+            function_name.to_string(),
+            variable_name.to_string(),
+        );
+
         // Check cache first
         if let Some(cached_source) = self.variable_source_cache.get(&cache_key) {
             return cached_source.clone();
         }
 
-        let source = self.compute_variable_source(file_path, function_name, variable_name, rule_deduplicator);
+        let source = self.compute_variable_source(
+            file_path,
+            function_name,
+            variable_name,
+            rule_deduplicator,
+        );
         self.variable_source_cache.insert(cache_key, source.clone());
         source
     }
@@ -4098,13 +4915,13 @@ impl DataFlowTracer {
             source_function: source_function.to_string(),
             source_pattern: source_pattern.to_string(),
             source_line,
-            
+
             sink_file: sink_file.to_string(),
             sink_function: sink_function.to_string(),
             sink_pattern: sink_pattern.to_string(),
             sink_line,
             sink_variable: sink_variable.to_string(),
-            
+
             call_chain,
             data_flow_evidence: DataFlowEvidence {
                 variable_assignments: Vec::new(), // TODO: Collect from AST analysis
@@ -4113,11 +4930,17 @@ impl DataFlowTracer {
             },
         };
 
-        log::debug!("[DATA_FLOW_TRACER] Verified taint flow: {} -> {} via {:?}", 
-            source_pattern, sink_pattern, verified_flow.call_chain.len());
+        log::debug!(
+            "[DATA_FLOW_TRACER] Verified taint flow: {} -> {} via {:?}",
+            source_pattern,
+            sink_pattern,
+            verified_flow.call_chain.len()
+        );
 
         self.verified_flows.push(verified_flow.clone());
-        AnalysisResult::DefinitelyTainted { flow: verified_flow }
+        AnalysisResult::DefinitelyTainted {
+            flow: verified_flow,
+        }
     }
 
     /// Actually analyze how a variable gets its value within a function
@@ -4128,14 +4951,21 @@ impl DataFlowTracer {
         variable_name: &str,
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> VariableSource {
-        log::debug!("[COMPUTE_VARIABLE_SOURCE] Analyzing variable '{}' in {}::{}", 
-            variable_name, file_path, function_name);
+        log::debug!(
+            "[COMPUTE_VARIABLE_SOURCE] Analyzing variable '{}' in {}::{}",
+            variable_name,
+            file_path,
+            function_name
+        );
 
         // Read the source code as text and do simple string analysis
         let source_text = match std::fs::read_to_string(file_path) {
             Ok(content) => content,
             Err(_) => {
-                log::debug!("[COMPUTE_VARIABLE_SOURCE] Could not read file: {}", file_path);
+                log::debug!(
+                    "[COMPUTE_VARIABLE_SOURCE] Could not read file: {}",
+                    file_path
+                );
                 return VariableSource::FunctionParameter { parameter_index: 0 };
             }
         };
@@ -4146,40 +4976,51 @@ impl DataFlowTracer {
             let line = line.trim();
             if line.starts_with(&format!("{} =", variable_name)) {
                 let rhs = line.split('=').nth(1).unwrap_or("").trim();
-                log::debug!("[COMPUTE_VARIABLE_SOURCE] Found assignment: {} = {}", variable_name, rhs);
+                log::debug!(
+                    "[COMPUTE_VARIABLE_SOURCE] Found assignment: {} = {}",
+                    variable_name,
+                    rhs
+                );
 
                 // Check if RHS is a direct taint source
                 if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(rhs) {
-                    log::debug!("[COMPUTE_VARIABLE_SOURCE] Direct taint source: '{}'", source_pattern);
-                    return VariableSource::DirectTaintSource { 
-                        pattern: source_pattern, 
-                        line: line_num + 1 
+                    log::debug!(
+                        "[COMPUTE_VARIABLE_SOURCE] Direct taint source: '{}'",
+                        source_pattern
+                    );
+                    return VariableSource::DirectTaintSource {
+                        pattern: source_pattern,
+                        line: line_num + 1,
                     };
                 }
 
                 // Check if RHS is a function call
                 if rhs.contains('(') && rhs.contains(')') {
                     let function_name = rhs.split('(').next().unwrap_or("").trim();
-                    log::debug!("[COMPUTE_VARIABLE_SOURCE] Function call assignment: '{}'", function_name);
-                    return VariableSource::LocalAssignment { 
-                        source_expression: rhs.to_string(), 
-                        line: line_num + 1 
+                    log::debug!(
+                        "[COMPUTE_VARIABLE_SOURCE] Function call assignment: '{}'",
+                        function_name
+                    );
+                    return VariableSource::LocalAssignment {
+                        source_expression: rhs.to_string(),
+                        line: line_num + 1,
                     };
                 }
 
                 // Otherwise, it's a simple local assignment
                 log::debug!("[COMPUTE_VARIABLE_SOURCE] Local assignment: '{}'", rhs);
-                return VariableSource::LocalAssignment { 
-                    source_expression: rhs.to_string(), 
-                    line: line_num + 1 
+                return VariableSource::LocalAssignment {
+                    source_expression: rhs.to_string(),
+                    line: line_num + 1,
                 };
             }
         }
 
         // Check if it might be a function parameter by looking for function definition
-        if let Some(func_line) = source_text.lines().find(|line| {
-            line.trim().starts_with(&format!("def {}(", function_name))
-        }) {
+        if let Some(func_line) = source_text
+            .lines()
+            .find(|line| line.trim().starts_with(&format!("def {}(", function_name)))
+        {
             if func_line.contains(variable_name) {
                 // Simple parameter detection
                 if let Some(params_part) = func_line.split('(').nth(1) {
@@ -4189,7 +5030,9 @@ impl DataFlowTracer {
                             if param == &variable_name {
                                 log::debug!("[COMPUTE_VARIABLE_SOURCE] Variable '{}' is function parameter at index {}", 
                                     variable_name, index);
-                                return VariableSource::FunctionParameter { parameter_index: index };
+                                return VariableSource::FunctionParameter {
+                                    parameter_index: index,
+                                };
                             }
                         }
                     }
@@ -4198,11 +5041,12 @@ impl DataFlowTracer {
         }
 
         // Default case - treat as parameter 0
-        log::debug!("[COMPUTE_VARIABLE_SOURCE] Variable '{}' source unknown, defaulting to parameter 0", variable_name);
+        log::debug!(
+            "[COMPUTE_VARIABLE_SOURCE] Variable '{}' source unknown, defaulting to parameter 0",
+            variable_name
+        );
         VariableSource::FunctionParameter { parameter_index: 0 }
     }
-
-
 
     fn trace_imported_function_taint(
         &mut self,
@@ -4214,27 +5058,37 @@ impl DataFlowTracer {
         sink_variable: &str,
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> AnalysisResult {
-        log::debug!("[TRACE_IMPORTED] Tracing imported function '{}' from '{}'", 
-            import_info.local_name, import_info.source_file);
+        log::debug!(
+            "[TRACE_IMPORTED] Tracing imported function '{}' from '{}'",
+            import_info.local_name,
+            import_info.source_file
+        );
 
         // Analyze the imported function in its source file
-        match self.analyze_function_taint_behavior(&import_info.source_file, &import_info.source_function, rule_deduplicator) {
+        match self.analyze_function_taint_behavior(
+            &import_info.source_file,
+            &import_info.source_function,
+            rule_deduplicator,
+        ) {
             AnalysisResult::DefinitelyTainted { flow } => {
-                log::debug!("[TRACE_IMPORTED] Function '{}' is tainted, creating cross-file flow", import_info.local_name);
-                
+                log::debug!(
+                    "[TRACE_IMPORTED] Function '{}' is tainted, creating cross-file flow",
+                    import_info.local_name
+                );
+
                 // Create a cross-file verified taint flow
                 let cross_file_flow = VerifiedTaintFlow {
                     source_file: flow.source_file,
                     source_function: flow.source_function,
                     source_pattern: flow.source_pattern,
                     source_line: flow.source_line,
-                    
+
                     sink_file: sink_file.to_string(),
                     sink_function: sink_function.to_string(),
                     sink_pattern: sink_pattern.to_string(),
                     sink_line,
                     sink_variable: sink_variable.to_string(),
-                    
+
                     call_chain: vec![FunctionCallNode {
                         function_name: import_info.local_name.clone(),
                         file_path: import_info.source_file.clone(),
@@ -4248,14 +5102,23 @@ impl DataFlowTracer {
                 };
 
                 self.verified_flows.push(cross_file_flow.clone());
-                AnalysisResult::DefinitelyTainted { flow: cross_file_flow }
-            },
+                AnalysisResult::DefinitelyTainted {
+                    flow: cross_file_flow,
+                }
+            }
             AnalysisResult::DefinitelySafe => {
-                log::debug!("[TRACE_IMPORTED] Function '{}' is safe", import_info.local_name);
+                log::debug!(
+                    "[TRACE_IMPORTED] Function '{}' is safe",
+                    import_info.local_name
+                );
                 AnalysisResult::DefinitelySafe
-            },
+            }
             AnalysisResult::Unknown { reason } => {
-                log::debug!("[TRACE_IMPORTED] Function '{}' analysis inconclusive: {}", import_info.local_name, reason);
+                log::debug!(
+                    "[TRACE_IMPORTED] Function '{}' analysis inconclusive: {}",
+                    import_info.local_name,
+                    reason
+                );
                 AnalysisResult::Unknown { reason }
             }
         }
@@ -4272,28 +5135,39 @@ impl DataFlowTracer {
         sink_variable: &str,
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> AnalysisResult {
-        log::debug!("[TRACE_LOCAL] Analyzing local assignment: '{}' in {}::{}", 
-            source_expression, file_path, function_name);
+        log::debug!(
+            "[TRACE_LOCAL] Analyzing local assignment: '{}' in {}::{}",
+            source_expression,
+            file_path,
+            function_name
+        );
 
         // Check if the source expression is a direct taint source
         if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(source_expression) {
-            log::debug!("[TRACE_LOCAL] Direct taint source found: '{}'", source_pattern);
-            
+            log::debug!(
+                "[TRACE_LOCAL] Direct taint source found: '{}'",
+                source_pattern
+            );
+
             let flow = VerifiedTaintFlow {
                 source_file: file_path.to_string(),
                 source_function: function_name.to_string(),
                 source_pattern: source_pattern.clone(),
                 source_line: assignment_line,
-                
+
                 sink_file: file_path.to_string(),
                 sink_function: function_name.to_string(),
                 sink_pattern: sink_pattern.to_string(),
                 sink_line,
                 sink_variable: sink_variable.to_string(),
-                
+
                 call_chain: Vec::new(),
                 data_flow_evidence: DataFlowEvidence {
-                    variable_assignments: vec![(sink_variable.to_string(), source_expression.to_string(), assignment_line)],
+                    variable_assignments: vec![(
+                        sink_variable.to_string(),
+                        source_expression.to_string(),
+                        assignment_line,
+                    )],
                     function_calls: Vec::new(),
                     return_statements: Vec::new(),
                 },
@@ -4310,26 +5184,34 @@ impl DataFlowTracer {
 
             // Find the source file for this function
             if let Some(source_file) = self.find_function_source_file(&function_name, file_path) {
-                log::debug!("[TRACE_LOCAL] Found function '{}' in '{}'", function_name, source_file);
-                
+                log::debug!(
+                    "[TRACE_LOCAL] Found function '{}' in '{}'",
+                    function_name,
+                    source_file
+                );
+
                 // Analyze the function to see if it returns tainted data
-                match self.analyze_function_taint_behavior(&source_file, &function_name, rule_deduplicator) {
+                match self.analyze_function_taint_behavior(
+                    &source_file,
+                    &function_name,
+                    rule_deduplicator,
+                ) {
                     AnalysisResult::DefinitelyTainted { flow } => {
                         log::debug!("[TRACE_LOCAL] Function '{}' returns tainted data, creating cross-file flow", function_name);
-                        
+
                         // Create a cross-file taint flow from the original source to the current sink
                         let cross_file_flow = VerifiedTaintFlow {
                             source_file: flow.source_file,
                             source_function: flow.source_function,
                             source_pattern: flow.source_pattern,
                             source_line: flow.source_line,
-                            
+
                             sink_file: file_path.to_string(),
                             sink_function: function_name.to_string(),
                             sink_pattern: sink_pattern.to_string(),
                             sink_line,
                             sink_variable: sink_variable.to_string(),
-                            
+
                             call_chain: vec![FunctionCallNode {
                                 function_name: function_name.clone(),
                                 file_path: source_file,
@@ -4340,19 +5222,32 @@ impl DataFlowTracer {
                                 taint_sources_accessed: Vec::new(),
                             }],
                             data_flow_evidence: DataFlowEvidence {
-                                variable_assignments: vec![(sink_variable.to_string(), source_expression.to_string(), assignment_line)],
-                                function_calls: vec![(function_name.clone(), "()".to_string(), assignment_line)],
+                                variable_assignments: vec![(
+                                    sink_variable.to_string(),
+                                    source_expression.to_string(),
+                                    assignment_line,
+                                )],
+                                function_calls: vec![(
+                                    function_name.clone(),
+                                    "()".to_string(),
+                                    assignment_line,
+                                )],
                                 return_statements: flow.data_flow_evidence.return_statements,
                             },
                         };
 
                         self.verified_flows.push(cross_file_flow.clone());
-                        return AnalysisResult::DefinitelyTainted { flow: cross_file_flow };
-                    },
+                        return AnalysisResult::DefinitelyTainted {
+                            flow: cross_file_flow,
+                        };
+                    }
                     other_result => return other_result,
                 }
             } else {
-                log::debug!("[TRACE_LOCAL] Could not find source file for function '{}'", function_name);
+                log::debug!(
+                    "[TRACE_LOCAL] Could not find source file for function '{}'",
+                    function_name
+                );
             }
         }
 
@@ -4370,8 +5265,11 @@ impl DataFlowTracer {
         }
 
         log::debug!("[TRACE_LOCAL] Could not determine taint status of assignment");
-        AnalysisResult::Unknown { 
-            reason: format!("Complex assignment analysis not implemented: \"{}\"", source_expression) 
+        AnalysisResult::Unknown {
+            reason: format!(
+                "Complex assignment analysis not implemented: \"{}\"",
+                source_expression
+            ),
         }
     }
 
@@ -4386,49 +5284,76 @@ impl DataFlowTracer {
 
     /// Find which file contains the definition of an imported function
     fn find_function_source_file(&self, function_name: &str, calling_file: &str) -> Option<String> {
-        log::debug!("[FIND_SOURCE_FILE] Looking for function \"{}\" imported by \"{}\"", function_name, calling_file);
+        log::debug!(
+            "[FIND_SOURCE_FILE] Looking for function \"{}\" imported by \"{}\"",
+            function_name,
+            calling_file
+        );
 
-        let calling_dir = std::path::Path::new(calling_file).parent()
+        let calling_dir = std::path::Path::new(calling_file)
+            .parent()
             .and_then(|p| p.to_str())
             .unwrap_or("");
 
         // Known patterns from the test files
-        match function_name.as_ref() {
+        match function_name {
             "get_database_config" | "get_user_args" | "get_safe_module_data" => {
                 let module_a_path = format!("{}/module_a.py", calling_dir);
                 if std::path::Path::new(&module_a_path).exists() {
-                    log::debug!("[FIND_SOURCE_FILE] Found \"{}\" in module_a.py", function_name);
+                    log::debug!(
+                        "[FIND_SOURCE_FILE] Found \"{}\" in module_a.py",
+                        function_name
+                    );
                     return Some(module_a_path);
                 }
-            },
-            name if name.starts_with("propagate_") || name == "combine_tainted_sources" 
-                 || name == "mix_safe_and_tainted" || name == "get_local_taint" 
-                 || name == "complex_processing_chain" || name == "use_class_instance" => {
+            }
+            name if name.starts_with("propagate_")
+                || name == "combine_tainted_sources"
+                || name == "mix_safe_and_tainted"
+                || name == "get_local_taint"
+                || name == "complex_processing_chain"
+                || name == "use_class_instance" =>
+            {
                 let module_b_path = format!("{}/module_b.py", calling_dir);
                 if std::path::Path::new(&module_b_path).exists() {
-                    log::debug!("[FIND_SOURCE_FILE] Found \"{}\" in module_b.py", function_name);
+                    log::debug!(
+                        "[FIND_SOURCE_FILE] Found \"{}\" in module_b.py",
+                        function_name
+                    );
                     return Some(module_b_path);
                 }
-            },
+            }
             _ => {
                 // Try to find in any Python file in the same directory
                 if let Ok(entries) = std::fs::read_dir(calling_dir) {
                     for entry in entries.flatten() {
                         if let Some(file_name) = entry.file_name().to_str() {
-                                                    if file_name.ends_with(".py") && file_name != std::path::Path::new(calling_file).file_name().unwrap_or_default() {
-                            let candidate_path = format!("{}/{}", calling_dir, file_name);
-                            if self.file_contains_function(&candidate_path, function_name) {
-                                log::debug!("[FIND_SOURCE_FILE] Found \"{}\" in \"{}\"", function_name, candidate_path);
-                                return Some(candidate_path);
+                            if file_name.ends_with(".py")
+                                && file_name
+                                    != std::path::Path::new(calling_file)
+                                        .file_name()
+                                        .unwrap_or_default()
+                            {
+                                let candidate_path = format!("{}/{}", calling_dir, file_name);
+                                if self.file_contains_function(&candidate_path, function_name) {
+                                    log::debug!(
+                                        "[FIND_SOURCE_FILE] Found \"{}\" in \"{}\"",
+                                        function_name,
+                                        candidate_path
+                                    );
+                                    return Some(candidate_path);
+                                }
                             }
-                        }
                         }
                     }
                 }
             }
         }
 
-        log::debug!("[FIND_SOURCE_FILE] Could not find source file for function \"{}\"", function_name);
+        log::debug!(
+            "[FIND_SOURCE_FILE] Could not find source file for function \"{}\"",
+            function_name
+        );
         None
     }
 
@@ -4449,14 +5374,18 @@ impl DataFlowTracer {
         function_name: &str,
         rule_deduplicator: &TaintRuleDeduplicator,
     ) -> AnalysisResult {
-        log::debug!("[ANALYZE_FUNCTION] Analyzing function \"{}\" in \"{}\"", function_name, file_path);
+        log::debug!(
+            "[ANALYZE_FUNCTION] Analyzing function \"{}\" in \"{}\"",
+            function_name,
+            file_path
+        );
 
         let source_text = match std::fs::read_to_string(file_path) {
             Ok(content) => content,
             Err(_) => {
                 log::debug!("[ANALYZE_FUNCTION] Could not read file: {}", file_path);
-                return AnalysisResult::Unknown { 
-                    reason: format!("Could not read source file: {}", file_path) 
+                return AnalysisResult::Unknown {
+                    reason: format!("Could not read source file: {}", file_path),
                 };
             }
         };
@@ -4466,15 +5395,23 @@ impl DataFlowTracer {
 
             for (line_num, line) in function_body.lines().enumerate() {
                 let line = line.trim();
-                
+
                 if line.starts_with("return ") {
                     let return_expr = line.strip_prefix("return ").unwrap_or("").trim();
-                    log::debug!("[ANALYZE_FUNCTION] Found return statement: \"{}\"", return_expr);
+                    log::debug!(
+                        "[ANALYZE_FUNCTION] Found return statement: \"{}\"",
+                        return_expr
+                    );
 
                     // Check if return expression is a direct taint source
-                    if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(return_expr) {
-                        log::debug!("[ANALYZE_FUNCTION] Function returns direct taint source: \"{}\"", source_pattern);
-                        
+                    if let Some(source_pattern) =
+                        rule_deduplicator.matches_source_pattern(return_expr)
+                    {
+                        log::debug!(
+                            "[ANALYZE_FUNCTION] Function returns direct taint source: \"{}\"",
+                            source_pattern
+                        );
+
                         let flow = VerifiedTaintFlow {
                             source_file: file_path.to_string(),
                             source_function: function_name.to_string(),
@@ -4497,21 +5434,31 @@ impl DataFlowTracer {
 
                     // Check if return expression is another function call
                     if return_expr.contains('(') && return_expr.contains(')') {
-                        log::debug!("[ANALYZE_FUNCTION] Return calls another function: \"{}\"", return_expr);
-                        
-                        let nested_result = self.trace_local_assignment_taint(
-                            file_path, function_name, return_expr, line_num + 1,
-                            "function_return", line_num + 1, "return_value",
-                            rule_deduplicator
+                        log::debug!(
+                            "[ANALYZE_FUNCTION] Return calls another function: \"{}\"",
+                            return_expr
                         );
-                        
+
+                        let nested_result = self.trace_local_assignment_taint(
+                            file_path,
+                            function_name,
+                            return_expr,
+                            line_num + 1,
+                            "function_return",
+                            line_num + 1,
+                            "return_value",
+                            rule_deduplicator,
+                        );
+
                         match nested_result {
                             AnalysisResult::DefinitelyTainted { flow } => {
                                 log::debug!("[ANALYZE_FUNCTION] Nested function is tainted, propagating taint");
                                 return AnalysisResult::DefinitelyTainted { flow };
-                            },
+                            }
                             _ => {
-                                log::debug!("[ANALYZE_FUNCTION] Nested function analysis inconclusive");
+                                log::debug!(
+                                    "[ANALYZE_FUNCTION] Nested function analysis inconclusive"
+                                );
                             }
                         }
                     }
@@ -4522,9 +5469,12 @@ impl DataFlowTracer {
             return AnalysisResult::DefinitelySafe;
         }
 
-        log::debug!("[ANALYZE_FUNCTION] Could not find function body for \"{}\"", function_name);
-        AnalysisResult::Unknown { 
-            reason: format!("Could not find function body for \"{}\"", function_name) 
+        log::debug!(
+            "[ANALYZE_FUNCTION] Could not find function body for \"{}\"",
+            function_name
+        );
+        AnalysisResult::Unknown {
+            reason: format!("Could not find function body for \"{}\"", function_name),
         }
     }
 
@@ -4535,11 +5485,18 @@ impl DataFlowTracer {
         let mut function_lines = Vec::new();
         let mut base_indent = None;
 
-        log::debug!("[EXTRACT_FUNCTION_BODY] Looking for function: {}", function_name);
+        log::debug!(
+            "[EXTRACT_FUNCTION_BODY] Looking for function: {}",
+            function_name
+        );
 
         for (line_num, line) in lines.iter().enumerate() {
             if line.trim().starts_with(&format!("def {}(", function_name)) {
-                log::debug!("[EXTRACT_FUNCTION_BODY] Found function definition at line {}: {}", line_num + 1, line.trim());
+                log::debug!(
+                    "[EXTRACT_FUNCTION_BODY] Found function definition at line {}: {}",
+                    line_num + 1,
+                    line.trim()
+                );
                 in_function = true;
                 continue;
             } else if in_function {
@@ -4547,34 +5504,50 @@ impl DataFlowTracer {
                 if base_indent.is_none() && !line.trim().is_empty() {
                     let indent = line.len() - line.trim_start().len();
                     base_indent = Some(indent);
-                    log::debug!("[EXTRACT_FUNCTION_BODY] Base indentation set to: {}", indent);
+                    log::debug!(
+                        "[EXTRACT_FUNCTION_BODY] Base indentation set to: {}",
+                        indent
+                    );
                 }
 
                 // Check if we've reached the end of the function
                 if let Some(indent) = base_indent {
                     // Function ends when we hit a non-empty line with indentation LESS than base
                     if !line.trim().is_empty() && (line.len() - line.trim_start().len()) < indent {
-                        log::debug!("[EXTRACT_FUNCTION_BODY] Function ended at line {}: {}", line_num + 1, line.trim());
+                        log::debug!(
+                            "[EXTRACT_FUNCTION_BODY] Function ended at line {}: {}",
+                            line_num + 1,
+                            line.trim()
+                        );
                         break;
                     }
                 }
 
                 // Add line to function body (including empty lines)
                 function_lines.push(*line);
-                log::debug!("[EXTRACT_FUNCTION_BODY] Added line {}: '{}'", line_num + 1, line);
+                log::debug!(
+                    "[EXTRACT_FUNCTION_BODY] Added line {}: '{}'",
+                    line_num + 1,
+                    line
+                );
             }
         }
 
         if function_lines.is_empty() {
-            log::debug!("[EXTRACT_FUNCTION_BODY] No function body found for: {}", function_name);
+            log::debug!(
+                "[EXTRACT_FUNCTION_BODY] No function body found for: {}",
+                function_name
+            );
             None
         } else {
             let body = function_lines.join("\n");
-            log::debug!("[EXTRACT_FUNCTION_BODY] Extracted {} lines for function: {}", function_lines.len(), function_name);
+            log::debug!(
+                "[EXTRACT_FUNCTION_BODY] Extracted {} lines for function: {}",
+                function_lines.len(),
+                function_name
+            );
             log::debug!("[EXTRACT_FUNCTION_BODY] Function body:\n{}", body);
             Some(body)
         }
     }
 }
-
-

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -17,6 +17,7 @@ use rayon::prelude::*;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::fs::{self, File};
+use std::io::{BufWriter, Write};
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -1696,7 +1697,9 @@ impl VulnerabilityScanner {
     ) -> Result<Vec<Finding>> {
         let files = self.discover_files(root_dir)?;
         if files.is_empty() {
-            println!("No {} files found in {}", language_name, root_dir);
+            if show_progress {
+                println!("No {} files found in {}", language_name, root_dir);
+            }
             return Ok(Vec::new());
         }
 
@@ -1714,7 +1717,9 @@ impl VulnerabilityScanner {
         }
 
         if filtered_files.is_empty() {
-            println!("No {} files remaining after filtering", language_name);
+            if show_progress {
+                println!("No {} files remaining after filtering", language_name);
+            }
             return Ok(Vec::new());
         }
 
@@ -2023,9 +2028,36 @@ impl VulnerabilityScanner {
                 log::info!("Performing cross-file taint analysis...");
             }
 
+            // Restrict cross-file analysis to the files that survived prefiltering and
+            // the code-type/language `retain` above. `files_by_language` is the raw,
+            // unfiltered discovery map, so filter each per-language Vec down to the
+            // paths still present in `filtered_files`. Keeping the same BTreeMap keys
+            // and grouping means the analyzer behaves identically except that
+            // minified/test/doc/excluded files no longer participate.
+            let filtered_set: std::collections::BTreeSet<&std::path::PathBuf> =
+                filtered_files.iter().collect();
+            let filtered_files_by_language: std::collections::BTreeMap<
+                String,
+                Vec<std::path::PathBuf>,
+            > = files_by_language
+                .iter()
+                .filter_map(|(language, paths)| {
+                    let kept: Vec<std::path::PathBuf> = paths
+                        .iter()
+                        .filter(|path| filtered_set.contains(path))
+                        .cloned()
+                        .collect();
+                    if kept.is_empty() {
+                        None
+                    } else {
+                        Some((language.clone(), kept))
+                    }
+                })
+                .collect();
+
             let mut multi_file_analyzer = MultiFileTaintAnalyzer::new();
             match multi_file_analyzer.analyze_cross_file_flows(
-                &files_by_language,
+                &filtered_files_by_language,
                 &taint_rules,
                 language_filter,
             ) {
@@ -2539,16 +2571,20 @@ impl ProgressManager {
 }
 
 /// Print findings in JSON format
-pub fn print_findings_json(findings: &[Finding]) {
-    match serde_json::to_string_pretty(findings) {
-        Ok(json) => println!("{}", json),
-        Err(e) => eprintln!("Error serializing findings to JSON: {}", e),
-    }
+pub fn print_findings_json(findings: &[Finding]) -> Result<()> {
+    let json = serde_json::to_string_pretty(findings)?;
+    let stdout = std::io::stdout();
+    let mut out = BufWriter::new(stdout.lock());
+    writeln!(out, "{}", json)?;
+    out.flush()?;
+    Ok(())
 }
 
 /// Print findings in CSV format
-pub fn print_findings_csv(findings: &[Finding]) {
-    println!("file,line,function,finding_type,code,severity,confidence,cwe_id,source_type,source_context,sink_type,sink_function,traces");
+pub fn print_findings_csv(findings: &[Finding]) -> Result<()> {
+    let stdout = std::io::stdout();
+    let mut out = BufWriter::new(stdout.lock());
+    writeln!(out, "file,line,function,finding_type,code,severity,confidence,cwe_id,source_type,source_context,sink_type,sink_function,traces")?;
     for finding in findings {
         let code = finding.snippet.replace('"', "\"\"");
         let source_type = finding
@@ -2583,7 +2619,8 @@ pub fn print_findings_csv(findings: &[Finding]) {
             String::new()
         };
 
-        println!(
+        writeln!(
+            out,
             "{},{},{},{},\"{}\",{},{},{},{},{},{},{},\"{}\"",
             finding.file,
             finding.line,
@@ -2598,8 +2635,10 @@ pub fn print_findings_csv(findings: &[Finding]) {
             sink_type,
             sink_function,
             traces
-        );
+        )?;
     }
+    out.flush()?;
+    Ok(())
 }
 
 /// Print findings in text format with syntax highlighting
@@ -2997,8 +3036,36 @@ impl MultiFileTaintAnalyzer {
         let mut findings = Vec::new();
         let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
 
+        // Dedup verified cross-file flows within this invocation. The same flow can be
+        // rediscovered when multiple sink_info entries / rule patterns match the same
+        // (sink_file, sink_variable). We key on the full flow identity rather than the sink
+        // line alone so that distinct tainted variables on the same line (now emitted as
+        // separate TaintSinkInfo per used variable) stay separate findings; only a flow whose
+        // source AND sink are byte-for-byte identical is collapsed. BTreeSet keeps the dedup
+        // deterministic per repo convention.
+        let mut seen_flows: std::collections::BTreeSet<(
+            String, // sink_file
+            usize,  // sink_line
+            String, // sink_variable
+            String, // sink_pattern
+            String, // source_file
+            usize,  // source_line
+            String, // source_pattern
+        )> = std::collections::BTreeSet::new();
+
         // Build legacy import/export maps for sink discovery (temporary)
         self.build_import_export_maps(files_by_language, taint_rules, language_filter)?;
+
+        // Hand the parsed import data to the tracer so it can resolve `from foo import bar`
+        // statements to their source file via real imports (no re-parsing). This is derived
+        // from `self.file_imports.functions`, which already maps imported function name ->
+        // resolved source file per calling file.
+        let import_map = self
+            .file_imports
+            .iter()
+            .map(|(file, imports)| (file.clone(), imports.functions.clone()))
+            .collect();
+        data_flow_tracer.set_import_map(import_map);
 
         log::debug!(
             "[CROSS_FILE_NEW] Analyzing {} files with sinks",
@@ -3037,8 +3104,29 @@ impl MultiFileTaintAnalyzer {
                         if let Some(rule) = rule_deduplicator
                             .get_rule_for_combination(&flow.source_pattern, &flow.sink_pattern)
                         {
-                            let finding = self.create_finding_from_verified_flow(&flow, rule);
-                            findings.push(finding);
+                            let flow_key = (
+                                flow.sink_file.clone(),
+                                flow.sink_line,
+                                flow.sink_variable.clone(),
+                                flow.sink_pattern.clone(),
+                                flow.source_file.clone(),
+                                flow.source_line,
+                                flow.source_pattern.clone(),
+                            );
+                            if seen_flows.insert(flow_key) {
+                                let finding = self.create_finding_from_verified_flow(&flow, rule);
+                                findings.push(finding);
+                            } else {
+                                log::debug!(
+                                    "[CROSS_FILE_NEW] Skipping duplicate flow: {} ({}:{}) -> {} ({}:{})",
+                                    flow.source_pattern,
+                                    flow.source_file,
+                                    flow.source_line,
+                                    flow.sink_pattern,
+                                    flow.sink_file,
+                                    flow.sink_line
+                                );
+                            }
                         }
                     }
                     AnalysisResult::DefinitelySafe => {
@@ -3260,14 +3348,22 @@ impl MultiFileTaintAnalyzer {
             if let Some(sink_pattern) =
                 Self::extract_taint_sink_pattern(&node, source, rule_deduplicator)
             {
-                // Extract variables from function call arguments
+                // Extract variables from function call arguments.
+                // `extract_all_variables` sorts+dedups its result, so `.first()`
+                // would return the lexicographically smallest name rather than the
+                // tainted argument (e.g. `subprocess.run(["sh","-c",cmd])` or
+                // `os.system(prefix + cmd)` could record the wrong variable).
+                // Record one sink per used variable so the data-flow tracer can
+                // check every argument — the tainted one is never dropped by sort
+                // order. This mirrors the "check ANY used variable" handling in the
+                // single-file sink analysis above.
                 let used_variables = CommonUtils::extract_all_variables(&node_text);
-                if let Some(first_var) = used_variables.first() {
+                for used_variable in used_variables {
                     imports.taint_sinks.push(TaintSinkInfo {
                         function: func_name.clone(),
                         line,
-                        pattern: sink_pattern,
-                        used_variable: first_var.clone(),
+                        pattern: sink_pattern.clone(),
+                        used_variable,
                     });
                 }
             }
@@ -3471,6 +3567,11 @@ struct DataFlowTracer {
     variable_source_cache: std::collections::HashMap<(String, String, String), VariableSource>,
     /// Verified taint flows that have been fully validated
     verified_flows: Vec<VerifiedTaintFlow>,
+    /// Resolved imports parsed elsewhere: calling_file -> {imported_function -> source_file}.
+    /// Lets `find_function_source_file` resolve real `from foo import bar` statements via the
+    /// already-parsed import data instead of relying on fixture-name heuristics. BTreeMap keeps
+    /// iteration deterministic per repo convention.
+    import_map: std::collections::BTreeMap<String, std::collections::BTreeMap<String, String>>,
 }
 
 impl DataFlowTracer {
@@ -3478,7 +3579,21 @@ impl DataFlowTracer {
         Self {
             variable_source_cache: std::collections::HashMap::new(),
             verified_flows: Vec::new(),
+            import_map: std::collections::BTreeMap::new(),
         }
+    }
+
+    /// Populate the import map from import data already parsed by the analyzer.
+    /// Called before cross-file flow analysis so `find_function_source_file` can resolve
+    /// imported functions to their source file without re-parsing any files.
+    fn set_import_map(
+        &mut self,
+        import_map: std::collections::BTreeMap<
+            String,
+            std::collections::BTreeMap<String, String>,
+        >,
+    ) {
+        self.import_map = import_map;
     }
 
     /// Analyze whether a sink variable in a function truly receives tainted data
@@ -3545,6 +3660,7 @@ impl DataFlowTracer {
                     sink_line,
                     sink_variable,
                     rule_deduplicator,
+                    &mut std::collections::BTreeSet::new(),
                 )
             }
 
@@ -3692,12 +3808,39 @@ impl DataFlowTracer {
             }
         };
 
+        // Scope the assignment search to the enclosing function's body so a
+        // same-named local variable in an EARLIER function can't shadow the
+        // real assignment in the target function. Each body line's 0-based
+        // index `i` maps to absolute file line `start_line + i`.
+        //
+        // Build (line, absolute_file_line) pairs to search. If the function
+        // body can't be located, fall back to the whole-file scan so we never
+        // regress detection (preserves the previous behavior).
+        let scoped_lines: Vec<(usize, String)> =
+            match self.extract_function_body(&source_text, function_name) {
+                Some((body, start_line)) => body
+                    .lines()
+                    .enumerate()
+                    .map(|(i, line)| (start_line + i, line.to_string()))
+                    .collect::<Vec<_>>(),
+                None => source_text
+                    .lines()
+                    .enumerate()
+                    .map(|(i, line)| (i + 1, line.to_string()))
+                    .collect::<Vec<_>>(),
+            };
+
         // Simple text-based analysis for now
         // Look for assignment patterns like "variable_name = something"
-        for (line_num, line) in source_text.lines().enumerate() {
+        for (file_line, line) in &scoped_lines {
+            let file_line = *file_line;
             let line = line.trim();
+            // Note: augmented assignments (`x += ...`, `x -= ...`) are intentionally
+            // not matched by this `{} =` guard and are not handled by this path.
             if line.starts_with(&format!("{} =", variable_name)) {
-                let rhs = line.split('=').nth(1).unwrap_or("").trim();
+                // Split on the FIRST '=' only so the full RHS is preserved even when
+                // it contains '==' or kwarg '=' (e.g. `x = a == b`, `x = f(k=v)`).
+                let rhs = line.split_once('=').map(|(_, rhs)| rhs).unwrap_or("").trim();
                 log::debug!(
                     "[COMPUTE_VARIABLE_SOURCE] Found assignment: {} = {}",
                     variable_name,
@@ -3712,7 +3855,7 @@ impl DataFlowTracer {
                     );
                     return VariableSource::DirectTaintSource {
                         pattern: source_pattern,
-                        line: line_num + 1,
+                        line: file_line,
                     };
                 }
 
@@ -3725,7 +3868,7 @@ impl DataFlowTracer {
                     );
                     return VariableSource::LocalAssignment {
                         source_expression: rhs.to_string(),
-                        line: line_num + 1,
+                        line: file_line,
                     };
                 }
 
@@ -3733,7 +3876,7 @@ impl DataFlowTracer {
                 log::debug!("[COMPUTE_VARIABLE_SOURCE] Local assignment: '{}'", rhs);
                 return VariableSource::LocalAssignment {
                     source_expression: rhs.to_string(),
-                    line: line_num + 1,
+                    line: file_line,
                 };
             }
         }
@@ -3780,6 +3923,7 @@ impl DataFlowTracer {
         sink_line: usize,
         sink_variable: &str,
         rule_deduplicator: &TaintRuleDeduplicator,
+        visited: &mut std::collections::BTreeSet<(String, String)>,
     ) -> AnalysisResult {
         log::debug!(
             "[TRACE_LOCAL] Analyzing local assignment: '{}' in {}::{}",
@@ -3816,25 +3960,26 @@ impl DataFlowTracer {
 
         // Check if the source expression is a function call
         if source_expression.contains('(') && source_expression.contains(')') {
-            let function_name = self.extract_function_name_from_call(source_expression);
-            log::debug!("[TRACE_LOCAL] Source is function call: '{}'", function_name);
+            let callee_name = self.extract_function_name_from_call(source_expression);
+            log::debug!("[TRACE_LOCAL] Source is function call: '{}'", callee_name);
 
             // Find the source file for this function
-            if let Some(source_file) = self.find_function_source_file(&function_name, file_path) {
+            if let Some(source_file) = self.find_function_source_file(&callee_name, file_path) {
                 log::debug!(
                     "[TRACE_LOCAL] Found function '{}' in '{}'",
-                    function_name,
+                    callee_name,
                     source_file
                 );
 
                 // Analyze the function to see if it returns tainted data
                 match self.analyze_function_taint_behavior(
                     &source_file,
-                    &function_name,
+                    &callee_name,
                     rule_deduplicator,
+                    visited,
                 ) {
                     AnalysisResult::DefinitelyTainted { flow } => {
-                        log::debug!("[TRACE_LOCAL] Function '{}' returns tainted data, creating cross-file flow", function_name);
+                        log::debug!("[TRACE_LOCAL] Function '{}' returns tainted data, creating cross-file flow", callee_name);
 
                         // Create a cross-file taint flow from the original source to the current sink
                         let cross_file_flow = VerifiedTaintFlow {
@@ -3862,7 +4007,7 @@ impl DataFlowTracer {
             } else {
                 log::debug!(
                     "[TRACE_LOCAL] Could not find source file for function '{}'",
-                    function_name
+                    callee_name
                 );
             }
         }
@@ -3905,6 +4050,26 @@ impl DataFlowTracer {
             function_name,
             calling_file
         );
+
+        // First, resolve via the real imports parsed for the calling file. `from foo import bar`
+        // populates this map with `bar -> foo.py`, so genuine code resolves here regardless of
+        // function name. The hardcoded fixture arms and read_dir heuristic below remain as a
+        // fallback when no parsed import covers this call (e.g. same-directory definitions with
+        // no explicit import).
+        if let Some(source_file) = self
+            .import_map
+            .get(calling_file)
+            .and_then(|functions| functions.get(function_name))
+        {
+            if std::path::Path::new(source_file).exists() {
+                log::debug!(
+                    "[FIND_SOURCE_FILE] Resolved \"{}\" via parsed import -> \"{}\"",
+                    function_name,
+                    source_file
+                );
+                return Some(source_file.clone());
+            }
+        }
 
         let calling_dir = std::path::Path::new(calling_file)
             .parent()
@@ -3989,12 +4154,31 @@ impl DataFlowTracer {
         file_path: &str,
         function_name: &str,
         rule_deduplicator: &TaintRuleDeduplicator,
+        visited: &mut std::collections::BTreeSet<(String, String)>,
     ) -> AnalysisResult {
         log::debug!(
             "[ANALYZE_FUNCTION] Analyzing function \"{}\" in \"{}\"",
             function_name,
             file_path
         );
+
+        // Guard against cyclic call graphs (e.g. a() returns b(), b() returns a()).
+        // Insert the (file, function) identity key; if it was already present we are
+        // re-entering a function still on the current call stack, so bail out as
+        // inconclusive instead of recursing into a stack overflow.
+        if !visited.insert((file_path.to_string(), function_name.to_string())) {
+            log::debug!(
+                "[ANALYZE_FUNCTION] Cycle detected for \"{}\" in \"{}\", stopping recursion",
+                function_name,
+                file_path
+            );
+            return AnalysisResult::Unknown {
+                reason: format!(
+                    "Recursion cutoff: already analyzing function \"{}\" in \"{}\"",
+                    function_name, file_path
+                ),
+            };
+        }
 
         let source_text = match std::fs::read_to_string(file_path) {
             Ok(content) => content,
@@ -4006,10 +4190,15 @@ impl DataFlowTracer {
             }
         };
 
-        if let Some(function_body) = self.extract_function_body(&source_text, function_name) {
+        if let Some((function_body, body_start_line)) =
+            self.extract_function_body(&source_text, function_name)
+        {
             log::debug!("[ANALYZE_FUNCTION] Function body found, analyzing...");
 
             for (line_num, line) in function_body.lines().enumerate() {
+                // Translate the 0-based body-relative index to the absolute,
+                // 1-based file line number using the body's start offset.
+                let file_line = body_start_line + line_num;
                 let line = line.trim();
 
                 if line.starts_with("return ") {
@@ -4031,11 +4220,11 @@ impl DataFlowTracer {
                         let flow = VerifiedTaintFlow {
                             source_file: file_path.to_string(),
                             source_function: function_name.to_string(),
-                            source_line: line_num + 1,
+                            source_line: file_line,
                             source_pattern: source_pattern.clone(),
                             sink_file: file_path.to_string(),
                             sink_function: function_name.to_string(),
-                            sink_line: line_num + 1,
+                            sink_line: file_line,
                             sink_variable: "return_value".to_string(),
                             sink_pattern: "function_return".to_string(),
                             call_chain_len: 0,
@@ -4054,11 +4243,12 @@ impl DataFlowTracer {
                             file_path,
                             function_name,
                             return_expr,
-                            line_num + 1,
+                            file_line,
                             "function_return",
-                            line_num + 1,
+                            file_line,
                             "return_value",
                             rule_deduplicator,
+                            visited,
                         );
 
                         match nested_result {
@@ -4089,11 +4279,22 @@ impl DataFlowTracer {
         }
     }
 
-    /// Extract the body of a function from source code
-    fn extract_function_body(&self, source_text: &str, function_name: &str) -> Option<String> {
+    /// Extract the body of a function from source code.
+    ///
+    /// Returns `(body, body_start_line)` where `body` is the function body text
+    /// (the `def` line is skipped) and `body_start_line` is the 1-based absolute
+    /// file line number of the FIRST body line. With this convention, the
+    /// absolute file line of the body line at 0-based index `i` (e.g. from
+    /// `body.lines().enumerate()`) is exactly `body_start_line + i`.
+    fn extract_function_body(
+        &self,
+        source_text: &str,
+        function_name: &str,
+    ) -> Option<(String, usize)> {
         let lines: Vec<&str> = source_text.lines().collect();
         let mut in_function = false;
         let mut function_lines = Vec::new();
+        let mut body_start_line: Option<usize> = None;
         let mut base_indent = None;
 
         log::debug!(
@@ -4134,7 +4335,12 @@ impl DataFlowTracer {
                     }
                 }
 
-                // Add line to function body (including empty lines)
+                // Add line to function body (including empty lines).
+                // Record the 1-based absolute file line of the first body line so
+                // callers can translate body-relative indices to file lines.
+                if body_start_line.is_none() {
+                    body_start_line = Some(line_num + 1);
+                }
                 function_lines.push(*line);
                 log::debug!(
                     "[EXTRACT_FUNCTION_BODY] Added line {}: '{}'",
@@ -4152,13 +4358,17 @@ impl DataFlowTracer {
             None
         } else {
             let body = function_lines.join("\n");
+            // body_start_line is guaranteed Some here: a non-empty function_lines
+            // means at least one body line was pushed, which sets body_start_line.
+            let body_start_line = body_start_line.unwrap_or(1);
             log::debug!(
-                "[EXTRACT_FUNCTION_BODY] Extracted {} lines for function: {}",
+                "[EXTRACT_FUNCTION_BODY] Extracted {} lines for function: {} (body starts at file line {})",
                 function_lines.len(),
-                function_name
+                function_name,
+                body_start_line
             );
             log::debug!("[EXTRACT_FUNCTION_BODY] Function body:\n{}", body);
-            Some(body)
+            Some((body, body_start_line))
         }
     }
 }

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -4,7 +4,6 @@
 //! - Pattern-based vulnerability detection
 //! - Taint flow analysis across single and multiple files
 #![allow(
-    dead_code,
     clippy::too_many_arguments,
     clippy::large_enum_variant,
     clippy::needless_range_loop
@@ -2862,20 +2861,6 @@ impl VariableFlowTracker {
         }
     }
 
-    /// Check if any variable in a list is tainted
-    fn is_any_variable_tainted(
-        &self,
-        variables: &[String],
-        function: &str,
-    ) -> Option<&TaintVariableInfo> {
-        for var in variables {
-            if let Some(info) = self.is_variable_tainted(var, function) {
-                return Some(info);
-            }
-        }
-        None
-    }
-
     /// Check if variable is likely global/passed between functions (reusing existing logic)
     fn is_global_variable(var_name: &str) -> bool {
         // Simple heuristics for global variables
@@ -2889,70 +2874,6 @@ impl VariableFlowTracker {
 // ============================================================================
 // ENHANCED DATA STRUCTURES - Phase 1: Precise Cross-File Analysis
 // ============================================================================
-
-/// Enhanced import mapping with precise function signatures and return value tracking
-#[derive(Debug, Clone)]
-struct FunctionImport {
-    local_name: String,
-    source_file: String,
-    source_function: String,
-    return_value_taint_status: TaintStatus,
-}
-
-/// Taint status classification for precise analysis
-#[derive(Debug, Clone)]
-enum TaintStatus {
-    Tainted { patterns: Vec<String> },
-    Safe,
-    Unknown,
-    Conditional { conditions: Vec<String> },
-}
-
-/// Function call graph node for data flow analysis
-#[derive(Debug, Clone)]
-struct FunctionCallNode {
-    function_name: String,
-    file_path: String,
-    line: usize,
-    arguments: Vec<String>,
-    return_value: Option<String>,
-    calls_made: Vec<FunctionCall>,
-    taint_sources_accessed: Vec<TaintSourceAccess>,
-}
-
-/// Represents a function call with precise argument tracking
-#[derive(Debug, Clone)]
-struct FunctionCall {
-    target_function: String,
-    target_file: Option<String>,
-    arguments: Vec<String>,
-    line: usize,
-}
-
-/// Direct access to a taint source within a function
-#[derive(Debug, Clone)]
-struct TaintSourceAccess {
-    pattern: String,
-    line: usize,
-    variable_assigned: Option<String>,
-}
-
-/// Analysis result for function taint behavior
-#[derive(Debug, Clone)]
-struct FunctionTaintBehavior {
-    returns_tainted_data: bool,
-    taint_sources_used: Vec<String>,
-    imported_functions_called: Vec<FunctionCall>,
-    propagates_arguments: Vec<usize>, // Which argument positions get propagated to return
-}
-
-/// Evidence supporting a verified taint flow
-#[derive(Debug, Clone)]
-struct DataFlowEvidence {
-    variable_assignments: Vec<(String, String, usize)>, // (var, source_expr, line)
-    function_calls: Vec<(String, String, usize)>,       // (func, args, line)
-    return_statements: Vec<(String, usize)>,            // (expr, line)
-}
 
 /// A verified taint flow with complete evidence chain
 #[derive(Debug, Clone)]
@@ -2968,8 +2889,8 @@ struct VerifiedTaintFlow {
     sink_line: usize,
     sink_variable: String,
 
-    call_chain: Vec<FunctionCallNode>,
-    data_flow_evidence: DataFlowEvidence,
+    /// Number of cross-file calls traversed to reach the sink (used for reporting).
+    call_chain_len: usize,
 }
 
 /// Classification of how a variable gets its value
@@ -2981,9 +2902,6 @@ enum VariableSource {
     },
     FunctionParameter {
         parameter_index: usize,
-    },
-    ImportedFunction {
-        import_info: FunctionImport,
     },
     DirectTaintSource {
         pattern: String,
@@ -3002,42 +2920,16 @@ enum AnalysisResult {
 /// Multi-file taint analysis infrastructure for cross-file data flow tracking
 #[derive(Debug)]
 struct MultiFileTaintAnalyzer {
-    /// Maps file paths to their exported functions/variables
-    file_exports: std::collections::BTreeMap<String, FileExports>,
     /// Maps file paths to their imported functions/variables
     file_imports: std::collections::BTreeMap<String, FileImports>,
-    /// Cross-file taint flows that span multiple files
-    cross_file_flows: Vec<CrossFileTaintFlow>,
-    /// Deduplication set for cross-file flows
-    processed_cross_file_flows: std::collections::BTreeSet<(String, String, String, String)>, // (source_file, source_func, sink_file, sink_func)
-}
-
-#[derive(Debug, Clone)]
-struct FileExports {
-    /// Functions exported from this file
-    functions: std::collections::BTreeSet<String>,
-    /// Variables exported from this file
-    variables: std::collections::BTreeSet<String>,
-    /// Taint sources in this file
-    taint_sources: Vec<TaintSourceInfo>,
 }
 
 #[derive(Debug, Clone)]
 struct FileImports {
     /// Functions imported into this file
     functions: std::collections::BTreeMap<String, String>, // local_name -> source_file
-    /// Variables imported into this file
-    variables: std::collections::BTreeMap<String, String>, // local_name -> source_file
     /// Taint sinks in this file
     taint_sinks: Vec<TaintSinkInfo>,
-}
-
-#[derive(Debug, Clone)]
-struct TaintSourceInfo {
-    function: String,
-    line: usize,
-    pattern: String,
-    code: String,
 }
 
 #[derive(Debug, Clone)]
@@ -3045,29 +2937,13 @@ struct TaintSinkInfo {
     function: String,
     line: usize,
     pattern: String,
-    code: String,
     used_variable: String,
-}
-
-#[derive(Debug, Clone)]
-struct CrossFileTaintFlow {
-    source_file: String,
-    source_function: String,
-    source_line: usize,
-    sink_file: String,
-    sink_function: String,
-    sink_line: usize,
-    flow_path: Vec<String>, // List of files in the flow path
-    rule: crate::rules::UnifiedRule,
 }
 
 impl MultiFileTaintAnalyzer {
     fn new() -> Self {
         Self {
-            file_exports: std::collections::BTreeMap::new(),
             file_imports: std::collections::BTreeMap::new(),
-            cross_file_flows: Vec::new(),
-            processed_cross_file_flows: std::collections::BTreeSet::new(),
         }
     }
 
@@ -3116,9 +2992,7 @@ impl MultiFileTaintAnalyzer {
             language
         );
 
-        // Initialize the new DataFlowTracer with the appropriate language files
         let mut data_flow_tracer = DataFlowTracer::new();
-        data_flow_tracer.initialize(&target_files, taint_rules)?;
 
         let mut findings = Vec::new();
         let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
@@ -3212,7 +3086,7 @@ impl MultiFileTaintAnalyzer {
                 flow.source_file,
                 flow.sink_pattern,
                 flow.sink_file,
-                flow.call_chain.len()
+                flow.call_chain_len
             )
         };
 
@@ -3338,15 +3212,8 @@ impl MultiFileTaintAnalyzer {
         rule_deduplicator: &TaintRuleDeduplicator,
         _language_support: &dyn crate::language::LanguageSupport,
     ) {
-        let mut exports = FileExports {
-            functions: std::collections::BTreeSet::new(),
-            variables: std::collections::BTreeSet::new(),
-            taint_sources: Vec::new(),
-        };
-
         let mut imports = FileImports {
             functions: std::collections::BTreeMap::new(),
-            variables: std::collections::BTreeMap::new(),
             taint_sinks: Vec::new(),
         };
 
@@ -3370,15 +3237,6 @@ impl MultiFileTaintAnalyzer {
                 continue;
             }
 
-            // Check for function definitions
-            if crate::scanner::utils::AstUtils::is_function_node(&node) {
-                if let Some(function_name) =
-                    crate::scanner::utils::AstUtils::extract_function_name(&node, source)
-                {
-                    exports.functions.insert(function_name);
-                }
-            }
-
             // Check for imports
             if let Some(import_list) = Self::extract_import_info(&node_text) {
                 for (func_name, module_name) in import_list {
@@ -3398,33 +3256,6 @@ impl MultiFileTaintAnalyzer {
                 }
             }
 
-            // Check for taint sources (environment variables, command line args, etc.)
-            if let Some(source_pattern) =
-                Self::extract_taint_source_pattern(&node, source, rule_deduplicator)
-            {
-                exports.taint_sources.push(TaintSourceInfo {
-                    function: func_name.clone(),
-                    line,
-                    pattern: source_pattern,
-                    code: node_text.clone(),
-                });
-            }
-
-            // ENHANCED: Check if this is a function definition that contains taint sources
-            if node.kind() == "function_definition"
-                && Self::function_contains_taint_sources(&node, source, rule_deduplicator)
-            {
-                let function_name =
-                    crate::scanner::utils::AstUtils::extract_function_name(&node, source)
-                        .unwrap_or("unknown".to_string());
-                exports.taint_sources.push(TaintSourceInfo {
-                    function: function_name,
-                    line,
-                    pattern: "function_with_taint_sources".to_string(),
-                    code: node_text.clone(),
-                });
-            }
-
             // Check for taint sinks (eval, exec, os.system, etc.)
             if let Some(sink_pattern) =
                 Self::extract_taint_sink_pattern(&node, source, rule_deduplicator)
@@ -3436,151 +3267,13 @@ impl MultiFileTaintAnalyzer {
                         function: func_name.clone(),
                         line,
                         pattern: sink_pattern,
-                        code: node_text.clone(),
                         used_variable: first_var.clone(),
                     });
                 }
             }
         }
 
-        self.file_exports.insert(filepath.to_string(), exports);
         self.file_imports.insert(filepath.to_string(), imports);
-    }
-
-    /// Extract taint source pattern by analyzing the node more intelligently - ENHANCED for better detection
-    fn extract_taint_source_pattern(
-        node: &tree_sitter::Node,
-        source: &[u8],
-        rule_deduplicator: &TaintRuleDeduplicator,
-    ) -> Option<String> {
-        let node_text = crate::parser::get_node_text(node, source);
-
-        // Skip string literals and other non-code nodes
-        if node.kind() == "string" || node.kind() == "string_literal" {
-            return None;
-        }
-
-        // Check all source patterns against this node
-        for pattern in &rule_deduplicator.source_patterns {
-            // Direct pattern matching for simple cases
-            if CommonUtils::matches_taint_pattern_in_context(pattern, &node_text, node.kind(), "") {
-                return Some(pattern.clone());
-            }
-
-            // Enhanced pattern matching for complex expressions
-            if Self::enhanced_taint_source_matching(pattern, &node_text, node, source) {
-                return Some(pattern.clone());
-            }
-        }
-
-        None
-    }
-
-    /// Enhanced taint source matching for complex expressions - NEW function
-    fn enhanced_taint_source_matching(
-        pattern: &str,
-        node_text: &str,
-        node: &tree_sitter::Node,
-        source: &[u8],
-    ) -> bool {
-        // Handle os.environ patterns
-        if (pattern.contains("os.environ") || pattern.contains("os\\.environ"))
-            && (node_text.contains("os.environ")
-                || node_text.contains("os.getenv")
-                || Self::contains_os_environ_call(node, source))
-        {
-            return true;
-        }
-
-        // Handle sys.argv patterns
-        if (pattern.contains("sys.argv") || pattern.contains("sys\\.argv"))
-            && (node_text.contains("sys.argv") || Self::contains_sys_argv_access(node, source))
-        {
-            return true;
-        }
-
-        // Handle request patterns (web frameworks)
-        if pattern.contains("request")
-            && (node_text.contains("request.")
-                || node_text.contains("flask.request")
-                || node_text.contains("django.request"))
-        {
-            return true;
-        }
-
-        // Handle input patterns
-        if (pattern.contains("input(") || pattern.contains("input\\("))
-            && (node_text.contains("input(") || node_text.contains("raw_input("))
-        {
-            return true;
-        }
-
-        false
-    }
-
-    /// Check if node contains os.environ access - NEW function
-    fn contains_os_environ_call(node: &tree_sitter::Node, source: &[u8]) -> bool {
-        // Check if this node or its children contain os.environ access
-        if node.kind() == "attribute" {
-            let node_text = crate::parser::get_node_text(node, source);
-            if node_text.contains("os.environ") {
-                return true;
-            }
-        }
-
-        // Check for method calls like os.environ.get(), os.getenv()
-        if node.kind() == "call" {
-            if let Some(func_node) = node.child_by_field_name("function") {
-                let func_text = crate::parser::get_node_text(&func_node, source);
-                if func_text.contains("os.environ")
-                    || func_text.contains("os.getenv")
-                    || func_text == "getenv"
-                {
-                    return true;
-                }
-            }
-        }
-
-        // Recursively check children
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                if Self::contains_os_environ_call(&cursor.node(), source) {
-                    return true;
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-
-        false
-    }
-
-    /// Check if node contains sys.argv access - NEW function
-    fn contains_sys_argv_access(node: &tree_sitter::Node, source: &[u8]) -> bool {
-        // Check if this node or its children contain sys.argv access
-        if node.kind() == "attribute" || node.kind() == "subscript" {
-            let node_text = crate::parser::get_node_text(node, source);
-            if node_text.contains("sys.argv") {
-                return true;
-            }
-        }
-
-        // Recursively check children
-        let mut cursor = node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                if Self::contains_sys_argv_access(&cursor.node(), source) {
-                    return true;
-                }
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-
-        false
     }
 
     /// Extract taint sink pattern by analyzing the node more intelligently - FIXED for context awareness
@@ -3714,97 +3407,6 @@ impl MultiFileTaintAnalyzer {
         false
     }
 
-    /// Create a finding from a cross-file taint flow
-    fn create_cross_file_finding(&self, flow: &CrossFileTaintFlow) -> crate::models::Finding {
-        let _taint_source = crate::models::TaintSource {
-            file: flow.source_file.clone(),
-            line: flow.source_line,
-            function: flow.source_function.clone(),
-            variable: flow.source_function.clone(), // Function name as variable
-            operation: "cross_file_import".to_string(),
-            code: format!("Function exported from {}", flow.source_file),
-            branch_id: None,
-        };
-
-        let _taint_sink = crate::models::TaintSink {
-            file: flow.sink_file.clone(),
-            line: flow.sink_line,
-            function: flow.sink_function.clone(),
-            variable: flow.source_function.clone(), // Imported function name
-            operation: "cross_file_sink".to_string(),
-            code: format!("Imported function used in {}", flow.sink_file),
-            branch_id: None,
-        };
-
-        let mut finding = crate::models::Finding {
-            file: flow.sink_file.clone(),
-            line: flow.sink_line,
-            column: 0,
-            end_line: flow.sink_line,
-            end_column: 0,
-            function: flow.sink_function.clone(),
-            finding_type: flow
-                .rule
-                .finding_type
-                .clone()
-                .unwrap_or_else(|| "Cross-File Taint Flow".to_string()),
-            snippet: format!(
-                "Cross-file flow: {} -> {}",
-                flow.source_file, flow.sink_file
-            ),
-            severity: flow
-                .rule
-                .severity
-                .clone()
-                .unwrap_or_else(|| "High".to_string()),
-            confidence: flow
-                .rule
-                .confidence
-                .clone()
-                .unwrap_or_else(|| "Medium".to_string()),
-            description: flow.rule.description.clone().or_else(|| {
-                Some(format!(
-                    "Cross-file taint flow detected from {} (line {}) to {} (line {})",
-                    flow.source_function, flow.source_line, flow.sink_function, flow.sink_line
-                ))
-            }),
-            cwe_id: None,
-            source_info: Some(crate::models::SourceInfo {
-                source_type: "cross_file_import".to_string(),
-                location: format!("{}:{}", flow.source_file, flow.source_line),
-                context: format!("Function exported from {}", flow.source_file),
-            }),
-            sink_info: Some(crate::models::SinkInfo {
-                sink_type: "cross_file_sink".to_string(),
-                function_name: flow.sink_function.clone(),
-                location: format!("{}:{}", flow.sink_file, flow.sink_line),
-                variable: Some(flow.source_function.clone()),
-            }),
-            traces: None,
-            tags: Some(vec![
-                "taint_analysis".to_string(),
-                "cross_file".to_string(),
-                "data_flow".to_string(),
-                flow.rule
-                    .category
-                    .clone()
-                    .unwrap_or_else(|| "injection".to_string()),
-            ]),
-        };
-
-        // Use CWE ID directly from rule, with fallback to tags for backward compatibility
-        finding.cwe_id = flow.rule.cwe_id.clone().or_else(|| {
-            // Fallback: extract from tags if rule doesn't have cwe_id field
-            if let Some(ref tags) = flow.rule.tags {
-                crate::models::Finding::extract_cwe_id_from_tags(&Some(tags.clone()))
-            } else {
-                None
-            }
-        });
-
-        finding
-    }
-
     /// Extract import information from node text - FIXED for multi-line imports and parentheses
     fn extract_import_info(text: &str) -> Option<Vec<(String, String)>> {
         let mut imports = Vec::new();
@@ -3856,799 +3458,6 @@ impl MultiFileTaintAnalyzer {
             Some(imports)
         }
     }
-
-    /// Recursively trace taint from a sink variable/function back to sources across files - COMPLETELY REWRITTEN
-    fn trace_taint_to_source(
-        &self,
-        start_file: &str,
-        start_var: &str,
-        visited: &mut std::collections::HashSet<(String, String)>,
-        max_hops: usize,
-        current_hops: usize,
-    ) -> Option<(String, TaintSourceInfo, Vec<String>)> {
-        let key = (start_file.to_string(), start_var.to_string());
-        if visited.contains(&key) || current_hops >= max_hops {
-            return None;
-        }
-        visited.insert(key.clone());
-
-        // Strategy 1: Check if this variable/function is directly a taint source in this file
-        if let Some(exports) = self.file_exports.get(start_file) {
-            for source_info in &exports.taint_sources {
-                // Check if the function name matches
-                if source_info.function == start_var {
-                    return Some((
-                        start_file.to_string(),
-                        source_info.clone(),
-                        vec![start_file.to_string()],
-                    ));
-                }
-
-                // Check if the variable might be related to this taint source
-                if source_info.code.contains(start_var) || source_info.function.contains(start_var)
-                {
-                    return Some((
-                        start_file.to_string(),
-                        source_info.clone(),
-                        vec![start_file.to_string()],
-                    ));
-                }
-            }
-        }
-
-        // Strategy 2: Check if this variable comes from a function call to an imported function
-        if let Some(imports) = self.file_imports.get(start_file) {
-            // Look for imported functions that might be the source of this variable
-            for (imported_func, source_file) in &imports.functions {
-                // Check if this imported function might be related to our variable
-                if imported_func == start_var ||
-                   start_var.contains(imported_func) ||
-                   imported_func.contains("get_") ||  // Common taint source pattern
-                   imported_func.contains("propagate_")
-                {
-                    // Common propagation pattern
-
-                    // Recursively trace in the source file
-                    if let Some((final_source_file, final_source_info, mut path)) = self
-                        .trace_taint_to_source(
-                            source_file,
-                            imported_func,
-                            visited,
-                            max_hops,
-                            current_hops + 1,
-                        )
-                    {
-                        path.push(start_file.to_string());
-                        return Some((final_source_file, final_source_info, path));
-                    }
-                }
-            }
-        }
-
-        // Strategy 3: Look for any tainted functions in the export file that could be the source
-        if let Some(imports) = self.file_imports.get(start_file) {
-            for (imported_func, source_file) in &imports.functions {
-                // Check if the source file has any taint sources
-                if let Some(source_exports) = self.file_exports.get(source_file) {
-                    for source_info in &source_exports.taint_sources {
-                        // If this imported function contains taint sources, trace it
-                        if &source_info.function == imported_func
-                            || source_info.function.contains("get_")
-                            || source_info.function.contains("env")
-                            || source_info.function.contains("arg")
-                        {
-                            let path = vec![source_file.to_string(), start_file.to_string()];
-                            return Some((source_file.to_string(), source_info.clone(), path));
-                        }
-                    }
-                }
-            }
-        }
-
-        // Strategy 4: Broad search - look for any functions that might propagate taint
-        if let Some(imports) = self.file_imports.get(start_file) {
-            for (imported_func, source_file) in &imports.functions {
-                // For functions that might be propagating taint
-                if imported_func.starts_with("propagate_")
-                    || imported_func.starts_with("get_")
-                    || imported_func.contains("config")
-                    || imported_func.contains("data")
-                    || imported_func.contains("env")
-                {
-                    // Check if the source file has taint sources
-                    if let Some(source_exports) = self.file_exports.get(source_file) {
-                        if !source_exports.taint_sources.is_empty() {
-                            // Find the most relevant taint source
-                            for source_info in &source_exports.taint_sources {
-                                // Match by function name or by pattern relevance
-                                if &source_info.function == imported_func
-                                    || source_info.function.contains("get_")
-                                    || source_info.function.contains("database")
-                                    || source_info.function.contains("config")
-                                    || source_info.function.contains("env")
-                                    || source_info.function.contains("arg")
-                                    || source_info.pattern.contains("os.environ")
-                                    || source_info.pattern.contains("sys.argv")
-                                {
-                                    let path =
-                                        vec![source_file.to_string(), start_file.to_string()];
-                                    return Some((
-                                        source_file.to_string(),
-                                        source_info.clone(),
-                                        path,
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        // Strategy 5: Last resort - if we have any taint sources in imported files, use them
-        if let Some(imports) = self.file_imports.get(start_file) {
-            for source_file in imports.functions.values() {
-                if let Some(source_exports) = self.file_exports.get(source_file) {
-                    if !source_exports.taint_sources.is_empty() {
-                        // Use the first available taint source as a potential match
-                        let source_info = &source_exports.taint_sources[0];
-                        let path = vec![source_file.to_string(), start_file.to_string()];
-                        return Some((source_file.to_string(), source_info.clone(), path));
-                    }
-                }
-            }
-        }
-
-        None
-    }
-
-    /// Check if a function definition contains taint sources in its body - NEW function
-    fn function_contains_taint_sources(
-        func_node: &tree_sitter::Node,
-        source: &[u8],
-        rule_deduplicator: &TaintRuleDeduplicator,
-    ) -> bool {
-        // Recursively check all nodes in the function body
-        let mut cursor = func_node.walk();
-        if cursor.goto_first_child() {
-            loop {
-                let node = cursor.node();
-
-                // Check if this node is a taint source
-                if Self::extract_taint_source_pattern(&node, source, rule_deduplicator).is_some() {
-                    return true;
-                }
-
-                // Recursively check children
-                if Self::function_contains_taint_sources(&node, source, rule_deduplicator) {
-                    return true;
-                }
-
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-
-        false
-    }
-}
-
-// ============================================================================
-// PHASE 1: IMPORT RESOLVER - Precise import chain resolution
-// ============================================================================
-
-/// Import resolution engine for precise cross-file analysis
-#[derive(Debug)]
-struct ImportResolver {
-    /// Bidirectional import mapping: file -> imported functions
-    import_graph:
-        std::collections::HashMap<String, std::collections::HashMap<String, FunctionImport>>,
-    /// Reverse mapping: file -> files that import from it
-    reverse_import_graph: std::collections::HashMap<String, std::collections::HashSet<String>>,
-    /// Cache for resolved file paths
-    path_resolution_cache: std::collections::HashMap<(String, String), Option<String>>,
-}
-
-impl ImportResolver {
-    fn new() -> Self {
-        Self {
-            import_graph: std::collections::HashMap::new(),
-            reverse_import_graph: std::collections::HashMap::new(),
-            path_resolution_cache: std::collections::HashMap::new(),
-        }
-    }
-
-    /// Convert relative imports to absolute file paths
-    fn resolve_import_path(
-        &mut self,
-        importing_file: &str,
-        imported_module: &str,
-    ) -> Option<String> {
-        let cache_key = (importing_file.to_string(), imported_module.to_string());
-
-        // Check cache first
-        if let Some(cached_result) = self.path_resolution_cache.get(&cache_key) {
-            return cached_result.clone();
-        }
-
-        let resolved_path = self.compute_import_path(importing_file, imported_module);
-        self.path_resolution_cache
-            .insert(cache_key, resolved_path.clone());
-        resolved_path
-    }
-
-    /// Compute the actual file path for an imported module
-    fn compute_import_path(&self, importing_file: &str, imported_module: &str) -> Option<String> {
-        // Handle different import patterns
-        if imported_module.ends_with(".py") {
-            // Direct file import
-            return Some(imported_module.to_string());
-        }
-
-        // Get the directory of the importing file
-        let importing_dir = std::path::Path::new(importing_file)
-            .parent()
-            .unwrap_or(std::path::Path::new(""));
-
-        // Try relative import first
-        let relative_path = importing_dir.join(format!("{}.py", imported_module));
-        if relative_path.exists() {
-            return Some(relative_path.to_string_lossy().to_string());
-        }
-
-        // Try same directory
-        let same_dir_path = importing_dir.join(format!("{}.py", imported_module));
-        if same_dir_path.exists() {
-            return Some(same_dir_path.to_string_lossy().to_string());
-        }
-
-        // Try with __init__.py
-        let package_path = importing_dir.join(imported_module).join("__init__.py");
-        if package_path.exists() {
-            return Some(package_path.to_string_lossy().to_string());
-        }
-
-        log::debug!(
-            "[IMPORT_RESOLVER] Could not resolve import '{}' from '{}'",
-            imported_module,
-            importing_file
-        );
-        None
-    }
-
-    /// Build bidirectional import mapping for all files
-    fn build_import_graph(&mut self, files: &[std::path::PathBuf]) -> Result<()> {
-        log::debug!(
-            "[IMPORT_RESOLVER] Building import graph for {} files",
-            files.len()
-        );
-
-        for file_path in files {
-            self.analyze_file_imports(file_path)?;
-        }
-
-        // Build reverse mapping
-        self.build_reverse_import_graph();
-
-        log::debug!(
-            "[IMPORT_RESOLVER] Import graph built: {} files with imports",
-            self.import_graph.len()
-        );
-        Ok(())
-    }
-
-    /// Analyze imports in a single file
-    fn analyze_file_imports(&mut self, file_path: &std::path::PathBuf) -> Result<()> {
-        let filepath_str = file_path.to_string_lossy().to_string();
-        let source = std::fs::read(file_path)?;
-
-        // Parse the file to extract import statements
-        with_local_parser("python", |parser| {
-            let tree = parser.parse(&source)?;
-            let mut file_imports = std::collections::HashMap::new();
-
-            // Collect all nodes to find import statements
-            let mut all_nodes = Vec::new();
-            ScanningLogic::collect_all_relevant_nodes(
-                tree.root_node(),
-                &mut all_nodes,
-                Some(&source),
-            );
-
-            for node in all_nodes {
-                let node_text = crate::parser::get_node_text(&node, &source);
-
-                // Extract import information using existing logic
-                if let Some(import_list) = MultiFileTaintAnalyzer::extract_import_info(&node_text) {
-                    for (func_name, module_name) in import_list {
-                        if let Some(resolved_path) =
-                            self.resolve_import_path(&filepath_str, &module_name)
-                        {
-                            let function_import = FunctionImport {
-                                local_name: func_name.clone(),
-                                source_file: resolved_path,
-                                source_function: func_name.clone(),
-                                return_value_taint_status: TaintStatus::Unknown,
-                            };
-                            file_imports.insert(func_name, function_import);
-                        }
-                    }
-                }
-            }
-
-            if !file_imports.is_empty() {
-                self.import_graph.insert(filepath_str, file_imports);
-            }
-
-            Ok(())
-        })?;
-
-        Ok(())
-    }
-
-    /// Build reverse import mapping for dependency tracking
-    fn build_reverse_import_graph(&mut self) {
-        for (importing_file, imports) in &self.import_graph {
-            for import in imports.values() {
-                self.reverse_import_graph
-                    .entry(import.source_file.clone())
-                    .or_default()
-                    .insert(importing_file.clone());
-            }
-        }
-    }
-
-    /// Verify that an import actually exists and is callable
-    fn validate_import(&self, import: &FunctionImport) -> bool {
-        // Check if the source file exists
-        if !std::path::Path::new(&import.source_file).exists() {
-            return false;
-        }
-
-        // TODO: Could add more sophisticated validation here
-        // - Check if the function is actually exported
-        // - Verify function signature compatibility
-
-        true
-    }
-
-    /// Get all imports for a specific file
-    fn get_file_imports(
-        &self,
-        file_path: &str,
-    ) -> Option<&std::collections::HashMap<String, FunctionImport>> {
-        self.import_graph.get(file_path)
-    }
-
-    /// Get all files that import from a specific file
-    fn get_reverse_imports(&self, file_path: &str) -> Option<&std::collections::HashSet<String>> {
-        self.reverse_import_graph.get(file_path)
-    }
-
-    /// Resolve function location (file and function name) for a given function call
-    fn resolve_function_location(
-        &self,
-        function_name: &str,
-        calling_file: &str,
-    ) -> Option<(String, String)> {
-        // Check if it's an imported function
-        if let Some(imports) = self.get_file_imports(calling_file) {
-            if let Some(import) = imports.get(function_name) {
-                return Some((import.source_file.clone(), import.source_function.clone()));
-            }
-        }
-
-        // If not imported, assume it's local to the same file
-        Some((calling_file.to_string(), function_name.to_string()))
-    }
-}
-
-// ============================================================================
-// PHASE 1: FUNCTION BODY ANALYZER - Precise function analysis
-// ============================================================================
-
-/// Function body analyzer for understanding taint behavior within functions
-#[derive(Debug)]
-struct FunctionBodyAnalyzer {
-    /// Maps (file, function) to its taint behavior analysis
-    function_behaviors: std::collections::HashMap<(String, String), FunctionTaintBehavior>,
-    /// Maps (file, function) to its parsed AST for repeated analysis
-    function_ast_cache: std::collections::HashMap<(String, String), tree_sitter::Node<'static>>,
-}
-
-impl FunctionBodyAnalyzer {
-    fn new() -> Self {
-        Self {
-            function_behaviors: std::collections::HashMap::new(),
-            function_ast_cache: std::collections::HashMap::new(),
-        }
-    }
-
-    /// Analyze all functions in a file for taint behavior
-    fn analyze_file_functions(
-        &mut self,
-        file_path: &str,
-        source: &[u8],
-        tree: &tree_sitter::Tree,
-        rule_deduplicator: &TaintRuleDeduplicator,
-    ) -> Result<()> {
-        log::debug!("[FUNCTION_ANALYZER] Analyzing functions in {}", file_path);
-
-        // Find all function definitions (collect them first to avoid borrow conflicts)
-        let function_nodes = self.extract_function_definitions(tree.root_node());
-        let mut function_data = Vec::new();
-
-        // Extract function names and analyze behaviors
-        for func_node in function_nodes {
-            let func_name = self.extract_function_name(&func_node, source);
-            if let Some(function_name) = func_name {
-                let behavior = self.analyze_function_body(
-                    file_path,
-                    &function_name,
-                    &func_node,
-                    source,
-                    rule_deduplicator,
-                )?;
-
-                function_data.push((function_name, behavior));
-            }
-        }
-
-        // Now insert all the function behaviors
-        for (function_name, behavior) in function_data {
-            self.function_behaviors
-                .insert((file_path.to_string(), function_name), behavior);
-        }
-
-        log::debug!(
-            "[FUNCTION_ANALYZER] Analyzed {} functions in {}",
-            self.function_behaviors.len(),
-            file_path
-        );
-        Ok(())
-    }
-
-    /// Extract all function definition nodes from the AST
-    fn extract_function_definitions<'a>(
-        &self,
-        root: tree_sitter::Node<'a>,
-    ) -> Vec<tree_sitter::Node<'a>> {
-        let mut functions = Vec::new();
-        let mut cursor = root.walk();
-
-        if cursor.goto_first_child() {
-            loop {
-                let node = cursor.node();
-
-                // Check if this is a function definition
-                if node.kind() == "function_definition" {
-                    functions.push(node);
-                }
-
-                // Recursively search child nodes
-                functions.extend(self.extract_function_definitions(node));
-
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-
-        functions
-    }
-
-    /// Extract function name from a function definition node
-    fn extract_function_name(
-        &self,
-        func_node: &tree_sitter::Node,
-        source: &[u8],
-    ) -> Option<String> {
-        let mut cursor = func_node.walk();
-
-        if cursor.goto_first_child() {
-            loop {
-                let node = cursor.node();
-                if node.kind() == "identifier" {
-                    let name = crate::parser::get_node_text(&node, source);
-                    return Some(name);
-                }
-
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-
-        None
-    }
-
-    /// Analyze a single function for taint behavior
-    fn analyze_function_body(
-        &self,
-        _file_path: &str,
-        function_name: &str,
-        func_node: &tree_sitter::Node,
-        source: &[u8],
-        rule_deduplicator: &TaintRuleDeduplicator,
-    ) -> Result<FunctionTaintBehavior> {
-        log::debug!(
-            "  [FUNCTION_ANALYZER] Analyzing function: {}",
-            function_name
-        );
-
-        let mut behavior = FunctionTaintBehavior {
-            returns_tainted_data: false,
-            taint_sources_used: Vec::new(),
-            imported_functions_called: Vec::new(),
-            propagates_arguments: Vec::new(),
-        };
-
-        // Collect all nodes in the function body
-        let mut all_nodes = Vec::new();
-        ScanningLogic::collect_all_relevant_nodes(*func_node, &mut all_nodes, Some(source));
-
-        // Analyze each node for taint-related behavior
-        for node in all_nodes {
-            let node_text = crate::parser::get_node_text(&node, source);
-            let line = node.start_position().row + 1;
-
-            // Check for taint sources
-            if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(&node_text) {
-                log::debug!(
-                    "    [FUNCTION_ANALYZER] Found taint source: {} -> {}",
-                    source_pattern,
-                    node_text
-                );
-                behavior.taint_sources_used.push(source_pattern);
-                behavior.returns_tainted_data = true; // Assume function returns tainted if it accesses sources
-            }
-
-            // Check for function calls (potential imports)
-            if node.kind() == "call" {
-                if let Some(called_func) =
-                    crate::scanner::utils::AstUtils::extract_function_name(&node, source)
-                {
-                    let func_call = FunctionCall {
-                        target_function: called_func,
-                        target_file: None, // Will be resolved later by ImportResolver
-                        arguments: self.extract_function_arguments(&node, source),
-                        line,
-                    };
-                    behavior.imported_functions_called.push(func_call);
-                }
-            }
-
-            // Check for return statements that might propagate taint
-            if node.kind() == "return_statement" {
-                behavior.returns_tainted_data =
-                    self.return_statement_uses_tainted_data(&node, source, &behavior);
-            }
-
-            // Check for argument propagation patterns
-            if let Some(propagated_args) = self.detect_argument_propagation(&node, source) {
-                behavior.propagates_arguments.extend(propagated_args);
-            }
-        }
-
-        log::debug!(
-            "    [FUNCTION_ANALYZER] Function {} behavior: returns_tainted={}, sources={:?}",
-            function_name,
-            behavior.returns_tainted_data,
-            behavior.taint_sources_used
-        );
-
-        Ok(behavior)
-    }
-
-    /// Extract function arguments from a call node
-    fn extract_function_arguments(
-        &self,
-        call_node: &tree_sitter::Node,
-        source: &[u8],
-    ) -> Vec<String> {
-        let mut arguments = Vec::new();
-        let mut cursor = call_node.walk();
-
-        if cursor.goto_first_child() {
-            loop {
-                let node = cursor.node();
-
-                // Look for argument_list node
-                if node.kind() == "argument_list" {
-                    let mut arg_cursor = node.walk();
-                    if arg_cursor.goto_first_child() {
-                        loop {
-                            let arg_node = arg_cursor.node();
-                            if arg_node.kind() != "("
-                                && arg_node.kind() != ")"
-                                && arg_node.kind() != ","
-                            {
-                                let arg_text = crate::parser::get_node_text(&arg_node, source);
-                                arguments.push(arg_text);
-                            }
-
-                            if !arg_cursor.goto_next_sibling() {
-                                break;
-                            }
-                        }
-                    }
-                    break;
-                }
-
-                if !cursor.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-
-        arguments
-    }
-
-    /// Check if a return statement uses tainted data
-    fn return_statement_uses_tainted_data(
-        &self,
-        return_node: &tree_sitter::Node,
-        source: &[u8],
-        function_behavior: &FunctionTaintBehavior,
-    ) -> bool {
-        let return_text = crate::parser::get_node_text(return_node, source);
-
-        // Check if return statement mentions any variables that could be tainted
-        for taint_source in &function_behavior.taint_sources_used {
-            if return_text.contains(taint_source) {
-                return true;
-            }
-        }
-
-        // Check for common patterns that propagate taint
-        return_text.contains("request.")
-            || return_text.contains("input(")
-            || return_text.contains("os.environ")
-            || return_text.contains("sys.argv")
-    }
-
-    /// Detect which argument positions get propagated to return value
-    fn detect_argument_propagation(
-        &self,
-        node: &tree_sitter::Node,
-        source: &[u8],
-    ) -> Option<Vec<usize>> {
-        let node_text = crate::parser::get_node_text(node, source);
-
-        // Simple heuristic: if return statement mentions parameter names
-        if node.kind() == "return_statement" {
-            let mut propagated_args = Vec::new();
-
-            // Look for common parameter names that get returned
-            if node_text.contains("data") {
-                propagated_args.push(0); // Assume first parameter
-            }
-            if node_text.contains("input") {
-                propagated_args.push(0);
-            }
-            if node_text.contains("value") {
-                propagated_args.push(0);
-            }
-
-            if !propagated_args.is_empty() {
-                return Some(propagated_args);
-            }
-        }
-
-        None
-    }
-
-    /// Get analyzed behavior for a specific function
-    fn get_function_behavior(
-        &self,
-        file_path: &str,
-        function_name: &str,
-    ) -> Option<&FunctionTaintBehavior> {
-        self.function_behaviors
-            .get(&(file_path.to_string(), function_name.to_string()))
-    }
-
-    /// Check if a function definitely returns tainted data
-    fn function_returns_tainted_data(&self, file_path: &str, function_name: &str) -> TaintStatus {
-        if let Some(behavior) = self.get_function_behavior(file_path, function_name) {
-            if behavior.returns_tainted_data {
-                return TaintStatus::Tainted {
-                    patterns: behavior.taint_sources_used.clone(),
-                };
-            } else if !behavior.taint_sources_used.is_empty() {
-                return TaintStatus::Conditional {
-                    conditions: behavior.taint_sources_used.clone(),
-                };
-            } else {
-                return TaintStatus::Safe;
-            }
-        }
-
-        TaintStatus::Unknown
-    }
-
-    /// Analyze function call chains to understand taint propagation
-    fn trace_function_call_chain(
-        &self,
-        start_file: &str,
-        start_function: &str,
-        import_resolver: &ImportResolver,
-        max_depth: usize,
-    ) -> Vec<FunctionCallNode> {
-        let mut call_chain = Vec::new();
-        let mut visited = std::collections::HashSet::new();
-
-        self.trace_function_calls_recursive(
-            start_file,
-            start_function,
-            import_resolver,
-            &mut call_chain,
-            &mut visited,
-            max_depth,
-            0,
-        );
-
-        call_chain
-    }
-
-    /// Recursive helper for tracing function call chains
-    fn trace_function_calls_recursive(
-        &self,
-        file_path: &str,
-        function_name: &str,
-        import_resolver: &ImportResolver,
-        call_chain: &mut Vec<FunctionCallNode>,
-        visited: &mut std::collections::HashSet<(String, String)>,
-        max_depth: usize,
-        current_depth: usize,
-    ) {
-        let key = (file_path.to_string(), function_name.to_string());
-        if visited.contains(&key) || current_depth >= max_depth {
-            return;
-        }
-        visited.insert(key);
-
-        if let Some(behavior) = self.get_function_behavior(file_path, function_name) {
-            // Create a call node for this function
-            let call_node = FunctionCallNode {
-                function_name: function_name.to_string(),
-                file_path: file_path.to_string(),
-                line: 0, // TODO: Extract actual line from AST
-                arguments: Vec::new(),
-                return_value: None,
-                calls_made: behavior.imported_functions_called.clone(),
-                taint_sources_accessed: behavior
-                    .taint_sources_used
-                    .iter()
-                    .map(|pattern| TaintSourceAccess {
-                        pattern: pattern.clone(),
-                        line: 0, // TODO: Extract actual line
-                        variable_assigned: None,
-                    })
-                    .collect(),
-            };
-
-            // For each function this one calls, resolve location and recurse
-            for func_call in &behavior.imported_functions_called {
-                if let Some((target_file, target_func)) =
-                    import_resolver.resolve_function_location(&func_call.target_function, file_path)
-                {
-                    self.trace_function_calls_recursive(
-                        &target_file,
-                        &target_func,
-                        import_resolver,
-                        call_chain,
-                        visited,
-                        max_depth,
-                        current_depth + 1,
-                    );
-                }
-            }
-
-            call_chain.push(call_node);
-        }
-    }
 }
 
 // ============================================================================
@@ -4658,10 +3467,6 @@ impl FunctionBodyAnalyzer {
 /// Advanced data flow analysis engine that verifies actual taint propagation chains
 #[derive(Debug)]
 struct DataFlowTracer {
-    /// Import resolution for cross-file function calls
-    import_resolver: ImportResolver,
-    /// Function behavior analysis for understanding taint propagation
-    function_analyzer: FunctionBodyAnalyzer,
     /// Cache of analyzed variable sources to avoid re-computation
     variable_source_cache: std::collections::HashMap<(String, String, String), VariableSource>,
     /// Verified taint flows that have been fully validated
@@ -4671,56 +3476,9 @@ struct DataFlowTracer {
 impl DataFlowTracer {
     fn new() -> Self {
         Self {
-            import_resolver: ImportResolver::new(),
-            function_analyzer: FunctionBodyAnalyzer::new(),
             variable_source_cache: std::collections::HashMap::new(),
             verified_flows: Vec::new(),
         }
-    }
-
-    /// Initialize the tracer with all files in the project
-    fn initialize(
-        &mut self,
-        files: &[std::path::PathBuf],
-        taint_rules: &[&crate::rules::UnifiedRule],
-    ) -> Result<()> {
-        log::debug!("[DATA_FLOW_TRACER] Initializing with {} files", files.len());
-
-        // Build import graph
-        self.import_resolver.build_import_graph(files)?;
-
-        // Analyze all functions for taint behavior
-        let rule_deduplicator = TaintRuleDeduplicator::new(taint_rules);
-        for file_path in files {
-            if let Ok(source) = std::fs::read(file_path) {
-                // FIXED: Determine language from file extension instead of hardcoding Python
-                let language = if file_path.extension().and_then(|ext| ext.to_str()) == Some("py") {
-                    "python"
-                } else if let Some(ext) = file_path.extension().and_then(|ext| ext.to_str()) {
-                    if ext == "js" || ext == "jsx" || ext == "ts" || ext == "tsx" {
-                        "javascript"
-                    } else {
-                        continue; // Skip unsupported file types
-                    }
-                } else {
-                    continue; // Skip files without extensions
-                };
-
-                with_local_parser(language, |parser| {
-                    let tree = parser.parse(&source)?;
-                    self.function_analyzer.analyze_file_functions(
-                        &file_path.to_string_lossy(),
-                        &source,
-                        &tree,
-                        &rule_deduplicator,
-                    )?;
-                    Ok(())
-                })?;
-            }
-        }
-
-        log::debug!("[DATA_FLOW_TRACER] Initialization complete");
-        Ok(())
     }
 
     /// Analyze whether a sink variable in a function truly receives tainted data
@@ -4765,24 +3523,7 @@ impl DataFlowTracer {
                     sink_pattern,
                     sink_line,
                     sink_variable,
-                    Vec::new(),
-                )
-            }
-
-            VariableSource::ImportedFunction { import_info } => {
-                log::debug!(
-                    "[DATA_FLOW_TRACER] Variable from imported function: {} from {}",
-                    import_info.local_name,
-                    import_info.source_file
-                );
-                self.trace_imported_function_taint(
-                    import_info,
-                    sink_file,
-                    sink_function,
-                    sink_pattern,
-                    sink_line,
-                    sink_variable,
-                    rule_deduplicator,
+                    0,
                 )
             }
 
@@ -4836,16 +3577,7 @@ impl DataFlowTracer {
                         sink_line,
                         sink_variable: sink_variable.to_string(),
 
-                        call_chain: Vec::new(),
-                        data_flow_evidence: DataFlowEvidence {
-                            variable_assignments: vec![(
-                                sink_variable.to_string(),
-                                format!("function parameter {}", parameter_index),
-                                1,
-                            )],
-                            function_calls: Vec::new(),
-                            return_statements: Vec::new(),
-                        },
+                        call_chain_len: 0,
                     };
 
                     self.verified_flows.push(flow.clone());
@@ -4891,11 +3623,6 @@ impl DataFlowTracer {
         source
     }
 
-    /// Get all verified taint flows found so far
-    fn get_verified_flows(&self) -> &[VerifiedTaintFlow] {
-        &self.verified_flows
-    }
-
     /// Create a verified taint flow with complete evidence
     fn create_verified_flow(
         &mut self,
@@ -4908,7 +3635,7 @@ impl DataFlowTracer {
         sink_pattern: &str,
         sink_line: usize,
         sink_variable: &str,
-        call_chain: Vec<FunctionCallNode>,
+        call_chain_len: usize,
     ) -> AnalysisResult {
         let verified_flow = VerifiedTaintFlow {
             source_file: source_file.to_string(),
@@ -4922,19 +3649,14 @@ impl DataFlowTracer {
             sink_line,
             sink_variable: sink_variable.to_string(),
 
-            call_chain,
-            data_flow_evidence: DataFlowEvidence {
-                variable_assignments: Vec::new(), // TODO: Collect from AST analysis
-                function_calls: Vec::new(),       // TODO: Collect from call chain
-                return_statements: Vec::new(),    // TODO: Collect from function analysis
-            },
+            call_chain_len,
         };
 
         log::debug!(
             "[DATA_FLOW_TRACER] Verified taint flow: {} -> {} via {:?}",
             source_pattern,
             sink_pattern,
-            verified_flow.call_chain.len()
+            verified_flow.call_chain_len
         );
 
         self.verified_flows.push(verified_flow.clone());
@@ -5048,82 +3770,6 @@ impl DataFlowTracer {
         VariableSource::FunctionParameter { parameter_index: 0 }
     }
 
-    fn trace_imported_function_taint(
-        &mut self,
-        import_info: FunctionImport,
-        sink_file: &str,
-        sink_function: &str,
-        sink_pattern: &str,
-        sink_line: usize,
-        sink_variable: &str,
-        rule_deduplicator: &TaintRuleDeduplicator,
-    ) -> AnalysisResult {
-        log::debug!(
-            "[TRACE_IMPORTED] Tracing imported function '{}' from '{}'",
-            import_info.local_name,
-            import_info.source_file
-        );
-
-        // Analyze the imported function in its source file
-        match self.analyze_function_taint_behavior(
-            &import_info.source_file,
-            &import_info.source_function,
-            rule_deduplicator,
-        ) {
-            AnalysisResult::DefinitelyTainted { flow } => {
-                log::debug!(
-                    "[TRACE_IMPORTED] Function '{}' is tainted, creating cross-file flow",
-                    import_info.local_name
-                );
-
-                // Create a cross-file verified taint flow
-                let cross_file_flow = VerifiedTaintFlow {
-                    source_file: flow.source_file,
-                    source_function: flow.source_function,
-                    source_pattern: flow.source_pattern,
-                    source_line: flow.source_line,
-
-                    sink_file: sink_file.to_string(),
-                    sink_function: sink_function.to_string(),
-                    sink_pattern: sink_pattern.to_string(),
-                    sink_line,
-                    sink_variable: sink_variable.to_string(),
-
-                    call_chain: vec![FunctionCallNode {
-                        function_name: import_info.local_name.clone(),
-                        file_path: import_info.source_file.clone(),
-                        line: sink_line,
-                        arguments: Vec::new(),
-                        return_value: Some(sink_variable.to_string()),
-                        calls_made: Vec::new(),
-                        taint_sources_accessed: Vec::new(),
-                    }],
-                    data_flow_evidence: flow.data_flow_evidence,
-                };
-
-                self.verified_flows.push(cross_file_flow.clone());
-                AnalysisResult::DefinitelyTainted {
-                    flow: cross_file_flow,
-                }
-            }
-            AnalysisResult::DefinitelySafe => {
-                log::debug!(
-                    "[TRACE_IMPORTED] Function '{}' is safe",
-                    import_info.local_name
-                );
-                AnalysisResult::DefinitelySafe
-            }
-            AnalysisResult::Unknown { reason } => {
-                log::debug!(
-                    "[TRACE_IMPORTED] Function '{}' analysis inconclusive: {}",
-                    import_info.local_name,
-                    reason
-                );
-                AnalysisResult::Unknown { reason }
-            }
-        }
-    }
-
     fn trace_local_assignment_taint(
         &mut self,
         file_path: &str,
@@ -5161,16 +3807,7 @@ impl DataFlowTracer {
                 sink_line,
                 sink_variable: sink_variable.to_string(),
 
-                call_chain: Vec::new(),
-                data_flow_evidence: DataFlowEvidence {
-                    variable_assignments: vec![(
-                        sink_variable.to_string(),
-                        source_expression.to_string(),
-                        assignment_line,
-                    )],
-                    function_calls: Vec::new(),
-                    return_statements: Vec::new(),
-                },
+                call_chain_len: 0,
             };
 
             self.verified_flows.push(flow.clone());
@@ -5212,28 +3849,7 @@ impl DataFlowTracer {
                             sink_line,
                             sink_variable: sink_variable.to_string(),
 
-                            call_chain: vec![FunctionCallNode {
-                                function_name: function_name.clone(),
-                                file_path: source_file,
-                                line: assignment_line,
-                                arguments: Vec::new(),
-                                return_value: Some(sink_variable.to_string()),
-                                calls_made: Vec::new(),
-                                taint_sources_accessed: Vec::new(),
-                            }],
-                            data_flow_evidence: DataFlowEvidence {
-                                variable_assignments: vec![(
-                                    sink_variable.to_string(),
-                                    source_expression.to_string(),
-                                    assignment_line,
-                                )],
-                                function_calls: vec![(
-                                    function_name.clone(),
-                                    "()".to_string(),
-                                    assignment_line,
-                                )],
-                                return_statements: flow.data_flow_evidence.return_statements,
-                            },
+                            call_chain_len: 1,
                         };
 
                         self.verified_flows.push(cross_file_flow.clone());
@@ -5422,12 +4038,7 @@ impl DataFlowTracer {
                             sink_line: line_num + 1,
                             sink_variable: "return_value".to_string(),
                             sink_pattern: "function_return".to_string(),
-                            call_chain: Vec::new(),
-                            data_flow_evidence: DataFlowEvidence {
-                                variable_assignments: Vec::new(),
-                                function_calls: Vec::new(),
-                                return_statements: vec![(return_expr.to_string(), line_num + 1)],
-                            },
+                            call_chain_len: 0,
                         };
                         return AnalysisResult::DefinitelyTainted { flow };
                     }

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,10 +1,10 @@
+pub mod conditions;
 pub mod core;
 pub mod modes;
-pub mod utils;
-pub mod conditions;
 pub mod prefilter;
+pub mod utils;
 
-pub use core::{VulnerabilityScanner, ScanningLogic};
 pub use crate::models::Finding;
-pub use modes::{run_explicit_scan, run_auto_detection_scan, run_taint_analysis};
-pub use prefilter::{PreFilter, FilterStats};
+pub use core::{ScanningLogic, VulnerabilityScanner};
+pub use modes::{run_auto_detection_scan, run_explicit_scan, run_taint_analysis};
+pub use prefilter::{FilterStats, PreFilter};

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -1,18 +1,17 @@
 use anyhow::Result;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 
 use crate::cli::Cli;
 use crate::rules::Rules;
-use crate::scanner::{VulnerabilityScanner, Finding};
-use crate::scanner::core::ScanningLogic;
 use crate::scanner::core::ProgressManager;
+use crate::scanner::core::ScanningLogic;
+use crate::scanner::{Finding, VulnerabilityScanner};
 
 /// Unified scan configuration and execution context
 #[derive(Debug)]
 struct ScanContext {
-    root_dir: String,
     single_threaded: bool,
     skip_minified: bool,
     discovery_time: std::time::Duration,
@@ -44,7 +43,6 @@ impl ScanContext {
         let total_files: usize = files_by_language.values().map(|files| files.len()).sum();
 
         Ok(Self {
-            root_dir: root_dir.to_string(),
             single_threaded: cli.single_threaded,
             skip_minified: cli.skip_minified.unwrap_or(true),
             discovery_time,
@@ -53,6 +51,7 @@ impl ScanContext {
         })
     }
 
+    /// Human-readable description of the threading mode, e.g. `parallel (8 threads)`.
     fn mode_display(&self, threads: Option<usize>) -> String {
         if self.single_threaded {
             "single-threaded".to_string()
@@ -62,13 +61,13 @@ impl ScanContext {
             "parallel".to_string()
         }
     }
-    
+
     /// Create and configure progress manager
     fn create_progress_manager(&self) -> ProgressManager {
         ProgressManager::new(self.total_files)
     }
-    
-    /// Print performance summary
+
+    /// Print throughput stats once a scan completes.
     fn print_performance_summary(&self, rule_count: usize, scan_duration: std::time::Duration) {
         crate::ui::note(&format!(
             "scanned {} files \u{b7} {} rules \u{b7} {} languages",
@@ -93,44 +92,46 @@ fn should_use_embedded_rules(cli: &Cli) -> bool {
 fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
     // If using embedded rules, load them directly
     if should_use_embedded_rules(cli) {
-        return Rules::load_all_embedded_rules(&context.detected_languages, cli.code_type.as_deref());
+        return Rules::load_all_embedded_rules(
+            &context.detected_languages,
+            cli.code_type.as_deref(),
+        );
     }
-    
+
     match (&cli.language, &cli.rules_path) {
         (Some(_language), Some(rules_path)) => Rules::load_from_path(rules_path),
         (None, None) => {
             // Auto-detect and merge rules from all languages
             let mut all_rules = Vec::new();
-            
+
             // Determine exclusion pattern type based on code_type
-            let pattern_type = if let Some(code_type) = &cli.code_type {
-                if code_type == "backend" {
-                    "backend"
-                } else if code_type == "frontend" {
-                    "frontend"
-                } else {
-                    "frontend" // default for "both" or other values
-                }
+            let pattern_type = if cli.code_type.as_deref() == Some("backend") {
+                "backend"
             } else {
-                "frontend" // default when no code_type specified
+                "frontend"
             };
-            
+
             for language in &context.detected_languages {
                 let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
                 let rules_dir = match language.as_str() {
                     "tsx" => format!("{}/javascript", base_rules_dir),
                     _ => format!("{}/{}", base_rules_dir, language),
                 };
-                if let Ok(rules) = Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type) {
+                if let Ok(rules) =
+                    Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type)
+                {
                     all_rules.push(rules);
                 }
-                
+
                 // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
                 if matches!(language.as_str(), "javascript" | "tsx") {
                     if let Some(code_type) = &cli.code_type {
                         if code_type != "frontend" {
                             let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
-                            let backend_rules_file = format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
+                            let backend_rules_file = format!(
+                                "{}/backend_javascript/backend_security.ron",
+                                base_rules_dir
+                            );
                             if let Ok(backend_rules) = Rules::load_from_file(&backend_rules_file) {
                                 all_rules.push(backend_rules);
                             }
@@ -138,11 +139,11 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
                     }
                 }
             }
-            
+
             if all_rules.is_empty() {
                 return Err(anyhow::anyhow!("No rules found for detected languages"));
             }
-            
+
             Rules::merge_rules(all_rules)
         }
         _ => Err(anyhow::anyhow!("Invalid CLI configuration")),
@@ -151,31 +152,38 @@ fn load_rules(cli: &Cli, context: &ScanContext) -> Result<Rules> {
 
 /// Run explicit scan mode (language and rules specified)
 pub fn run_explicit_scan(cli: &Cli, root_dir: &str, show_progress: bool) -> Result<Vec<Finding>> {
-    let language = cli.language.as_ref()
+    let language = cli
+        .language
+        .as_ref()
         .ok_or_else(|| anyhow::anyhow!("Language required for explicit scan"))?;
-    
+
     let mut all_rules = if should_use_embedded_rules(cli) {
-        vec![Rules::load_embedded_rules(language, cli.code_type.as_deref())?]
+        vec![Rules::load_embedded_rules(
+            language,
+            cli.code_type.as_deref(),
+        )?]
     } else {
-        let rules_path = cli.rules_path.as_ref()
-            .ok_or_else(|| anyhow::anyhow!("Rules path required for explicit scan when not using embedded rules"))?;
+        let rules_path = cli.rules_path.as_ref().ok_or_else(|| {
+            anyhow::anyhow!("Rules path required for explicit scan when not using embedded rules")
+        })?;
         vec![Rules::load_from_path(rules_path)?]
     };
-    
+
     // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
     // (Note: For embedded rules, backend rules are already loaded in load_embedded_rules)
     if !should_use_embedded_rules(cli) && matches!(language.as_str(), "javascript" | "tsx") {
         if let Some(code_type) = &cli.code_type {
-            if code_type != "frontend"{
+            if code_type != "frontend" {
                 let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
-                let backend_rules_file = format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
+                let backend_rules_file =
+                    format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
                 if let Ok(backend_rules) = Rules::load_from_file(&backend_rules_file) {
                     all_rules.push(backend_rules);
                 }
             }
         }
     }
-    
+
     let rules = if all_rules.len() == 1 {
         all_rules.into_iter().next().unwrap()
     } else {
@@ -184,11 +192,7 @@ pub fn run_explicit_scan(cli: &Cli, root_dir: &str, show_progress: bool) -> Resu
     let total_rules = ScanningLogic::count_total_rules(&rules);
     // Configure minified file skipping
     let skip_minified = cli.skip_minified.unwrap_or(true);
-    let scanner = VulnerabilityScanner::with_skip_minified(
-        language, 
-        rules, 
-        skip_minified
-    )?;
+    let scanner = VulnerabilityScanner::with_skip_minified(language, rules, skip_minified)?;
 
     if show_progress {
         let mode = if cli.single_threaded {
@@ -222,11 +226,11 @@ pub fn run_explicit_scan(cli: &Cli, root_dir: &str, show_progress: bool) -> Resu
     // Use the new filtering method if filters are specified
     if cli.code_type.is_some() || cli.language_filter.is_some() {
         scanner.find_vulnerabilities_unified_with_filters(
-            root_dir, 
-            language, 
+            root_dir,
+            language,
             show_progress,
             cli.code_type.as_deref(),
-            cli.language_filter.as_deref()
+            cli.language_filter.as_deref(),
         )
     } else {
         scanner.find_vulnerabilities_parallel(root_dir, language, show_progress)
@@ -234,9 +238,13 @@ pub fn run_explicit_scan(cli: &Cli, root_dir: &str, show_progress: bool) -> Resu
 }
 
 /// Run auto-detection scan mode (automatically detect languages and load rules)
-pub fn run_auto_detection_scan(cli: &Cli, root_dir: &str, show_progress: bool) -> Result<Vec<Finding>> {
+pub fn run_auto_detection_scan(
+    cli: &Cli,
+    root_dir: &str,
+    show_progress: bool,
+) -> Result<Vec<Finding>> {
     let scan_start = std::time::Instant::now();
-    
+
     // Initialize unified scan context
     let context = ScanContext::new(cli, root_dir, show_progress)?;
 
@@ -252,27 +260,29 @@ pub fn run_auto_detection_scan(cli: &Cli, root_dir: &str, show_progress: bool) -
         );
         crate::ui::field("mode", &context.mode_display(cli.threads));
     }
-    
+
     // Rediscover files by language for actual processing (context only used for validation)
     let files_by_language = if cli.single_threaded {
         crate::scanner::utils::discover_files_by_language_sequential_with_progress(root_dir, false)?
     } else {
         crate::scanner::utils::discover_files_by_language_parallel_with_progress(root_dir, false)?
     };
-    
+
     let total_findings = Arc::new(AtomicUsize::new(0));
     let mut progress_manager = if !cli.single_threaded && show_progress {
         Some(context.create_progress_manager())
-    } else { None };
-    
+    } else {
+        None
+    };
+
     if show_progress {
         println!();
     }
-    
+
     // Convert to Vec to own data
     let lang_jobs: Vec<(String, Vec<PathBuf>)> = files_by_language.into_iter().collect();
     let processed_files = Arc::new(AtomicUsize::new(0));
-    
+
     // Start progress tracking
     if let Some(ref mut progress) = progress_manager {
         progress.start_tracking(Arc::clone(&processed_files), Arc::clone(&total_findings));
@@ -280,7 +290,7 @@ pub fn run_auto_detection_scan(cli: &Cli, root_dir: &str, show_progress: bool) -
 
     let total_rules_loaded = Arc::new(AtomicUsize::new(0));
     let mut all_findings = Vec::new();
-    
+
     // Process languages sequentially to avoid nested parallelism deadlocks
     for (language, files) in lang_jobs {
         let base_rules_dir = cli.rules_dir.as_deref().unwrap_or("rules");
@@ -288,39 +298,38 @@ pub fn run_auto_detection_scan(cli: &Cli, root_dir: &str, show_progress: bool) -
             "tsx" => format!("{}/javascript", base_rules_dir),
             _ => format!("{}/{}", base_rules_dir, language),
         };
-        
+
         // Load rules - either embedded or from files
         let mut all_rules = Vec::new();
-        
+
         if should_use_embedded_rules(cli) {
             // Use embedded rules
-            if let Ok(embedded_rules) = Rules::load_embedded_rules(&language, cli.code_type.as_deref()) {
+            if let Ok(embedded_rules) =
+                Rules::load_embedded_rules(&language, cli.code_type.as_deref())
+            {
                 all_rules.push(embedded_rules);
             }
         } else {
             // Load base rules for the language with centralized exclusions
             // Determine exclusion pattern type based on code_type
-            let pattern_type = if let Some(code_type) = &cli.code_type {
-                if code_type == "backend" {
-                    "backend"
-                } else if code_type == "frontend" {
-                    "frontend"
-                } else {
-                    "frontend" // default for "both" or other values
-                }
+            let pattern_type = if cli.code_type.as_deref() == Some("backend") {
+                "backend"
             } else {
-                "frontend" // default when no code_type specified
+                "frontend"
             };
-            
-            if let Ok(base_rules) = Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type) {
+
+            if let Ok(base_rules) =
+                Rules::load_from_directory_with_exclusions(&rules_dir, pattern_type)
+            {
                 all_rules.push(base_rules);
             }
-            
+
             // Load additional backend rules for JavaScript/TypeScript if code_type is backend or both
             if matches!(language.as_str(), "javascript" | "tsx") {
                 if let Some(code_type) = &cli.code_type {
                     if code_type != "frontend" {
-                        let backend_rules_dir = format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
+                        let backend_rules_dir =
+                            format!("{}/backend_javascript/backend_security.ron", base_rules_dir);
                         if let Ok(backend_rules) = Rules::load_from_file(&backend_rules_dir) {
                             all_rules.push(backend_rules);
                         }
@@ -328,69 +337,68 @@ pub fn run_auto_detection_scan(cli: &Cli, root_dir: &str, show_progress: bool) -
                 }
             }
         }
-        
+
         if all_rules.is_empty() {
             continue; // Skip if no rules found
         }
-        
+
         let rules = if all_rules.len() == 1 {
             all_rules.into_iter().next().unwrap()
         } else {
             Rules::merge_rules(all_rules)?
         };
-        
+
         {
-                let rule_count = ScanningLogic::count_total_rules(&rules);
-                total_rules_loaded.fetch_add(rule_count, Ordering::Relaxed);
-                
-                if let Some(ref progress) = progress_manager {
-                    progress.set_message(format!("| scanning {} ({}/{} files)", language, files.len(), context.total_files));
+            let rule_count = ScanningLogic::count_total_rules(&rules);
+            total_rules_loaded.fetch_add(rule_count, Ordering::Relaxed);
+
+            if let Some(ref progress) = progress_manager {
+                progress.set_message(format!("scanning {}", language));
+            }
+
+            let scanner =
+                VulnerabilityScanner::with_skip_minified(&language, rules, context.skip_minified)
+                    .expect("scanner");
+
+            let findings_result = if cli.code_type.is_some() || cli.language_filter.is_some() {
+                scanner.find_vulnerabilities_unified_with_filters(
+                    root_dir,
+                    &language,
+                    false, // Never show progress for individual languages in auto-detection
+                    cli.code_type.as_deref(),
+                    cli.language_filter.as_deref(),
+                )
+            } else {
+                scanner.find_vulnerabilities_parallel(root_dir, &language, false)
+            };
+
+            match findings_result {
+                Ok(fnds) => {
+                    processed_files.fetch_add(files.len(), Ordering::Relaxed);
+                    if !fnds.is_empty() {
+                        total_findings.fetch_add(fnds.len(), Ordering::Relaxed);
+                    }
+                    all_findings.extend(fnds);
                 }
-                
-                let scanner = VulnerabilityScanner::with_skip_minified(
-                    &language, 
-                    rules, 
-                    context.skip_minified
-                ).expect("scanner");
-                
-                let findings_result = if cli.code_type.is_some() || cli.language_filter.is_some() {
-                    scanner.find_vulnerabilities_unified_with_filters(
-                        root_dir, 
-                        &language, 
-                        false, // Never show progress for individual languages in auto-detection
-                        cli.code_type.as_deref(),
-                        cli.language_filter.as_deref()
-                    )
-                } else {
-                    scanner.find_vulnerabilities_parallel(root_dir, &language, false)
-                };
-                
-                match findings_result {
-                    Ok(fnds) => {
-                        processed_files.fetch_add(files.len(), Ordering::Relaxed);
-                        if !fnds.is_empty() {
-                            total_findings.fetch_add(fnds.len(), Ordering::Relaxed);
-                        }
-                        all_findings.extend(fnds);
-                    }
-                    Err(e) => {
-                        crate::ui::warn(&format!("failed to scan {}: {}", language, e));
-                    }
+                Err(e) => {
+                    crate::ui::warn(&format!("failed to scan {}: {}", language, e));
                 }
             }
+        }
     }
 
     // Stop progress tracking
     if let Some(mut progress) = progress_manager {
         progress.stop();
     }
-    
+
     // Use unified performance reporting
     let scan_duration = scan_start.elapsed();
     if show_progress {
-        context.print_performance_summary(total_rules_loaded.load(Ordering::Relaxed), scan_duration);
+        context
+            .print_performance_summary(total_rules_loaded.load(Ordering::Relaxed), scan_duration);
     }
-    
+
     Ok(all_findings)
 }
 
@@ -400,33 +408,48 @@ pub fn run_taint_analysis(cli: &Cli, root_dir: &str, show_progress: bool) -> Res
 }
 
 /// Run taint analysis mode with verbosity control
-pub fn run_taint_analysis_with_verbosity(cli: &Cli, root_dir: &str, show_progress: bool, verbose_mode: bool) -> Result<Vec<Finding>> {
+pub fn run_taint_analysis_with_verbosity(
+    cli: &Cli,
+    root_dir: &str,
+    show_progress: bool,
+    verbose_mode: bool,
+) -> Result<Vec<Finding>> {
+    // When taint runs as the second pass of a combined scan (verbose_mode = false),
+    // stay completely silent so we don't duplicate the banner, progress bar, or tallies.
     let report = show_progress && verbose_mode;
     let scan_start = std::time::Instant::now();
 
+    // Initialize unified scan context (reuse existing infrastructure)
     let context = ScanContext::new(cli, root_dir, report)?;
 
+    // Load rules using unified pattern (reuse existing infrastructure)
     let rules = load_rules(cli, &context)?;
 
+    // Check if we have taint flow rules
     let taint_rules_count = rules.rules.iter().filter(|r| r.is_taint_rule()).count();
 
     if taint_rules_count == 0 {
-        return Err(anyhow::anyhow!("No taint flow rules found. Please ensure your rules contain rules with mode='taint'."));
+        return Err(anyhow::anyhow!(
+            "No taint flow rules found. Please ensure your rules contain rules with mode='taint'."
+        ));
     }
-    if report {
+    if show_progress && verbose_mode {
         crate::ui::banner(root_dir);
         crate::ui::field("mode", "taint analysis");
         crate::ui::field("rules", &format!("{} taint-flow rules", taint_rules_count));
         crate::ui::field("files", &context.total_files.to_string());
         println!();
     }
+    // Use the unified VulnerabilityScanner infrastructure for massive speedup!
+    // This reuses ALL existing optimizations: parallel processing, prefiltering,
+    // memory mapping, thread-local parsers, progress tracking, etc.
+    // Respect CLI language parameter for proper prefiltering (especially minified file skipping)
     let language = cli.language.as_deref().unwrap_or("");
-    let scanner = VulnerabilityScanner::with_skip_minified(
-        language,
-        rules, 
-        context.skip_minified
-    )?;
+    let scanner = VulnerabilityScanner::with_skip_minified(language, rules, context.skip_minified)?;
 
+    // When taint runs as the silent second pass of a combined scan, the unified
+    // scanner shows no bar of its own (report = false), so drive a spinner here to
+    // keep the terminal alive during what is often the slowest phase.
     let mut spinner = if show_progress && !verbose_mode {
         Some(ProgressManager::new_spinner("analyzing data flows"))
     } else {
@@ -435,11 +458,11 @@ pub fn run_taint_analysis_with_verbosity(cli: &Cli, root_dir: &str, show_progres
 
     let all_findings = if cli.code_type.is_some() || cli.language_filter.is_some() {
         scanner.find_vulnerabilities_unified_with_filters(
-            root_dir, 
-            language, 
+            root_dir,
+            language,
             report,
             cli.code_type.as_deref(),
-            cli.language_filter.as_deref()
+            cli.language_filter.as_deref(),
         )?
     } else {
         scanner.find_vulnerabilities_unified(root_dir, language, report)?
@@ -448,24 +471,31 @@ pub fn run_taint_analysis_with_verbosity(cli: &Cli, root_dir: &str, show_progres
     if let Some(mut spinner) = spinner.take() {
         spinner.stop();
     }
-        
-    // Filter to only taint analysis findings 
-    let taint_findings: Vec<Finding> = all_findings.into_iter()
+
+    // Filter to only taint analysis findings
+    let taint_findings: Vec<Finding> = all_findings
+        .into_iter()
         .filter(|f| {
-            f.tags.as_ref().map_or(false, |tags| 
-                tags.contains(&"taint_analysis".to_string())
-            )
+            f.tags
+                .as_ref()
+                .is_some_and(|tags| tags.contains(&"taint_analysis".to_string()))
         })
         .collect();
-    
+
     let scan_duration = scan_start.elapsed();
-    
-    if report {
+
+    if show_progress && verbose_mode {
+        // Use unified performance reporting (reuse existing infrastructure)
         context.print_performance_summary(taint_rules_count, scan_duration);
 
         if !taint_findings.is_empty() {
-            let same_file_count = taint_findings.iter()
-                .filter(|f| f.tags.as_ref().map_or(false, |tags| tags.contains(&"same_file".to_string())))
+            let same_file_count = taint_findings
+                .iter()
+                .filter(|f| {
+                    f.tags
+                        .as_ref()
+                        .is_some_and(|tags| tags.contains(&"same_file".to_string()))
+                })
                 .count();
             let cross_file_count = taint_findings.len() - same_file_count;
 
@@ -477,8 +507,6 @@ pub fn run_taint_analysis_with_verbosity(cli: &Cli, root_dir: &str, show_progres
             ));
         }
     }
-    
+
     Ok(taint_findings)
 }
-
- 

--- a/src/scanner/prefilter.rs
+++ b/src/scanner/prefilter.rs
@@ -4,6 +4,7 @@ use crate::rules::Rules;
 use crate::scanner::utils::matches_glob_pattern;
 use anyhow::Result;
 use std::fs;
+use std::io::Read;
 use std::path::Path;
 use tree_sitter::Node;
 
@@ -57,7 +58,13 @@ impl PreFilter {
             }
         }
 
-        // Always skip text/doc files for both modes
+        // For malicious scanning, scan everything else (including text/doc and
+        // binary files such as .svg, which can carry payloads)
+        if self.is_malicious_scan {
+            return true;
+        }
+
+        // Skip text/doc files (except in malicious-scan mode, handled above)
         if self.is_text_or_doc_file(file_path) {
             return false;
         }
@@ -66,11 +73,6 @@ impl PreFilter {
         if self.skip_minified && self.is_js_or_ts_language() && self.is_minified_js_file(file_path)
         {
             return false;
-        }
-
-        // For malicious scanning, scan everything else
-        if self.is_malicious_scan {
-            return true;
         }
 
         // For general scanning, also skip test/migration files
@@ -147,17 +149,32 @@ impl PreFilter {
             return false;
         }
 
-        // Simple check: large single-line files are likely minified
-        match fs::read_to_string(file_path) {
-            Ok(content) => {
-                let line_count = content.lines().count();
-                let char_count = content.len();
+        // Sniff only the first chunk of the file instead of reading it whole.
+        // The heuristic (<= 3 lines && > 2000 bytes) is fully decidable on a
+        // capped window: the > 2000 byte threshold is reachable within 8 KB,
+        // and if the first 8 KB already holds > 3 lines the file is not the
+        // "few huge lines" minified shape. A file that packs its first 8 KB
+        // into <= 3 lines is exactly the minified signature we want to catch.
+        const MAX_SNIFF_BYTES: u64 = 8192;
 
-                // Single line with lots of content = likely minified
-                line_count <= 3 && char_count > 2000
-            }
-            Err(_) => false,
+        let file = match fs::File::open(file_path) {
+            Ok(file) => file,
+            Err(_) => return false,
+        };
+
+        let mut buf = Vec::new();
+        if file.take(MAX_SNIFF_BYTES).read_to_end(&mut buf).is_err() {
+            return false;
         }
+
+        // Decode lossily so non-UTF8 bytes don't abort the heuristic (the old
+        // read_to_string returned false on non-UTF8; here we still classify).
+        let content = String::from_utf8_lossy(&buf);
+        let line_count = content.lines().count();
+        let char_count = buf.len();
+
+        // Single line with lots of content = likely minified
+        line_count <= 3 && char_count > 2000
     }
 
     /// Use tree-sitter to check if file is test or migration
@@ -314,14 +331,16 @@ impl PreFilter {
             }
         }
 
-        // Check text/doc files next (relatively fast)
-        if self.is_text_or_doc_file(file_path) {
-            return FilterReason::Doc;
-        }
-
-        // For malicious scanning, include everything else (skip other checks)
+        // For malicious scanning, include everything else (skip other checks),
+        // including text/doc and binary files such as .svg, which can carry payloads
         if self.is_malicious_scan {
             return FilterReason::Include;
+        }
+
+        // Check text/doc files next (relatively fast); skipped except in
+        // malicious-scan mode, handled above
+        if self.is_text_or_doc_file(file_path) {
+            return FilterReason::Doc;
         }
 
         // Check minified files for JS/TS (potentially expensive, so do conditionally)

--- a/src/scanner/prefilter.rs
+++ b/src/scanner/prefilter.rs
@@ -1,10 +1,10 @@
+use crate::config::filters::SKIP_MINIFIED_PATTERNS;
+use crate::parser::{get_node_text, LanguageParser};
+use crate::rules::Rules;
+use crate::scanner::utils::matches_glob_pattern;
+use anyhow::Result;
 use std::fs;
 use std::path::Path;
-use anyhow::Result;
-use crate::rules::Rules;
-use crate::parser::{LanguageParser, get_node_text};
-use crate::config::filters::SKIP_MINIFIED_PATTERNS;
-use crate::scanner::utils::matches_glob_pattern;
 use tree_sitter::Node;
 
 #[derive(Debug, Clone)]
@@ -20,15 +20,20 @@ impl PreFilter {
         Self::with_options(rules, language, true, Vec::new())
     }
 
-    pub fn with_options(rules: &Rules, language: &str, skip_minified: bool, custom_patterns: Vec<String>) -> Self {
+    pub fn with_options(
+        rules: &Rules,
+        language: &str,
+        skip_minified: bool,
+        custom_patterns: Vec<String>,
+    ) -> Self {
         // Check if we have any malware detection rules
         let is_malicious_scan = rules.rules.iter().any(|rule| {
-            rule.name.as_ref().map_or(false, |name| {
+            rule.name.as_ref().is_some_and(|name| {
                 let name_lower = name.to_lowercase();
-                name_lower.contains("malware") ||
-                name_lower.contains("malicious") ||
-                name_lower.contains("backdoor") ||
-                name_lower.contains("trojan")
+                name_lower.contains("malware")
+                    || name_lower.contains("malicious")
+                    || name_lower.contains("backdoor")
+                    || name_lower.contains("trojan")
             }) || rule.get_category().to_lowercase().contains("malware")
         });
 
@@ -58,7 +63,8 @@ impl PreFilter {
         }
 
         // Skip minified files for JavaScript/TypeScript if enabled
-        if self.skip_minified && self.is_js_or_ts_language() && self.is_minified_js_file(file_path) {
+        if self.skip_minified && self.is_js_or_ts_language() && self.is_minified_js_file(file_path)
+        {
             return false;
         }
 
@@ -74,11 +80,12 @@ impl PreFilter {
     /// Simple text/doc file detection
     fn is_text_or_doc_file(&self, file_path: &str) -> bool {
         let path_lower = file_path.to_lowercase();
-        
+
         // File extensions
-        let skip_extensions = [".txt", ".md", ".rst", ".pdf", ".doc", ".docx", 
-                              ".jpg", ".png", ".gif", ".svg", ".ico"];
-        
+        let skip_extensions = [
+            ".txt", ".md", ".rst", ".pdf", ".doc", ".docx", ".jpg", ".png", ".gif", ".svg", ".ico",
+        ];
+
         if skip_extensions.iter().any(|ext| path_lower.ends_with(ext)) {
             return true;
         }
@@ -88,8 +95,9 @@ impl PreFilter {
             .file_name()
             .and_then(|n| n.to_str())
             .unwrap_or("");
-            
-        ["readme", "license", "changelog", "authors"].iter()
+
+        ["readme", "license", "changelog", "authors"]
+            .iter()
             .any(|name| filename.starts_with(name))
     }
 
@@ -131,8 +139,11 @@ impl PreFilter {
     /// Simple heuristic to detect minified content (edge cases only)
     fn is_likely_minified_content(&self, file_path: &str) -> bool {
         // Only check JS/TS files
-        if !file_path.ends_with(".js") && !file_path.ends_with(".jsx") && 
-           !file_path.ends_with(".ts") && !file_path.ends_with(".tsx") {
+        if !file_path.ends_with(".js")
+            && !file_path.ends_with(".jsx")
+            && !file_path.ends_with(".ts")
+            && !file_path.ends_with(".tsx")
+        {
             return false;
         }
 
@@ -141,7 +152,7 @@ impl PreFilter {
             Ok(content) => {
                 let line_count = content.lines().count();
                 let char_count = content.len();
-                
+
                 // Single line with lots of content = likely minified
                 line_count <= 3 && char_count > 2000
             }
@@ -164,10 +175,10 @@ impl PreFilter {
         let source = fs::read(file_path)?;
         let mut parser = LanguageParser::new(&self.language)?;
         let tree = parser.parse(&source)?;
-        
+
         let mut imports_text = String::new();
         self.collect_imports(&tree.root_node(), &source, &mut imports_text);
-        
+
         Ok(imports_text.to_lowercase())
     }
 
@@ -197,41 +208,69 @@ impl PreFilter {
     fn has_test_patterns(&self, imports_text: &str) -> bool {
         let test_patterns = [
             // Universal test indicators
-            "test", "mock", "spec", "jest", "pytest", "unittest",
-            "cypress", "selenium", "junit", "testng", "mocha",
+            "test",
+            "mock",
+            "spec",
+            "jest",
+            "pytest",
+            "unittest",
+            "cypress",
+            "selenium",
+            "junit",
+            "testng",
+            "mocha",
             // Language specific
-            "django.test", "flask.testing", "@testing-library",
-            "org.junit", "org.mockito", "org.testng",
+            "django.test",
+            "flask.testing",
+            "@testing-library",
+            "org.junit",
+            "org.mockito",
+            "org.testng",
         ];
-        
-        test_patterns.iter().any(|pattern| imports_text.contains(pattern))
+
+        test_patterns
+            .iter()
+            .any(|pattern| imports_text.contains(pattern))
     }
 
     /// Simple pattern matching for migration frameworks
     fn has_migration_patterns(&self, imports_text: &str) -> bool {
         let migration_patterns = [
-            "migration", "migrations", "migrate", "alembic", "flyway", "liquibase",
-            "django.db.migrations", "sequelize", "knex", "typeorm",
+            "migration",
+            "migrations",
+            "migrate",
+            "alembic",
+            "flyway",
+            "liquibase",
+            "django.db.migrations",
+            "sequelize",
+            "knex",
+            "typeorm",
         ];
-        
-        migration_patterns.iter().any(|pattern| imports_text.contains(pattern))
+
+        migration_patterns
+            .iter()
+            .any(|pattern| imports_text.contains(pattern))
     }
 
-    pub fn filter_files(&self, files: Vec<std::path::PathBuf>) -> (Vec<std::path::PathBuf>, FilterStats) {
+    pub fn filter_files(
+        &self,
+        files: Vec<std::path::PathBuf>,
+    ) -> (Vec<std::path::PathBuf>, FilterStats) {
         let mut included = 0;
         let mut filtered_out = 0;
         let mut minified_filtered = 0;
         let mut test_filtered = 0;
         let mut doc_filtered = 0;
-        
+
         let filtered: Vec<_> = files
             .into_iter()
             .filter(|path| {
                 let path_str = path.to_string_lossy();
-                
+
                 // Optimized filtering with single-pass checks to avoid redundancy
                 let filter_result = self.check_file_with_reason(&path_str);
-                
+
                 match filter_result {
                     FilterReason::Include => {
                         included += 1;
@@ -255,9 +294,9 @@ impl PreFilter {
                 }
             })
             .collect();
-        
-        let stats = FilterStats { 
-            included, 
+
+        let stats = FilterStats {
+            included,
             filtered_out,
             minified_filtered,
             test_filtered,
@@ -286,7 +325,8 @@ impl PreFilter {
         }
 
         // Check minified files for JS/TS (potentially expensive, so do conditionally)
-        if self.skip_minified && self.is_js_or_ts_language() && self.is_minified_js_file(file_path) {
+        if self.skip_minified && self.is_js_or_ts_language() && self.is_minified_js_file(file_path)
+        {
             return FilterReason::Minified;
         }
 
@@ -323,8 +363,10 @@ impl FilterStats {
     }
 
     pub fn filter_percentage(&self) -> f32 {
-        if self.total() == 0 { 0.0 } else { 
-            (self.filtered_out as f32 / self.total() as f32) * 100.0 
+        if self.total() == 0 {
+            0.0
+        } else {
+            (self.filtered_out as f32 / self.total() as f32) * 100.0
         }
     }
 }
@@ -353,7 +395,7 @@ impl std::fmt::Display for FilterStats {
             }
             write!(f, "{}", details.join(", "))?;
         }
-        
+
         Ok(())
     }
-} 
+}

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -3,6 +3,7 @@ use crate::config::filters::SKIP_DIRS;
 use crate::parser::get_node_text;
 use crate::rules::FileTypes;
 use anyhow::Result;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use ignore::WalkBuilder;
 use once_cell::sync::Lazy;
 use rayon::prelude::*;
@@ -12,7 +13,13 @@ use std::sync::{Arc, Mutex};
 use tree_sitter::Node;
 use walkdir::WalkDir;
 
-static GIT_IGNORE_CACHE: Lazy<Mutex<HashMap<PathBuf, bool>>> =
+/// Cache of compiled gitignore matchers, keyed by repository root.
+///
+/// A matcher is built once per repo root by walking the repo a single time to
+/// collect every `.gitignore` file, then reused for all subsequent per-file
+/// queries. This turns the previous O(files x repo_size) cost (a full repo
+/// walk on every cache miss) into ~O(repo_size) per repo plus O(1) per query.
+static GIT_IGNORE_MATCHER_CACHE: Lazy<Mutex<HashMap<PathBuf, Arc<RepoGitignore>>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Check if a file path matches a glob pattern (delegates to common utils)
@@ -21,39 +28,89 @@ pub fn matches_glob_pattern(pattern: &str, file_path: &str) -> bool {
 }
 
 pub fn is_git_ignored(path: &Path) -> bool {
+    // Outside a git repo nothing is git-ignored.
+    let Some(repo_root) = find_git_repo_root(path) else {
+        return false;
+    };
+
+    matcher_for_repo(&repo_root).is_ignored(path)
+}
+
+/// Compiled gitignore state for a single repository.
+///
+/// Holds one `Gitignore` matcher per `.gitignore` file discovered under the
+/// repo root, each rooted at that file's own directory so nested patterns are
+/// matched with the correct relative semantics. Matchers are ordered deepest
+/// first so the most specific `.gitignore` wins (matching git's precedence).
+struct RepoGitignore {
+    /// (matcher root dir, matcher), deepest dir first.
+    matchers: Vec<(PathBuf, Gitignore)>,
+}
+
+impl RepoGitignore {
+    /// Build by walking the repo root once and compiling every `.gitignore`.
+    fn build(repo_root: &Path) -> Self {
+        let mut matchers: Vec<(PathBuf, Gitignore)> = WalkBuilder::new(repo_root)
+            .standard_filters(false)
+            .hidden(false)
+            .parents(false)
+            .build()
+            .filter_map(|entry| entry.ok())
+            .filter(|entry| entry.file_name() == ".gitignore")
+            .filter_map(|entry| {
+                let gitignore_path = entry.path();
+                let dir = gitignore_path.parent()?.to_path_buf();
+                let mut builder = GitignoreBuilder::new(&dir);
+                builder.add(gitignore_path);
+                let matcher = builder.build().ok()?;
+                Some((dir, matcher))
+            })
+            .collect();
+
+        // Deepest directories first so the most specific gitignore is checked
+        // before shallower ones.
+        matchers.sort_by_key(|(dir, _)| std::cmp::Reverse(dir.components().count()));
+
+        RepoGitignore { matchers }
+    }
+
+    /// Returns true if `path` is ignored by any applicable `.gitignore`.
+    ///
+    /// Uses `matched_path_or_any_parents` so that a directory pattern (e.g.
+    /// `build/`) ignores everything beneath it, matching git's behaviour of
+    /// pruning whole ignored subtrees. A matcher is only consulted for paths
+    /// under its own root directory (where its patterns apply).
+    fn is_ignored(&self, path: &Path) -> bool {
+        let is_dir = path.is_dir();
+        for (root, matcher) in &self.matchers {
+            if !path.starts_with(root) {
+                continue;
+            }
+            match matcher.matched_path_or_any_parents(path, is_dir) {
+                m if m.is_ignore() => return true,
+                m if m.is_whitelist() => return false,
+                _ => {}
+            }
+        }
+        false
+    }
+}
+
+/// Get (building and caching on first use) the gitignore matcher for a repo.
+fn matcher_for_repo(repo_root: &Path) -> Arc<RepoGitignore> {
     {
-        // Try to get from cache first
-        let cache = GIT_IGNORE_CACHE.lock().unwrap();
-        if let Some(cached) = cache.get(path) {
-            return *cached;
+        let cache = GIT_IGNORE_MATCHER_CACHE.lock().unwrap();
+        if let Some(matcher) = cache.get(repo_root) {
+            return Arc::clone(matcher);
         }
     }
 
-    // Compute the result
-    let result = if !is_within_git_repo(path) {
-        false
-    } else if let Some(repo_root) = find_git_repo_root(path) {
-        let mut walker = WalkBuilder::new(&repo_root)
-            .git_ignore(true)
-            .git_global(false)
-            .git_exclude(false)
-            .build();
+    // Build outside the lock; a concurrent racer may build the same matcher,
+    // which is harmless and cheap relative to a full repo walk per file.
+    let matcher = Arc::new(RepoGitignore::build(repo_root));
 
-        !walker.any(|entry| entry.map(|e| e.path() == path).unwrap_or(false))
-    } else {
-        false
-    };
-
-    // Store the result in the cache
-    let mut cache = GIT_IGNORE_CACHE.lock().unwrap();
-    cache.insert(path.to_path_buf(), result);
-
-    result
-}
-
-/// Check if a path is within a Git repository
-fn is_within_git_repo(path: &Path) -> bool {
-    find_git_repo_root(path).is_some()
+    let mut cache = GIT_IGNORE_MATCHER_CACHE.lock().unwrap();
+    Arc::clone(cache.entry(repo_root.to_path_buf()).or_insert(matcher))
 }
 
 /// Find the root of the Git repository containing the given path

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -1,26 +1,24 @@
-use crate::rules::FileTypes;
-use std::path::{Path, PathBuf};
-use std::collections::{HashMap, BTreeMap};
-use anyhow::Result;
-use walkdir::WalkDir;
-use rayon::prelude::*;
-use std::sync::{Arc, Mutex};
-use crate::config::filters::SKIP_DIRS;
-use tree_sitter::Node;
 use crate::common::CommonUtils;
+use crate::config::filters::SKIP_DIRS;
 use crate::parser::get_node_text;
+use crate::rules::FileTypes;
+use anyhow::Result;
 use ignore::WalkBuilder;
 use once_cell::sync::Lazy;
+use rayon::prelude::*;
+use std::collections::{BTreeMap, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use tree_sitter::Node;
+use walkdir::WalkDir;
 
-static GIT_IGNORE_CACHE: Lazy<Mutex<HashMap<PathBuf, bool>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static GIT_IGNORE_CACHE: Lazy<Mutex<HashMap<PathBuf, bool>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Check if a file path matches a glob pattern (delegates to common utils)
 pub fn matches_glob_pattern(pattern: &str, file_path: &str) -> bool {
     crate::common::CommonUtils::matches_file_pattern(pattern, file_path)
 }
-
-
-
 
 pub fn is_git_ignored(path: &Path) -> bool {
     {
@@ -108,7 +106,8 @@ pub fn rule_applies_to_file(file_types: Option<&FileTypes>, file_path: &str) -> 
         if let Some(file_extension) = Path::new(file_path).extension() {
             if let Some(ext_str) = file_extension.to_str() {
                 let ext_with_dot = format!(".{}", ext_str);
-                if !extensions.contains(&ext_str.to_string()) && !extensions.contains(&ext_with_dot) {
+                if !extensions.contains(&ext_str.to_string()) && !extensions.contains(&ext_with_dot)
+                {
                     return false;
                 }
             }
@@ -129,13 +128,13 @@ pub fn rule_applies_to_file_path(file_types: Option<&FileTypes>, file_path: &Pat
 /// Detect programming language from file path
 pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
     let file_name = file_path.file_name()?.to_str()?;
-    
+
     // Handle standard extensions
     match file_path.extension()?.to_str()? {
         // Python extensions
         "py" | "pyw" | "pyi" | "pyx" => Some("python"),
-        
-        // Java extensions  
+
+        // Java extensions
         "java" | "jav" => Some("java"),
 
         // C# extensions
@@ -149,53 +148,72 @@ pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
 
         // PHP extensions
         "php" | "php3" | "php4" | "php5" | "php7" | "phtml" => Some("php"),
-        
+
         // JavaScript extensions (including modern variants)
         "js" | "mjs" | "cjs" | "jsx" => Some("javascript"),
-        
+
         // TypeScript extensions (including all variants)
         "ts" | "tsx" | "mts" | "cts" => Some("tsx"),
-        
+
         // HTML and template extensions
         "html" | "htm" | "xhtml" | "shtml" | "dhtml" => Some("html"),
-        
+
         // Template file extensions that should be treated as HTML
-        "hbs" | "handlebars" | "mustache" | "twig" | "njk" | "nunjucks" | "ejs" | "pug" | "jade" => Some("html"),
-        
+        "hbs" | "handlebars" | "mustache" | "twig" | "njk" | "nunjucks" | "ejs" | "pug"
+        | "jade" => Some("html"),
+
         // Vue.js single file components (contain HTML, JS, and CSS)
         "vue" => Some("javascript"),
-        
-        // Svelte components 
+
+        // Svelte components
         "svelte" => Some("javascript"),
-        
+
         // Handle config files and other special cases
         _ => {
             // Check for JavaScript/TypeScript config files
-            if file_name.contains("webpack") || file_name.contains("rollup") || file_name.contains("vite") {
-                if file_name.ends_with(".config.js") || file_name.ends_with(".config.mjs") || file_name.ends_with(".config.cjs") {
+            if file_name.contains("webpack")
+                || file_name.contains("rollup")
+                || file_name.contains("vite")
+            {
+                if file_name.ends_with(".config.js")
+                    || file_name.ends_with(".config.mjs")
+                    || file_name.ends_with(".config.cjs")
+                {
                     return Some("javascript");
                 }
-                if file_name.ends_with(".config.ts") || file_name.ends_with(".config.mts") || file_name.ends_with(".config.cts") {
+                if file_name.ends_with(".config.ts")
+                    || file_name.ends_with(".config.mts")
+                    || file_name.ends_with(".config.cts")
+                {
                     return Some("tsx");
                 }
             }
-            
+
             // Check for Python files with unusual extensions
-            if file_name.ends_with("file") && (file_name.contains("requirements") || file_name.contains("Pipfile")) {
+            if file_name.ends_with("file")
+                && (file_name.contains("requirements") || file_name.contains("Pipfile"))
+            {
                 return Some("python");
             }
-            
+
             None
         }
     }
 }
 
 /// Discover files by language with configurable parallelism
-pub fn discover_files_by_language(root_dir: &str, parallel: bool) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+pub fn discover_files_by_language(
+    root_dir: &str,
+    parallel: bool,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     discover_files_by_language_with_progress(root_dir, parallel, true)
 }
 
-pub fn discover_files_by_language_with_progress(root_dir: &str, parallel: bool, show_progress: bool) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+pub fn discover_files_by_language_with_progress(
+    root_dir: &str,
+    parallel: bool,
+    show_progress: bool,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     let estimated_languages = crate::config::ScanDefaults::ESTIMATED_LANGUAGES;
 
     if parallel {
@@ -206,7 +224,11 @@ pub fn discover_files_by_language_with_progress(root_dir: &str, parallel: bool, 
 }
 
 /// Internal parallel file discovery implementation
-fn discover_files_parallel(root_dir: &str, estimated_languages: usize, show_progress: bool) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+fn discover_files_parallel(
+    root_dir: &str,
+    estimated_languages: usize,
+    _show_progress: bool,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     let all_paths: Vec<PathBuf> = WalkDir::new(root_dir)
         .follow_links(false)
         .into_iter()
@@ -228,7 +250,9 @@ fn discover_files_parallel(root_dir: &str, estimated_languages: usize, show_prog
                     } else {
                         Some(e.path().to_path_buf())
                     }
-                } else { None }
+                } else {
+                    None
+                }
             })
         })
         .collect();
@@ -236,20 +260,11 @@ fn discover_files_parallel(root_dir: &str, estimated_languages: usize, show_prog
     let estimated_files_per_lang = if all_paths.is_empty() {
         crate::config::ScanDefaults::ESTIMATED_FILES_PER_LANG
     } else {
-        (all_paths.len() / estimated_languages).max(crate::config::ScanDefaults::ESTIMATED_FILES_PER_LANG)
+        (all_paths.len() / estimated_languages)
+            .max(crate::config::ScanDefaults::ESTIMATED_FILES_PER_LANG)
     };
 
-    if show_progress {
-        crate::ui::note(&format!(
-            "discovered {} files (est. {} per language)",
-            all_paths.len(),
-            estimated_files_per_lang
-        ));
-    }
-
-    let files_by_language = Arc::new(Mutex::new(
-        BTreeMap::<String, Vec<PathBuf>>::new()
-    ));
+    let files_by_language = Arc::new(Mutex::new(BTreeMap::<String, Vec<PathBuf>>::new()));
 
     all_paths.par_iter().for_each(|path| {
         if let Some(language) = detect_language_from_path(path) {
@@ -267,7 +282,11 @@ fn discover_files_parallel(root_dir: &str, estimated_languages: usize, show_prog
 }
 
 /// Internal sequential file discovery implementation
-fn discover_files_sequential(root_dir: &str, estimated_languages: usize, _show_progress: bool) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+fn discover_files_sequential(
+    root_dir: &str,
+    _estimated_languages: usize,
+    _show_progress: bool,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     let mut files_by_language = BTreeMap::new();
 
     for entry in WalkDir::new(root_dir)
@@ -289,7 +308,11 @@ fn discover_files_sequential(root_dir: &str, estimated_languages: usize, _show_p
                 if let Some(language) = detect_language_from_path(entry.path()) {
                     files_by_language
                         .entry(language.to_string())
-                        .or_insert_with(|| Vec::with_capacity(crate::config::ScanDefaults::ESTIMATED_FILES_PER_LANG))
+                        .or_insert_with(|| {
+                            Vec::with_capacity(
+                                crate::config::ScanDefaults::ESTIMATED_FILES_PER_LANG,
+                            )
+                        })
                         .push(entry.path().to_path_buf());
                 }
             }
@@ -300,22 +323,32 @@ fn discover_files_sequential(root_dir: &str, estimated_languages: usize, _show_p
 }
 
 /// Parallel file discovery (replaces legacy wrapper)
-pub fn discover_files_by_language_parallel(root_dir: &str) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+pub fn discover_files_by_language_parallel(
+    root_dir: &str,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     discover_files_by_language(root_dir, true)
 }
 
 /// Sequential file discovery (replaces legacy wrapper)
-pub fn discover_files_by_language_sequential(root_dir: &str) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+pub fn discover_files_by_language_sequential(
+    root_dir: &str,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     discover_files_by_language(root_dir, false)
 }
 
 /// Parallel file discovery with progress control
-pub fn discover_files_by_language_parallel_with_progress(root_dir: &str, show_progress: bool) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+pub fn discover_files_by_language_parallel_with_progress(
+    root_dir: &str,
+    show_progress: bool,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     discover_files_by_language_with_progress(root_dir, true, show_progress)
 }
 
 /// Sequential file discovery with progress control
-pub fn discover_files_by_language_sequential_with_progress(root_dir: &str, show_progress: bool) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+pub fn discover_files_by_language_sequential_with_progress(
+    root_dir: &str,
+    show_progress: bool,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     discover_files_by_language_with_progress(root_dir, false, show_progress)
 }
 
@@ -349,11 +382,11 @@ impl AstUtils {
     fn is_configuration_pattern(code: &str) -> bool {
         // SPECIFIC configuration patterns only - not broad keyword matching
         let specific_config_patterns = [
-            ".setdefault(",           // os.environ.setdefault()
-            "load_config(",           // config loading
-            "configure(",             // configure() calls
-            "settings.",              // settings.SOMETHING
-            "_config.",               // some_config.something
+            ".setdefault(", // os.environ.setdefault()
+            "load_config(", // config loading
+            "configure(",   // configure() calls
+            "settings.",    // settings.SOMETHING
+            "_config.",     // some_config.something
         ];
 
         // Only match if it's clearly a configuration operation, not just containing keywords
@@ -374,8 +407,8 @@ impl AstUtils {
             "sys.argv",
         ];
 
-        user_input_patterns.iter().any(|&p| code.contains(p)) ||
-        (pattern.contains("environ") && Self::is_environment_read(code))
+        user_input_patterns.iter().any(|&p| code.contains(p))
+            || (pattern.contains("environ") && Self::is_environment_read(code))
     }
 
     /// Check if environment access is reading (source) vs setting (config)
@@ -426,10 +459,16 @@ impl AstUtils {
 
     /// Check if node is a function definition
     pub fn is_function_node(node: &Node) -> bool {
-        matches!(node.kind(),
-            "function_definition" | "function_declaration" | "method_definition" |
-            "arrow_function" | "function_expression" | "generator_function" |
-            "async_function" | "constructor_definition"
+        matches!(
+            node.kind(),
+            "function_definition"
+                | "function_declaration"
+                | "method_definition"
+                | "arrow_function"
+                | "function_expression"
+                | "generator_function"
+                | "async_function"
+                | "constructor_definition"
         )
     }
 
@@ -483,26 +522,43 @@ impl AstUtils {
 
     fn check_python_sanitization(code: &str) -> bool {
         let py_sanitizers = [
-            "html.escape", "cgi.escape", "urllib.parse.quote", "bleach.clean",
-            "markupsafe.escape", "jinja2.escape", "django.utils.html.escape",
+            "html.escape",
+            "cgi.escape",
+            "urllib.parse.quote",
+            "bleach.clean",
+            "markupsafe.escape",
+            "jinja2.escape",
+            "django.utils.html.escape",
         ];
         py_sanitizers.iter().any(|pattern| code.contains(pattern))
     }
 
     fn check_java_sanitization(code: &str) -> bool {
         let java_sanitizers = [
-            "StringEscapeUtils.escape", "ESAPI.encoder", "URLEncoder.encode",
-            "StringUtils.escape", ".encode(", "sanitize(",
+            "StringEscapeUtils.escape",
+            "ESAPI.encoder",
+            "URLEncoder.encode",
+            "StringUtils.escape",
+            ".encode(",
+            "sanitize(",
         ];
         java_sanitizers.iter().any(|pattern| code.contains(pattern))
     }
 
     fn check_generic_sanitization(code: &str) -> bool {
         let generic_sanitizers = [
-            "sanitize(", "escape(", "encode(", "clean(", "validate(",
-            "filter(", "purify(", "safe(",
+            "sanitize(",
+            "escape(",
+            "encode(",
+            "clean(",
+            "validate(",
+            "filter(",
+            "purify(",
+            "safe(",
         ];
-        generic_sanitizers.iter().any(|pattern| code.contains(pattern))
+        generic_sanitizers
+            .iter()
+            .any(|pattern| code.contains(pattern))
     }
 
     /// Extract variables from expression with semantic understanding
@@ -512,7 +568,9 @@ impl AstUtils {
 
         match node.kind() {
             "assignment" | "assignment_expression" => {
-                if let Some(target) = CommonUtils::extract_variable_from_assignment(&node_text, false) {
+                if let Some(target) =
+                    CommonUtils::extract_variable_from_assignment(&node_text, false)
+                {
                     variables.push(SemanticVariable {
                         name: target,
                         var_type: VariableType::AssignmentTarget,

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,50 +1,37 @@
 # Test Organization
 
-This directory contains all the tests for the vulnerability scanner. The tests are organized into three categories:
+This directory contains all tests for Sighthound, organized into three suites.
 
 ## Directory Structure
 
 - **unit/**: Tests for individual components
-  - `injection_pattern_tests.rs`: Tests for injection pattern detection
-  - `django_xss_prevention_tests.rs`: Tests for Django XSS prevention
-  - `file_pattern_tests.rs`: Tests for file pattern matching
-  - `directory_loading_tests.rs`: Tests for directory loading
-  - `rule_deserialization_tests.rs`: Tests for rule deserialization
-  - `pattern_matching_tests.rs`: Tests for pattern matching
+  - `injection_pattern_tests.rs`: Injection pattern detection
+  - `django_xss_prevention_tests.rs`: Django XSS prevention
+  - `file_pattern_tests.rs`: File pattern matching
+  - `directory_loading_tests.rs`: Directory loading
+  - `rule_deserialization_tests.rs`: Rule deserialization
+  - `pattern_matching_tests.rs`: Pattern matching
 
 - **integration/**: Tests for multiple components working together
-  - `integration_tests.rs`: Tests for integrating rule parsing, scanning, and results
+  - `integration_tests.rs`: Rule parsing, scanning, and results integration
 
-- **end_to_end/**: Tests for the entire system
-  - `end_to_end_injection_tests.rs`: End-to-end tests for injection vulnerability detection
-
-## Running Tests
-
-To run all tests:
-```bash
-cargo test
-```
-
-To run a specific category of tests:
-```bash
-cargo test unit_tests
-cargo test integration_tests
-cargo test end_to_end_tests
-```
-
-To run a specific test:
-```bash
-cargo test pattern_matching
-```
+- **end_to_end/**: Full scanner flows
+  - `end_to_end_injection_tests.rs`: End-to-end injection detection
 
 ## Test Fixtures
 
-Test fixtures (sample code and rule files) are located in the `test_fixtures/` directory at the project root.
+Sample code and scenarios live under `tests/test_files/`:
 
-- `test_fixtures/python/`: Python test files
-- `test_fixtures/java/`: Java test files
-- `test_fixtures/rules/`: Rule files for testing
+- `python/`, `javascript/`, etc. — language-specific fixtures
+- `false_positives/` — patterns that must not be flagged
+- `multi_file_taint_tests/` — cross-file taint scenarios
 
-## Test Scripts
+## Running Tests
 
-Test scripts and utilities are located in the `test_scripts/` directory at the project root. 
+```bash
+cargo test                       # all suites
+cargo test --test unit_tests
+cargo test --test integration_tests
+cargo test --test end_to_end_tests
+cargo test pattern_matching      # filter by test name
+```

--- a/tests/end_to_end/end_to_end_injection_tests.rs
+++ b/tests/end_to_end/end_to_end_injection_tests.rs
@@ -1,8 +1,8 @@
-use sighthound::VulnerabilityScanner;
 use sighthound::rules::Rules;
-use tempfile::{TempDir, NamedTempFile};
+use sighthound::VulnerabilityScanner;
 use std::fs;
 use std::io::Write;
+use tempfile::{NamedTempFile, TempDir};
 
 #[cfg(test)]
 mod end_to_end_injection_tests {
@@ -10,7 +10,7 @@ mod end_to_end_injection_tests {
 
     fn create_temp_dir_with_files(files: Vec<(&str, &str)>) -> TempDir {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        
+
         for (filename, content) in files {
             let file_path = temp_dir.path().join(filename);
             if let Some(parent) = file_path.parent() {
@@ -18,7 +18,7 @@ mod end_to_end_injection_tests {
             }
             fs::write(&file_path, content).expect("Failed to write file");
         }
-        
+
         temp_dir
     }
 
@@ -64,7 +64,7 @@ mod end_to_end_injection_tests {
                 ),
             ],
         )"#;
-        
+
         let mut temp_file = NamedTempFile::with_suffix(".ron").expect("Failed to create temp file");
         write!(temp_file, "{}", rules_content).expect("Failed to write rules");
         temp_file
@@ -74,7 +74,9 @@ mod end_to_end_injection_tests {
     #[cfg(feature = "python")]
     fn test_python_sql_injection_detection() {
         let python_files = vec![
-            ("vulnerable.py", r#"
+            (
+                "vulnerable.py",
+                r#"
 import sqlite3
 
 def get_user_vulnerable(user_id):
@@ -108,8 +110,11 @@ def get_user_safe():
     # This should NOT be detected - literal string
     cursor.execute("SELECT * FROM users")
     return cursor.fetchall()
-"#),
-            ("safe.py", r#"
+"#,
+            ),
+            (
+                "safe.py",
+                r#"
 import sqlite3
 
 def get_all_users():
@@ -123,53 +128,67 @@ def count_users():
     cursor = conn.cursor()
     cursor.execute("SELECT COUNT(*) FROM users")
     return cursor.fetchone()[0]
-"#),
+"#,
+            ),
         ];
 
         let temp_dir = create_temp_dir_with_files(python_files);
 
         // Use the production Python rule set, which is injection-aware (it flags
         // dynamic query construction but leaves literal queries alone).
-        let rules = Rules::load_from_directory("rules/python/")
-            .expect("Failed to load python rules");
-        let scanner = VulnerabilityScanner::new("python", rules)
-            .expect("Failed to create scanner");
+        let rules =
+            Rules::load_from_directory("rules/python/").expect("Failed to load python rules");
+        let scanner = VulnerabilityScanner::new("python", rules).expect("Failed to create scanner");
 
         // Scan the directory
-        let findings = scanner.find_vulnerabilities_single_threaded(
-            temp_dir.path().to_str().unwrap(),
-            "python"
-        ).expect("Failed to scan directory");
+        let findings = scanner
+            .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "python")
+            .expect("Failed to scan directory");
 
         println!("Found {} findings", findings.len());
         for finding in &findings {
-            println!("Finding: {} in {} at line {} - {}", 
-                finding.finding_type, finding.file, finding.line, finding.snippet);
+            println!(
+                "Finding: {} in {} at line {} - {}",
+                finding.finding_type, finding.file, finding.line, finding.snippet
+            );
         }
 
         // The 3 dynamically-built queries in vulnerable.py should be detected as SQL injection.
-        let sql_injection_count = findings.iter()
+        let sql_injection_count = findings
+            .iter()
             .filter(|f| f.finding_type.to_lowercase().contains("sql"))
             .count();
-        assert!(sql_injection_count >= 3, "Should find at least 3 SQL injection vulnerabilities");
+        assert!(
+            sql_injection_count >= 3,
+            "Should find at least 3 SQL injection vulnerabilities"
+        );
 
-        let vulnerable_findings = findings.iter()
+        let vulnerable_findings = findings
+            .iter()
             .filter(|f| f.file.contains("vulnerable.py"))
             .count();
-        assert!(vulnerable_findings >= 3, "Should find vulnerabilities in vulnerable.py");
+        assert!(
+            vulnerable_findings >= 3,
+            "Should find vulnerabilities in vulnerable.py"
+        );
 
         // safe.py contains only literal queries and must not be flagged.
-        let safe_findings = findings.iter()
+        let safe_findings = findings
+            .iter()
             .filter(|f| f.file.contains("safe.py"))
             .count();
-        assert_eq!(safe_findings, 0, "Should find no vulnerabilities in safe.py");
+        assert_eq!(
+            safe_findings, 0,
+            "Should find no vulnerabilities in safe.py"
+        );
     }
 
     #[test]
     #[cfg(feature = "python")]
     fn test_python_command_injection_detection() {
-        let python_files = vec![
-            ("cmd_vulnerable.py", r#"
+        let python_files = vec![(
+            "cmd_vulnerable.py",
+            r#"
 import os
 import subprocess
 
@@ -188,45 +207,53 @@ def run_command_vulnerable3(file):
 def run_safe_command():
     # This should NOT be detected - literal string
     os.system("ls -la")
-"#),
-        ];
+"#,
+        )];
 
         let temp_dir = create_temp_dir_with_files(python_files);
         let rules_file = create_test_rules();
-        
+
         let rules = Rules::load_from_file(rules_file.path().to_str().unwrap())
             .expect("Failed to load rules");
-        let mut scanner = VulnerabilityScanner::new("python", rules)
-            .expect("Failed to create scanner");
+        let scanner = VulnerabilityScanner::new("python", rules).expect("Failed to create scanner");
 
-        let findings = scanner.find_vulnerabilities_single_threaded(
-            temp_dir.path().to_str().unwrap(),
-            "python"
-        ).expect("Failed to scan directory");
+        let findings = scanner
+            .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "python")
+            .expect("Failed to scan directory");
 
         println!("Found {} command injection findings", findings.len());
         for finding in &findings {
-            println!("Finding: {} in {} at line {} - {}", 
-                finding.finding_type, finding.file, finding.line, finding.snippet);
+            println!(
+                "Finding: {} in {} at line {} - {}",
+                finding.finding_type, finding.file, finding.line, finding.snippet
+            );
         }
 
         // Should find command injection vulnerabilities
-        assert!(findings.len() >= 2, "Should find at least 2 command injection vulnerabilities");
-        
-        let cmd_injection_count = findings.iter()
+        assert!(
+            findings.len() >= 2,
+            "Should find at least 2 command injection vulnerabilities"
+        );
+
+        let cmd_injection_count = findings
+            .iter()
             .filter(|f| f.finding_type == "command_injection")
             .count();
-        assert!(cmd_injection_count >= 2, "Should find command injection vulnerabilities");
+        assert!(
+            cmd_injection_count >= 2,
+            "Should find command injection vulnerabilities"
+        );
     }
 
     #[test]
     #[cfg(feature = "java")]
     fn test_java_sql_injection_detection() {
         // For this test, we'll use a direct validation approach rather than using the scanner
-        
+
         // 1. Create our test files
-        let java_files = vec![
-            ("VulnerableService.java", r#"
+        let java_files = vec![(
+            "VulnerableService.java",
+            r#"
 package com.example;
 import java.sql.*;
 import java.io.*;
@@ -253,36 +280,36 @@ public class VulnerableService {
         stmt.execute("SELECT COUNT(*) FROM users");
     }
 }
-"#),
-        ];
+"#,
+        )];
 
         let temp_dir = create_temp_dir_with_files(java_files);
         println!("Java test files created at: {}", temp_dir.path().display());
-        
+
         // 2. Directly validate the injection pattern detection logic
         #[cfg(feature = "java")]
         {
-            use sighthound::parser::LanguageParser;
             use sighthound::language::LanguageSupport;
-            use sighthound::rules::check_for_injection_pattern;
             use sighthound::models::Finding;
-            
+            use sighthound::parser::LanguageParser;
+            use sighthound::rules::check_for_injection_pattern;
+
             // Create findings vector to store our results
             let mut findings = Vec::new();
-            
+
             let java_file_path = temp_dir.path().join("VulnerableService.java");
             let filepath = java_file_path.to_string_lossy().to_string();
-            
+
             // Parse the source code
             let mut parser = LanguageParser::new("java").expect("Failed to create Java parser");
             let source = fs::read(&java_file_path).expect("Failed to read Java file");
             let tree = parser.parse(&source).expect("Failed to parse Java file");
             let root_node = tree.root_node();
             let language_support = parser.language_support();
-            
+
             // Define a function to recursively search for method invocations
             fn find_vulnerabilities(
-                node: &tree_sitter::Node, 
+                node: &tree_sitter::Node,
                 source: &[u8],
                 filepath: &str,
                 language_support: &dyn LanguageSupport,
@@ -290,34 +317,40 @@ public class VulnerableService {
                 depth: usize,
             ) {
                 let indent = "  ".repeat(depth);
-                
+
                 // Check if this node is a method invocation
                 if node.kind() == "method_invocation" {
-                    let node_text = String::from_utf8_lossy(&source[node.start_byte()..node.end_byte()]);
+                    let node_text =
+                        String::from_utf8_lossy(&source[node.start_byte()..node.end_byte()]);
                     let line = node.start_position().row + 1;
-                    
+
                     // If this is an execute() method, check its arguments for injection patterns
                     if let Some(func_name) = language_support.get_function_name(node, source) {
                         println!("{}Processing method: {}", indent, func_name);
-                        
+
                         // Check for SQL injection
                         if func_name == "execute" {
                             if let Some(args_node) = language_support.get_arguments_node(node) {
                                 for i in 0..args_node.named_child_count() {
                                     if let Some(arg) = args_node.named_child(i as u32) {
-                                        let arg_text = String::from_utf8_lossy(&source[arg.start_byte()..arg.end_byte()]);
+                                        let arg_text = String::from_utf8_lossy(
+                                            &source[arg.start_byte()..arg.end_byte()],
+                                        );
                                         let arg_kind = arg.kind();
-                                        
-                                        println!("{}Argument {}: {} (kind: {})", indent, i, arg_text, arg_kind);
-                                        
+
+                                        println!(
+                                            "{}Argument {}: {} (kind: {})",
+                                            indent, i, arg_text, arg_kind
+                                        );
+
                                         // Check for signs of injection vulnerability
                                         let is_vulnerable = arg_kind == "binary_expression" || // String concatenation
                                                            arg_kind == "method_invocation" || // Method calls like String.format
                                                            check_for_injection_pattern(&arg_text, language_support);
-                                        
+
                                         if is_vulnerable {
                                             println!("{}VULNERABLE: SQL injection found", indent);
-                                            
+
                                             findings.push(Finding {
                                                 file: filepath.to_string(),
                                                 line,
@@ -341,26 +374,34 @@ public class VulnerableService {
                                 }
                             }
                         }
-                        
+
                         // Check for command injection
                         if func_name == "exec" {
                             if let Some(args_node) = language_support.get_arguments_node(node) {
                                 for i in 0..args_node.named_child_count() {
                                     if let Some(arg) = args_node.named_child(i as u32) {
-                                        let arg_text = String::from_utf8_lossy(&source[arg.start_byte()..arg.end_byte()]);
+                                        let arg_text = String::from_utf8_lossy(
+                                            &source[arg.start_byte()..arg.end_byte()],
+                                        );
                                         let arg_kind = arg.kind();
-                                        
-                                        println!("{}Argument {}: {} (kind: {})", indent, i, arg_text, arg_kind);
-                                        
+
+                                        println!(
+                                            "{}Argument {}: {} (kind: {})",
+                                            indent, i, arg_text, arg_kind
+                                        );
+
                                         // Check for signs of injection vulnerability
                                         let is_vulnerable = arg_kind == "binary_expression" || // String concatenation
                                                            arg_text.contains("+") ||
                                                            arg_text.contains(";") ||
                                                            check_for_injection_pattern(&arg_text, language_support);
-                                        
+
                                         if is_vulnerable {
-                                            println!("{}VULNERABLE: Command injection found", indent);
-                                            
+                                            println!(
+                                                "{}VULNERABLE: Command injection found",
+                                                indent
+                                            );
+
                                             findings.push(Finding {
                                                 file: filepath.to_string(),
                                                 line,
@@ -386,39 +427,66 @@ public class VulnerableService {
                         }
                     }
                 }
-                
+
                 // Recursively process all children
                 for i in 0..node.child_count() {
                     if let Some(child) = node.child(i as u32) {
-                        find_vulnerabilities(&child, &source, filepath, language_support, findings, depth + 1);
+                        find_vulnerabilities(
+                            &child,
+                            source,
+                            filepath,
+                            language_support,
+                            findings,
+                            depth + 1,
+                        );
                     }
                 }
             }
-            
+
             // Analyze the Java file directly
-            find_vulnerabilities(&root_node, &source, &filepath, language_support, &mut findings, 0);
-            
+            find_vulnerabilities(
+                &root_node,
+                &source,
+                &filepath,
+                language_support,
+                &mut findings,
+                0,
+            );
+
             // Display findings
             println!("\nFound {} Java findings", findings.len());
             for finding in &findings {
-                println!("Finding: {} in {} at line {} - {}", 
-                    finding.finding_type, finding.file, finding.line, finding.snippet);
+                println!(
+                    "Finding: {} in {} at line {} - {}",
+                    finding.finding_type, finding.file, finding.line, finding.snippet
+                );
             }
-            
+
             // Verify results
-            assert!(findings.len() >= 3, "Should find at least 3 vulnerabilities in Java code");
-            
-            let sql_findings = findings.iter()
+            assert!(
+                findings.len() >= 3,
+                "Should find at least 3 vulnerabilities in Java code"
+            );
+
+            let sql_findings = findings
+                .iter()
                 .filter(|f| f.finding_type == "sql_injection")
                 .count();
-            let cmd_findings = findings.iter()
+            let cmd_findings = findings
+                .iter()
                 .filter(|f| f.finding_type == "command_injection")
                 .count();
-                
-            assert!(sql_findings >= 2, "Should find at least 2 SQL injection vulnerabilities");
-            assert!(cmd_findings >= 1, "Should find at least 1 command injection vulnerability");
+
+            assert!(
+                sql_findings >= 2,
+                "Should find at least 2 SQL injection vulnerabilities"
+            );
+            assert!(
+                cmd_findings >= 1,
+                "Should find at least 1 command injection vulnerability"
+            );
         }
-        
+
         #[cfg(not(feature = "java"))]
         {
             println!("Java feature not enabled, skipping test");
@@ -429,8 +497,9 @@ public class VulnerableService {
     #[test]
     #[cfg(feature = "javascript")]
     fn test_javascript_injection_detection() {
-        let js_files = vec![
-            ("vulnerable.js", r#"
+        let js_files = vec![(
+            "vulnerable.js",
+            r#"
 const db = require('db');
 
 function getUserVulnerable1(userId) {
@@ -457,12 +526,12 @@ function safeQuery() {
     // This should NOT be detected - literal string
     db.execute("SELECT COUNT(*) FROM users");
 }
-"#),
-        ];
+"#,
+        )];
 
         let temp_dir = create_temp_dir_with_files(js_files);
         let _rules_file = create_test_rules();
-        
+
         // Add JavaScript-specific rules
         let js_rules_content = r#"(
             rules: [
@@ -489,42 +558,50 @@ function safeQuery() {
                 ),
             ],
         )"#;
-        
-        let mut js_rules_file = NamedTempFile::with_suffix(".ron").expect("Failed to create temp file");
+
+        let mut js_rules_file =
+            NamedTempFile::with_suffix(".ron").expect("Failed to create temp file");
         write!(js_rules_file, "{}", js_rules_content).expect("Failed to write rules");
-        
+
         let rules = Rules::load_from_file(js_rules_file.path().to_str().unwrap())
             .expect("Failed to load rules");
-        let mut scanner = VulnerabilityScanner::new("javascript", rules)
-            .expect("Failed to create scanner");
+        let scanner =
+            VulnerabilityScanner::new("javascript", rules).expect("Failed to create scanner");
 
-        let findings = scanner.find_vulnerabilities_single_threaded(
-            temp_dir.path().to_str().unwrap(),
-            "javascript"
-        ).expect("Failed to scan directory");
+        let findings = scanner
+            .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "javascript")
+            .expect("Failed to scan directory");
 
         println!("Found {} JavaScript findings", findings.len());
         for finding in &findings {
-            println!("Finding: {} in {} at line {} - {}", 
-                finding.finding_type, finding.file, finding.line, finding.snippet);
+            println!(
+                "Finding: {} in {} at line {} - {}",
+                finding.finding_type, finding.file, finding.line, finding.snippet
+            );
         }
 
         // Should find multiple vulnerabilities
-        assert!(findings.len() >= 3, "Should find at least 3 vulnerabilities in JavaScript code");
-        
+        assert!(
+            findings.len() >= 3,
+            "Should find at least 3 vulnerabilities in JavaScript code"
+        );
+
         // Check for different types of vulnerabilities
         let has_sql_injection = findings.iter().any(|f| f.finding_type == "sql_injection");
         let has_code_injection = findings.iter().any(|f| f.finding_type == "code_injection");
         let has_xss = findings.iter().any(|f| f.finding_type == "xss");
-        
-        assert!(has_sql_injection || has_code_injection || has_xss, 
-               "Should find different types of injection vulnerabilities");
+
+        assert!(
+            has_sql_injection || has_code_injection || has_xss,
+            "Should find different types of injection vulnerabilities"
+        );
     }
 
     #[test]
     fn test_no_false_positives_on_safe_code() {
-        let safe_files = vec![
-            ("SafePython.py", r#"
+        let safe_files = vec![(
+            "SafePython.py",
+            r#"
 import sqlite3
 
 def get_all_users():
@@ -543,32 +620,40 @@ def safe_print():
     print("Hello World")
     print(f"Static message")
     print("Value: {}".format(42))
-"#),
-        ];
+"#,
+        )];
 
         let temp_dir = create_temp_dir_with_files(safe_files);
 
-        let rules = Rules::load_from_directory("rules/python/")
-            .expect("Failed to load python rules");
+        let rules =
+            Rules::load_from_directory("rules/python/").expect("Failed to load python rules");
 
         #[cfg(feature = "python")]
         {
-            let scanner = VulnerabilityScanner::new("python", rules)
-                .expect("Failed to create scanner");
+            let scanner =
+                VulnerabilityScanner::new("python", rules).expect("Failed to create scanner");
 
-            let findings = scanner.find_vulnerabilities_single_threaded(
-                temp_dir.path().to_str().unwrap(),
-                "python"
-            ).expect("Failed to scan directory");
+            let findings = scanner
+                .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "python")
+                .expect("Failed to scan directory");
 
-            println!("Found {} findings in safe code (should be 0)", findings.len());
+            println!(
+                "Found {} findings in safe code (should be 0)",
+                findings.len()
+            );
             for finding in &findings {
-                println!("Unexpected finding: {} in {} at line {} - {}", 
-                    finding.finding_type, finding.file, finding.line, finding.snippet);
+                println!(
+                    "Unexpected finding: {} in {} at line {} - {}",
+                    finding.finding_type, finding.file, finding.line, finding.snippet
+                );
             }
 
             // Should find no vulnerabilities in safe code
-            assert_eq!(findings.len(), 0, "Should find no vulnerabilities in safe code");
+            assert_eq!(
+                findings.len(),
+                0,
+                "Should find no vulnerabilities in safe code"
+            );
         }
     }
-} 
+}

--- a/tests/end_to_end/main.rs
+++ b/tests/end_to_end/main.rs
@@ -1,2 +1,3 @@
 // End-to-end tests for the vulnerability scanner
-mod end_to_end_injection_tests; 
+#![allow(clippy::module_inception)]
+mod end_to_end_injection_tests;

--- a/tests/integration/integration_tests.rs
+++ b/tests/integration/integration_tests.rs
@@ -1,6 +1,6 @@
-use sighthound::rules::{Rules, rule_matches_pattern_unified, validate_unified_rule_patterns};
-use tempfile::NamedTempFile;
+use sighthound::rules::{rule_matches_pattern_unified, validate_unified_rule_patterns, Rules};
 use std::io::Write;
+use tempfile::NamedTempFile;
 
 #[cfg(test)]
 mod integration_tests {
@@ -47,10 +47,22 @@ mod integration_tests {
             assert!(validate_unified_rule_patterns(rule).is_ok());
         }
 
-        assert!(rule_matches_pattern_unified(&rules.rules[0], "pyperclip.copy"));
-        assert!(!rule_matches_pattern_unified(&rules.rules[0], "pyperclip.paste"));
-        assert!(rule_matches_pattern_unified(&rules.rules[1], "pyperclip.paste"));
-        assert!(!rule_matches_pattern_unified(&rules.rules[1], "pyperclip.copy"));
+        assert!(rule_matches_pattern_unified(
+            &rules.rules[0],
+            "pyperclip.copy"
+        ));
+        assert!(!rule_matches_pattern_unified(
+            &rules.rules[0],
+            "pyperclip.paste"
+        ));
+        assert!(rule_matches_pattern_unified(
+            &rules.rules[1],
+            "pyperclip.paste"
+        ));
+        assert!(!rule_matches_pattern_unified(
+            &rules.rules[1],
+            "pyperclip.copy"
+        ));
     }
 
     #[test]
@@ -131,10 +143,22 @@ mod integration_tests {
     fn test_rule_validation_integration() {
         // Valid patterns (literal + regex) validate; an invalid regex must fail.
         let test_cases = vec![
-            (r#"(rules: [(mode: "search", pattern: Some("test_function"), finding_type: Some("test"))])"#, true),
-            (r#"(rules: [(mode: "search", patterns: Some(["test1", "test2"]), finding_type: Some("test"))])"#, true),
-            (r#"(rules: [(mode: "search", pattern: Some("regex:^valid[0-9]+$"), finding_type: Some("test"))])"#, true),
-            (r#"(rules: [(mode: "search", pattern: Some("regex:[unterminated"), finding_type: Some("test"))])"#, false),
+            (
+                r#"(rules: [(mode: "search", pattern: Some("test_function"), finding_type: Some("test"))])"#,
+                true,
+            ),
+            (
+                r#"(rules: [(mode: "search", patterns: Some(["test1", "test2"]), finding_type: Some("test"))])"#,
+                true,
+            ),
+            (
+                r#"(rules: [(mode: "search", pattern: Some("regex:^valid[0-9]+$"), finding_type: Some("test"))])"#,
+                true,
+            ),
+            (
+                r#"(rules: [(mode: "search", pattern: Some("regex:[unterminated"), finding_type: Some("test"))])"#,
+                false,
+            ),
         ];
 
         for (rules_content, should_be_valid) in test_cases {
@@ -145,9 +169,17 @@ mod integration_tests {
             for rule in &rules.rules {
                 let validation_result = validate_unified_rule_patterns(rule);
                 if should_be_valid {
-                    assert!(validation_result.is_ok(), "Rule should be valid: {:?}", rule);
+                    assert!(
+                        validation_result.is_ok(),
+                        "Rule should be valid: {:?}",
+                        rule
+                    );
                 } else {
-                    assert!(validation_result.is_err(), "Rule should be invalid: {:?}", rule);
+                    assert!(
+                        validation_result.is_err(),
+                        "Rule should be invalid: {:?}",
+                        rule
+                    );
                 }
             }
         }
@@ -190,9 +222,18 @@ mod integration_tests {
         assert_eq!(file_types1.exclude_patterns, None);
 
         let file_types2 = rules.rules[1].file_types.as_ref().unwrap();
-        assert_eq!(file_types2.extensions, Some(vec![".py".to_string(), ".pyw".to_string()]));
-        assert_eq!(file_types2.include_patterns, Some(vec!["*test*".to_string()]));
-        assert_eq!(file_types2.exclude_patterns, Some(vec!["*safe*".to_string()]));
+        assert_eq!(
+            file_types2.extensions,
+            Some(vec![".py".to_string(), ".pyw".to_string()])
+        );
+        assert_eq!(
+            file_types2.include_patterns,
+            Some(vec!["*test*".to_string()])
+        );
+        assert_eq!(
+            file_types2.exclude_patterns,
+            Some(vec!["*safe*".to_string()])
+        );
     }
 
     #[test]
@@ -239,11 +280,14 @@ mod integration_tests {
         assert_eq!(conditions[0].patterns, None);
 
         assert_eq!(conditions[1].pattern, None);
-        assert_eq!(conditions[1].patterns, Some(vec![
-            "*.exe*".to_string(),
-            "*.bat*".to_string(),
-            "*.cmd*".to_string(),
-        ]));
+        assert_eq!(
+            conditions[1].patterns,
+            Some(vec![
+                "*.exe*".to_string(),
+                "*.bat*".to_string(),
+                "*.cmd*".to_string(),
+            ])
+        );
     }
 
     #[test]

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -1,2 +1,3 @@
 // Integration tests for the vulnerability scanner
-mod integration_tests; 
+#![allow(clippy::module_inception)]
+mod integration_tests;

--- a/tests/test_files/multi_file_taint_tests/README.md
+++ b/tests/test_files/multi_file_taint_tests/README.md
@@ -1,10 +1,10 @@
 # Comprehensive Multi-File Taint Analysis Test Suite
 
-This directory contains a comprehensive test suite designed to validate the multi-file taint analysis fixes implemented in Greppy.
+This directory contains a comprehensive test suite designed to validate the multi-file taint analysis fixes implemented in Sighthound.
 
-## 🎯 **Test Strategy Overview**
+## Test Strategy Overview
 
-The test suite implements the testing strategy defined in `../../TAINT_TESTING_STRATEGY.md` and focuses on 5 critical categories:
+The test suite focuses on 5 critical categories:
 
 ### **Category 1: Valid Cross-File Flows** (Should DETECT ✅)
 - **Test 1.1**: Direct function import flow

--- a/tests/test_files/python/general/test_1.py
+++ b/tests/test_files/python/general/test_1.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/test_files/python/general/test_10.py
+++ b/tests/test_files/python/general/test_10.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/test_files/python/general/test_20.py
+++ b/tests/test_files/python/general/test_20.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/test_files/python/general/vulnerable_test.py
+++ b/tests/test_files/python/general/vulnerable_test.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/test_files/python/sql_injection_test.py
+++ b/tests/test_files/python/sql_injection_test.py
@@ -6,8 +6,8 @@ import requests
 from lxml import etree
 
 # Example hardcoded AWS credentials (sensitive data leakage)
-aws_access_key_id = "AKIA2JAPX77RGLB664VE"
-aws_secret = "v5xpjkWYoy45fGKFSMajSn+sqs22WI2niacX9yO5"
+aws_access_key_id = "AKIAFAKEKEY00000000"
+aws_secret = "fake-secret-not-real-do-not-use-in-production"
 
 app = Flask(__name__)
 

--- a/tests/test_files/python/test_1.py
+++ b/tests/test_files/python/test_1.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/test_files/python/test_10.py
+++ b/tests/test_files/python/test_10.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/test_files/python/test_20.py
+++ b/tests/test_files/python/test_20.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/test_files/python/vulnerable_test.py
+++ b/tests/test_files/python/vulnerable_test.py
@@ -36,7 +36,7 @@ def generate_password():
 
 
 # Hardcoded secret
-API_KEY = "sk-1234567890abcdef"  # Hardcoded secret
+API_KEY = "sk-fake-test-key-not-real"  # Hardcoded secret
 
 
 # Safe patterns (should not trigger)

--- a/tests/unit/directory_loading_tests.rs
+++ b/tests/unit/directory_loading_tests.rs
@@ -1,6 +1,6 @@
 use sighthound::rules::Rules;
-use tempfile::TempDir;
 use std::fs;
+use tempfile::TempDir;
 
 #[cfg(test)]
 mod directory_loading_tests {
@@ -82,13 +82,17 @@ mod directory_loading_tests {
         // All rules from both files are merged into a single flat list.
         assert_eq!(rules.rules.len(), 4);
 
-        let patterns: Vec<&str> = rules.rules.iter()
+        let patterns: Vec<&str> = rules
+            .rules
+            .iter()
             .filter_map(|r| r.pattern.as_deref())
             .collect();
         assert!(patterns.contains(&"sql_inject"));
         assert!(patterns.contains(&"weak_crypto"));
 
-        let finding_types: Vec<&str> = rules.rules.iter()
+        let finding_types: Vec<&str> = rules
+            .rules
+            .iter()
             .filter_map(|r| r.finding_type.as_deref())
             .collect();
         assert!(finding_types.contains(&"sql_injection"));
@@ -101,14 +105,20 @@ mod directory_loading_tests {
 
         let result = Rules::load_from_path(temp_dir.path().to_str().unwrap());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("No valid .ron rules files found"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("No valid .ron rules files found"));
     }
 
     #[test]
     fn test_load_from_nonexistent_path() {
         let result = Rules::load_from_path("/nonexistent/path");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("neither a file nor a directory"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("neither a file nor a directory"));
     }
 
     #[test]
@@ -121,7 +131,10 @@ mod directory_loading_tests {
 
         let result = Rules::load_from_path(file_path.to_str().unwrap());
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Unsupported file format. Only .ron files are supported"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported file format. Only .ron files are supported"));
     }
 
     #[test]
@@ -132,8 +145,7 @@ mod directory_loading_tests {
         let rules1: Rules = ron::from_str(ron1).expect("parse rules1");
         let rules2: Rules = ron::from_str(ron2).expect("parse rules2");
 
-        let merged = Rules::merge_rules(vec![rules1, rules2])
-            .expect("Failed to merge rules");
+        let merged = Rules::merge_rules(vec![rules1, rules2]).expect("Failed to merge rules");
 
         assert_eq!(merged.rules.len(), 3);
     }

--- a/tests/unit/django_xss_prevention_tests.rs
+++ b/tests/unit/django_xss_prevention_tests.rs
@@ -1,7 +1,7 @@
 use sighthound::rules::Rules;
 use sighthound::VulnerabilityScanner;
-use tempfile::TempDir;
 use std::fs;
+use tempfile::TempDir;
 
 /// Load a representative set of Python security rules.
 fn load_general_rules() -> Rules {
@@ -17,53 +17,80 @@ mod django_xss_tests {
     fn test_basic_scanner_functionality() {
         let rules = load_general_rules();
         let scanner_result = VulnerabilityScanner::new("python", rules);
-        assert!(scanner_result.is_ok(), "Should be able to create scanner with general rules");
+        assert!(
+            scanner_result.is_ok(),
+            "Should be able to create scanner with general rules"
+        );
     }
 
     #[test]
     fn test_django_xss_patterns_with_general_rules() {
         let rules = load_general_rules();
         let scanner_result = VulnerabilityScanner::new("python", rules);
-        assert!(scanner_result.is_ok(), "Should be able to create scanner for Django patterns");
+        assert!(
+            scanner_result.is_ok(),
+            "Should be able to create scanner for Django patterns"
+        );
     }
 
     #[test]
     fn test_mark_safe_patterns() {
         let rules = load_general_rules();
         let scanner_result = VulnerabilityScanner::new("python", rules);
-        assert!(scanner_result.is_ok(), "Should be able to create scanner for mark_safe patterns");
+        assert!(
+            scanner_result.is_ok(),
+            "Should be able to create scanner for mark_safe patterns"
+        );
     }
 
     #[test]
     fn test_template_injection_patterns() {
         let rules = load_general_rules();
         let scanner_result = VulnerabilityScanner::new("python", rules);
-        assert!(scanner_result.is_ok(), "Should be able to create scanner for template injection patterns");
+        assert!(
+            scanner_result.is_ok(),
+            "Should be able to create scanner for template injection patterns"
+        );
     }
 
     #[test]
     fn test_safe_django_patterns() {
         let rules = load_general_rules();
         let scanner_result = VulnerabilityScanner::new("python", rules);
-        assert!(scanner_result.is_ok(), "Should be able to create scanner for safe Django patterns");
+        assert!(
+            scanner_result.is_ok(),
+            "Should be able to create scanner for safe Django patterns"
+        );
     }
 
     #[test]
     fn test_xss_prevention_rule_structure() {
         let rules = load_general_rules();
-        assert!(!rules.rules.is_empty(), "Should have loaded general security rules");
+        assert!(
+            !rules.rules.is_empty(),
+            "Should have loaded general security rules"
+        );
 
         // The general security rule set includes an XSS rule.
         let has_xss_rule = rules.rules.iter().any(|r| {
             r.category.as_deref() == Some("xss")
-                || r.finding_type.as_deref().map(|t| t.to_lowercase().contains("scripting")).unwrap_or(false)
+                || r.finding_type
+                    .as_deref()
+                    .map(|t| t.to_lowercase().contains("scripting"))
+                    .unwrap_or(false)
         });
-        assert!(has_xss_rule, "Expected an XSS rule in the general security rule set");
+        assert!(
+            has_xss_rule,
+            "Expected an XSS rule in the general security rule set"
+        );
 
         // Every search rule must carry a matchable pattern or patterns.
         for rule in rules.rules.iter().filter(|r| r.mode == "search") {
-            assert!(rule.pattern.is_some() || rule.patterns.is_some(),
-                "Each search rule should have either pattern or patterns: {:?}", rule.id);
+            assert!(
+                rule.pattern.is_some() || rule.patterns.is_some(),
+                "Each search rule should have either pattern or patterns: {:?}",
+                rule.id
+            );
         }
     }
 
@@ -71,28 +98,36 @@ mod django_xss_tests {
     fn test_python_rules_directory_loading_and_scan() {
         let rules = Rules::load_from_directory("rules/python/")
             .expect("Failed to load Python rules directory");
-        assert!(!rules.rules.is_empty(), "Should have loaded some Python rules");
+        assert!(
+            !rules.rules.is_empty(),
+            "Should have loaded some Python rules"
+        );
 
-        let scanner = VulnerabilityScanner::new("python", rules)
-            .expect("Failed to create scanner");
+        let scanner = VulnerabilityScanner::new("python", rules).expect("Failed to create scanner");
 
         // Scan an inline file with unambiguous command-execution sinks.
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
         let vuln_file = temp_dir.path().join("vuln.py");
-        fs::write(&vuln_file, r#"
+        fs::write(
+            &vuln_file,
+            r#"
 import os
 import subprocess
 
 def run(cmd):
     os.system(cmd)
     subprocess.Popen(cmd, shell=True)
-"#).expect("Failed to write fixture");
+"#,
+        )
+        .expect("Failed to write fixture");
 
-        let results = scanner.find_vulnerabilities_single_threaded(
-            temp_dir.path().to_str().unwrap(),
-            "python"
-        ).expect("Failed to scan directory");
+        let results = scanner
+            .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "python")
+            .expect("Failed to scan directory");
 
-        assert!(results.len() >= 1, "Should detect at least one vulnerability in the fixture");
+        assert!(
+            !results.is_empty(),
+            "Should detect at least one vulnerability in the fixture"
+        );
     }
 }

--- a/tests/unit/file_pattern_tests.rs
+++ b/tests/unit/file_pattern_tests.rs
@@ -1,8 +1,8 @@
 use sighthound::rules::Rules;
 use sighthound::VulnerabilityScanner;
-use tempfile::{NamedTempFile, TempDir};
 use std::fs;
 use std::io::Write;
+use tempfile::{NamedTempFile, TempDir};
 
 #[cfg(test)]
 mod file_pattern_tests {
@@ -66,34 +66,44 @@ mod file_pattern_tests {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
 
         let test_file = temp_dir.path().join("my_test_file.py");
-        fs::write(&test_file, "test_function()\nuniversal_function()").expect("Failed to write test file");
+        fs::write(&test_file, "test_function()\nuniversal_function()")
+            .expect("Failed to write test file");
 
         let normal_file = temp_dir.path().join("normal_file.py");
-        fs::write(&normal_file, "test_function()\nuniversal_function()").expect("Failed to write normal file");
+        fs::write(&normal_file, "test_function()\nuniversal_function()")
+            .expect("Failed to write normal file");
 
         let rules = Rules::load_from_file(rules_file.path().to_str().unwrap())
             .expect("Failed to load rules");
-        let scanner = VulnerabilityScanner::new("python", rules)
-            .expect("Failed to create scanner");
+        let scanner = VulnerabilityScanner::new("python", rules).expect("Failed to create scanner");
 
-        let test_findings = scanner.find_vulnerabilities_single_threaded(
-            temp_dir.path().to_str().unwrap(),
-            "python"
-        ).expect("Failed to scan test file");
+        let test_findings = scanner
+            .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "python")
+            .expect("Failed to scan test file");
 
-        let test_only_findings: Vec<_> = test_findings.iter()
+        let test_only_findings: Vec<_> = test_findings
+            .iter()
             .filter(|f| f.finding_type == "test_only")
             .collect();
-        let universal_findings: Vec<_> = test_findings.iter()
+        let universal_findings: Vec<_> = test_findings
+            .iter()
             .filter(|f| f.finding_type == "universal")
             .collect();
 
         // test_only rule should only fire in files matching include pattern "*test*".
-        assert!(!test_only_findings.is_empty(), "test_function should be found in file matching include pattern");
-        assert!(test_only_findings.iter().all(|f| f.file.contains("test")),
-            "test_only findings should only be in files containing 'test'");
+        assert!(
+            !test_only_findings.is_empty(),
+            "test_function should be found in file matching include pattern"
+        );
+        assert!(
+            test_only_findings.iter().all(|f| f.file.contains("test")),
+            "test_only findings should only be in files containing 'test'"
+        );
         // The universal rule applies to all .py files.
-        assert!(!universal_findings.is_empty(), "universal_function should be found");
+        assert!(
+            !universal_findings.is_empty(),
+            "universal_function should be found"
+        );
     }
 
     #[test]
@@ -102,49 +112,67 @@ mod file_pattern_tests {
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
 
         let safe_file = temp_dir.path().join("safe_file.py");
-        fs::write(&safe_file, "dangerous_function()\nuniversal_function()").expect("Failed to write safe file");
+        fs::write(&safe_file, "dangerous_function()\nuniversal_function()")
+            .expect("Failed to write safe file");
 
         let unsafe_file = temp_dir.path().join("dangerous_file.py");
-        fs::write(&unsafe_file, "dangerous_function()\nuniversal_function()").expect("Failed to write unsafe file");
+        fs::write(&unsafe_file, "dangerous_function()\nuniversal_function()")
+            .expect("Failed to write unsafe file");
 
         let rules = Rules::load_from_file(rules_file.path().to_str().unwrap())
             .expect("Failed to load rules");
-        let scanner = VulnerabilityScanner::new("python", rules)
-            .expect("Failed to create scanner");
+        let scanner = VulnerabilityScanner::new("python", rules).expect("Failed to create scanner");
 
-        let findings = scanner.find_vulnerabilities_single_threaded(
-            temp_dir.path().to_str().unwrap(),
-            "python"
-        ).expect("Failed to scan files");
+        let findings = scanner
+            .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "python")
+            .expect("Failed to scan files");
 
-        let safe_findings: Vec<_> = findings.iter()
+        let safe_findings: Vec<_> = findings
+            .iter()
             .filter(|f| f.file.contains("safe_file"))
             .collect();
-        let dangerous_findings: Vec<_> = findings.iter()
+        let dangerous_findings: Vec<_> = findings
+            .iter()
             .filter(|f| f.file.contains("dangerous_file"))
             .collect();
 
         // Safe file should NOT have danger findings (excluded by "*safe_*").
-        let safe_dangerous: Vec<_> = safe_findings.iter()
+        let safe_dangerous: Vec<_> = safe_findings
+            .iter()
             .filter(|f| f.finding_type == "danger_not_safe")
             .collect();
-        assert!(safe_dangerous.is_empty(), "dangerous_function should be excluded from safe file");
+        assert!(
+            safe_dangerous.is_empty(),
+            "dangerous_function should be excluded from safe file"
+        );
 
         // Dangerous file SHOULD have danger findings.
-        let dangerous_dangerous: Vec<_> = dangerous_findings.iter()
+        let dangerous_dangerous: Vec<_> = dangerous_findings
+            .iter()
             .filter(|f| f.finding_type == "danger_not_safe")
             .collect();
-        assert!(!dangerous_dangerous.is_empty(), "dangerous_function should be found in dangerous file");
+        assert!(
+            !dangerous_dangerous.is_empty(),
+            "dangerous_function should be found in dangerous file"
+        );
 
         // The universal rule applies to both files.
-        let safe_universal: Vec<_> = safe_findings.iter()
+        let safe_universal: Vec<_> = safe_findings
+            .iter()
             .filter(|f| f.finding_type == "universal")
             .collect();
-        let dangerous_universal: Vec<_> = dangerous_findings.iter()
+        let dangerous_universal: Vec<_> = dangerous_findings
+            .iter()
             .filter(|f| f.finding_type == "universal")
             .collect();
-        assert!(!safe_universal.is_empty(), "universal rule should apply to safe file");
-        assert!(!dangerous_universal.is_empty(), "universal rule should apply to dangerous file");
+        assert!(
+            !safe_universal.is_empty(),
+            "universal rule should apply to safe file"
+        );
+        assert!(
+            !dangerous_universal.is_empty(),
+            "universal rule should apply to dangerous file"
+        );
     }
 
     #[test]
@@ -156,38 +184,51 @@ mod file_pattern_tests {
         fs::write(&config_file, "config_function()").expect("Failed to write config file");
 
         let test_config_file = temp_dir.path().join("test_config.py");
-        fs::write(&test_config_file, "config_function()").expect("Failed to write test config file");
+        fs::write(&test_config_file, "config_function()")
+            .expect("Failed to write test config file");
 
         let settings_file = temp_dir.path().join("settings.py");
         fs::write(&settings_file, "config_function()").expect("Failed to write settings file");
 
         let backup_settings_file = temp_dir.path().join("backup_settings.py");
-        fs::write(&backup_settings_file, "config_function()").expect("Failed to write backup settings file");
+        fs::write(&backup_settings_file, "config_function()")
+            .expect("Failed to write backup settings file");
 
         let rules = Rules::load_from_file(rules_file.path().to_str().unwrap())
             .expect("Failed to load rules");
-        let scanner = VulnerabilityScanner::new("python", rules)
-            .expect("Failed to create scanner");
+        let scanner = VulnerabilityScanner::new("python", rules).expect("Failed to create scanner");
 
-        let findings = scanner.find_vulnerabilities_single_threaded(
-            temp_dir.path().to_str().unwrap(),
-            "python"
-        ).expect("Failed to scan files");
+        let findings = scanner
+            .find_vulnerabilities_single_threaded(temp_dir.path().to_str().unwrap(), "python")
+            .expect("Failed to scan files");
 
-        let config_findings: Vec<_> = findings.iter()
+        let config_findings: Vec<_> = findings
+            .iter()
             .filter(|f| f.finding_type == "config_issue")
             .collect();
 
         // Should match: app_config (includes "*config*"), settings (includes "*settings*").
         // Should NOT match: test_config (excluded by "*test*"), backup_settings (excluded by "*backup*").
-        let config_files: Vec<&str> = config_findings.iter()
-            .map(|f| f.file.as_str())
-            .collect();
+        let config_files: Vec<&str> = config_findings.iter().map(|f| f.file.as_str()).collect();
 
-        assert!(config_files.iter().any(|f| f.contains("app_config.py")), "Should include app_config.py");
-        assert!(config_files.iter().any(|f| f.contains("settings.py")), "Should include settings.py");
-        assert!(!config_files.iter().any(|f| f.contains("test_config.py")), "Should exclude test_config.py");
-        assert!(!config_files.iter().any(|f| f.contains("backup_settings.py")), "Should exclude backup_settings.py");
+        assert!(
+            config_files.iter().any(|f| f.contains("app_config.py")),
+            "Should include app_config.py"
+        );
+        assert!(
+            config_files.iter().any(|f| f.contains("settings.py")),
+            "Should include settings.py"
+        );
+        assert!(
+            !config_files.iter().any(|f| f.contains("test_config.py")),
+            "Should exclude test_config.py"
+        );
+        assert!(
+            !config_files
+                .iter()
+                .any(|f| f.contains("backup_settings.py")),
+            "Should exclude backup_settings.py"
+        );
     }
 
     #[test]
@@ -201,17 +242,29 @@ mod file_pattern_tests {
 
         let test_rule = &rules.rules[0];
         let file_types = test_rule.file_types.as_ref().unwrap();
-        assert_eq!(file_types.include_patterns, Some(vec!["*test*".to_string()]));
+        assert_eq!(
+            file_types.include_patterns,
+            Some(vec!["*test*".to_string()])
+        );
         assert_eq!(file_types.exclude_patterns, None);
 
         let danger_rule = &rules.rules[1];
         let file_types = danger_rule.file_types.as_ref().unwrap();
         assert_eq!(file_types.include_patterns, None);
-        assert_eq!(file_types.exclude_patterns, Some(vec!["*safe_*".to_string()]));
+        assert_eq!(
+            file_types.exclude_patterns,
+            Some(vec!["*safe_*".to_string()])
+        );
 
         let config_rule = &rules.rules[2];
         let file_types = config_rule.file_types.as_ref().unwrap();
-        assert_eq!(file_types.include_patterns, Some(vec!["*config*".to_string(), "*settings*".to_string()]));
-        assert_eq!(file_types.exclude_patterns, Some(vec!["*test*".to_string(), "*backup*".to_string()]));
+        assert_eq!(
+            file_types.include_patterns,
+            Some(vec!["*config*".to_string(), "*settings*".to_string()])
+        );
+        assert_eq!(
+            file_types.exclude_patterns,
+            Some(vec!["*test*".to_string(), "*backup*".to_string()])
+        );
     }
 }

--- a/tests/unit/injection_pattern_tests.rs
+++ b/tests/unit/injection_pattern_tests.rs
@@ -1,7 +1,7 @@
 use sighthound::language::{get_language_support, LanguageSupport};
+use sighthound::parser::{get_node_text, LanguageParser};
 use sighthound::rules::{check_for_injection_pattern, is_literal_node};
 use sighthound::scanner::core::ScanningLogic;
-use sighthound::parser::{LanguageParser, get_node_text};
 
 /// Return true if any call node in the tree has an injectable (non-literal,
 /// separator-bearing) argument according to the scanner heuristic.
@@ -12,16 +12,9 @@ fn any_call_has_injection(language: &str, code: &str) -> bool {
     let source = code.as_bytes();
     let tree = parser.parse(source).expect("parse");
 
-    fn visit(
-        node: &tree_sitter::Node,
-        source: &[u8],
-        ls: &dyn LanguageSupport,
-        found: &mut bool,
-    ) {
+    fn visit(node: &tree_sitter::Node, source: &[u8], ls: &dyn LanguageSupport, found: &mut bool) {
         for call_type in ls.call_node_types() {
-            if node.kind() == *call_type
-                && ScanningLogic::has_injection_pattern(node, source, ls)
-            {
+            if node.kind() == *call_type && ScanningLogic::has_injection_pattern(node, source, ls) {
                 *found = true;
                 return;
             }
@@ -34,8 +27,23 @@ fn any_call_has_injection(language: &str, code: &str) -> bool {
     }
 
     let mut found = false;
-    visit(&tree.root_node(), source, language_support.as_ref(), &mut found);
+    visit(
+        &tree.root_node(),
+        source,
+        language_support.as_ref(),
+        &mut found,
+    );
     found
+}
+
+#[cfg(any(feature = "python", feature = "javascript"))]
+fn visit_all<F: FnMut(&tree_sitter::Node)>(node: &tree_sitter::Node, f: &mut F) {
+    f(node);
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i as u32) {
+            visit_all(&child, f);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -49,10 +57,22 @@ mod injection_pattern_tests {
 
         // Command separators / chaining.
         assert!(check_for_injection_pattern("cmd; rm -rf /", ls.as_ref()));
-        assert!(check_for_injection_pattern("ls -la && malware", ls.as_ref()));
-        assert!(check_for_injection_pattern("echo 'safe' || dangerous_cmd", ls.as_ref()));
-        assert!(check_for_injection_pattern("result = $(whoami)", ls.as_ref()));
-        assert!(check_for_injection_pattern("`cat /etc/passwd`", ls.as_ref()));
+        assert!(check_for_injection_pattern(
+            "ls -la && malware",
+            ls.as_ref()
+        ));
+        assert!(check_for_injection_pattern(
+            "echo 'safe' || dangerous_cmd",
+            ls.as_ref()
+        ));
+        assert!(check_for_injection_pattern(
+            "result = $(whoami)",
+            ls.as_ref()
+        ));
+        assert!(check_for_injection_pattern(
+            "`cat /etc/passwd`",
+            ls.as_ref()
+        ));
 
         // Dangerous function calls.
         assert!(check_for_injection_pattern("eval(userCode)", ls.as_ref()));
@@ -62,8 +82,14 @@ mod injection_pattern_tests {
         // Template / URL-scheme indicators.
         assert!(check_for_injection_pattern("Hello {{ user }}", ls.as_ref()));
         assert!(check_for_injection_pattern("{% if admin %}", ls.as_ref()));
-        assert!(check_for_injection_pattern("javascript:alert(1)", ls.as_ref()));
-        assert!(check_for_injection_pattern("data:text/html,<script>", ls.as_ref()));
+        assert!(check_for_injection_pattern(
+            "javascript:alert(1)",
+            ls.as_ref()
+        ));
+        assert!(check_for_injection_pattern(
+            "data:text/html,<script>",
+            ls.as_ref()
+        ));
     }
 
     #[test]
@@ -73,10 +99,19 @@ mod injection_pattern_tests {
 
         // Plain queries / format strings without separators are not flagged by
         // this language-agnostic indicator check.
-        assert!(!check_for_injection_pattern("SELECT * FROM users", ls.as_ref()));
-        assert!(!check_for_injection_pattern("'SELECT * FROM users WHERE id = %s'", ls.as_ref()));
+        assert!(!check_for_injection_pattern(
+            "SELECT * FROM users",
+            ls.as_ref()
+        ));
+        assert!(!check_for_injection_pattern(
+            "'SELECT * FROM users WHERE id = %s'",
+            ls.as_ref()
+        ));
         assert!(!check_for_injection_pattern("${userInput}", ls.as_ref()));
-        assert!(!check_for_injection_pattern("query.format(user_id)", ls.as_ref()));
+        assert!(!check_for_injection_pattern(
+            "query.format(user_id)",
+            ls.as_ref()
+        ));
         assert!(!check_for_injection_pattern("variable_name", ls.as_ref()));
         assert!(!check_for_injection_pattern("123456", ls.as_ref()));
         assert!(!check_for_injection_pattern("", ls.as_ref()));
@@ -86,7 +121,10 @@ mod injection_pattern_tests {
     #[test]
     fn test_edge_cases_unsupported_language() {
         let unsupported_result = get_language_support("unsupported");
-        assert!(unsupported_result.is_err(), "Should fail for unsupported language");
+        assert!(
+            unsupported_result.is_err(),
+            "Should fail for unsupported language"
+        );
     }
 
     #[test]
@@ -97,16 +135,20 @@ mod injection_pattern_tests {
 def run(cmd):
     subprocess.call("ping " + cmd + "; rm -rf /")
 "#;
-        assert!(any_call_has_injection("python", vulnerable),
-            "Should detect injectable argument in command-building concatenation");
+        assert!(
+            any_call_has_injection("python", vulnerable),
+            "Should detect injectable argument in command-building concatenation"
+        );
 
         // A literal argument is not injectable.
         let safe = r#"
 def get_all_users():
     cursor.execute("SELECT * FROM users")
 "#;
-        assert!(!any_call_has_injection("python", safe),
-            "Literal query argument should not be flagged");
+        assert!(
+            !any_call_has_injection("python", safe),
+            "Literal query argument should not be flagged"
+        );
     }
 
     #[test]
@@ -119,8 +161,10 @@ public class T {
     }
 }
 "#;
-        assert!(any_call_has_injection("java", vulnerable),
-            "Should detect injectable argument in Java command concatenation");
+        assert!(
+            any_call_has_injection("java", vulnerable),
+            "Should detect injectable argument in Java command concatenation"
+        );
 
         let safe = r#"
 public class T {
@@ -129,8 +173,10 @@ public class T {
     }
 }
 "#;
-        assert!(!any_call_has_injection("java", safe),
-            "Literal Java query argument should not be flagged");
+        assert!(
+            !any_call_has_injection("java", safe),
+            "Literal Java query argument should not be flagged"
+        );
     }
 
     #[test]
@@ -141,16 +187,20 @@ function getUser(userId) {
     db.execute("SELECT * FROM users WHERE id = " + userId + "; DROP TABLE users");
 }
 "#;
-        assert!(any_call_has_injection("javascript", vulnerable),
-            "Should detect injectable argument in JS query concatenation");
+        assert!(
+            any_call_has_injection("javascript", vulnerable),
+            "Should detect injectable argument in JS query concatenation"
+        );
 
         let safe = r#"
 function safe() {
     db.execute("SELECT COUNT(*) FROM users");
 }
 "#;
-        assert!(!any_call_has_injection("javascript", safe),
-            "Literal JS query argument should not be flagged");
+        assert!(
+            !any_call_has_injection("javascript", safe),
+            "Literal JS query argument should not be flagged"
+        );
     }
 
     #[test]
@@ -198,20 +248,13 @@ function safe() {
             if node.kind() == "template_string" {
                 saw_template = true;
                 // Template strings interpolate values, so they are NOT literals.
-                assert!(!is_literal_node(node), "template string should not be a literal");
+                assert!(
+                    !is_literal_node(node),
+                    "template string should not be a literal"
+                );
             }
             let _ = get_node_text(node, source);
         });
         assert!(saw_template, "expected a template_string node");
-    }
-}
-
-#[cfg(any(feature = "python", feature = "javascript"))]
-fn visit_all<F: FnMut(&tree_sitter::Node)>(node: &tree_sitter::Node, f: &mut F) {
-    f(node);
-    for i in 0..node.child_count() {
-        if let Some(child) = node.child(i as u32) {
-            visit_all(&child, f);
-        }
     }
 }

--- a/tests/unit/javascript_rules_tests.rs
+++ b/tests/unit/javascript_rules_tests.rs
@@ -1,5 +1,5 @@
-use sighthound::rules::Rules;
 use sighthound::models::UnifiedRule;
+use sighthound::rules::Rules;
 
 /// Collect every literal pattern string referenced by a rule set
 /// (`pattern`, `patterns`, `sinks`).
@@ -27,12 +27,18 @@ fn load_js_rules() -> Rules {
 #[test]
 fn test_javascript_rules_load() {
     let rules = load_js_rules();
-    assert!(!rules.rules.is_empty(), "JavaScript rules should not be empty");
+    assert!(
+        !rules.rules.is_empty(),
+        "JavaScript rules should not be empty"
+    );
 
     // Every search rule must carry a matchable pattern or patterns.
     for rule in rules.rules.iter().filter(|r| r.mode == "search") {
-        assert!(rule.pattern.is_some() || rule.patterns.is_some(),
-            "Each search rule should have a pattern or patterns: {:?}", rule.id);
+        assert!(
+            rule.pattern.is_some() || rule.patterns.is_some(),
+            "Each search rule should have a pattern or patterns: {:?}",
+            rule.id
+        );
     }
 }
 
@@ -42,9 +48,14 @@ fn test_dom_xss_sinks_present() {
     let patterns = collect_patterns(&rules.rules);
     let joined = patterns.join("\n");
 
-    assert!(joined.contains("innerHTML"), "JS rules should cover innerHTML");
-    assert!(joined.contains("document.write") || joined.contains("write"),
-        "JS rules should cover document.write");
+    assert!(
+        joined.contains("innerHTML"),
+        "JS rules should cover innerHTML"
+    );
+    assert!(
+        joined.contains("document.write") || joined.contains("write"),
+        "JS rules should cover document.write"
+    );
 }
 
 #[test]
@@ -63,7 +74,13 @@ fn test_rules_carry_cwe_metadata() {
     // findings can be matched to ground-truth labels.
     let with_cwe = rules.rules.iter().any(|r| {
         r.cwe_id.is_some()
-            || r.tags.as_ref().map(|t| t.iter().any(|tag| tag.to_lowercase().starts_with("cwe"))).unwrap_or(false)
+            || r.tags
+                .as_ref()
+                .map(|t| t.iter().any(|tag| tag.to_lowercase().starts_with("cwe")))
+                .unwrap_or(false)
     });
-    assert!(with_cwe, "Expected at least one JavaScript rule to carry CWE metadata");
+    assert!(
+        with_cwe,
+        "Expected at least one JavaScript rule to carry CWE metadata"
+    );
 }

--- a/tests/unit/main.rs
+++ b/tests/unit/main.rs
@@ -1,8 +1,9 @@
 // Unit tests for the vulnerability scanner
-mod injection_pattern_tests;
+#![allow(clippy::module_inception)]
+mod directory_loading_tests;
 mod django_xss_prevention_tests;
 mod file_pattern_tests;
-mod directory_loading_tests;
-mod rule_deserialization_tests;
-mod pattern_matching_tests;
+mod injection_pattern_tests;
 mod javascript_rules_tests;
+mod pattern_matching_tests;
+mod rule_deserialization_tests;

--- a/tests/unit/pattern_matching_tests.rs
+++ b/tests/unit/pattern_matching_tests.rs
@@ -1,5 +1,7 @@
-use sighthound::rules::{match_pattern, match_any_pattern, rule_matches_pattern_unified, validate_unified_rule_patterns};
 use sighthound::models::UnifiedRule;
+use sighthound::rules::{
+    match_any_pattern, match_pattern, rule_matches_pattern_unified, validate_unified_rule_patterns,
+};
 
 /// Build a minimal search-mode rule for pattern-matching tests.
 fn search_rule(pattern: Option<&str>, patterns: Option<Vec<&str>>) -> UnifiedRule {
@@ -35,8 +37,8 @@ mod pattern_matching_tests {
         // A non-wildcard, non-regex pattern matches as a substring of the text.
         assert!(match_pattern("print", "print"));
         assert!(match_pattern("os.system", "os.system"));
-        assert!(match_pattern("print", "printf"));      // "printf" contains "print"
-        assert!(match_pattern("system", "os.system"));  // "os.system" contains "system"
+        assert!(match_pattern("print", "printf")); // "printf" contains "print"
+        assert!(match_pattern("system", "os.system")); // "os.system" contains "system"
         assert!(!match_pattern("os.system", "os.path"));
         assert!(!match_pattern("xyz", "os.system"));
     }
@@ -135,10 +137,7 @@ mod pattern_matching_tests {
 
     #[test]
     fn test_wildcard_patterns_in_multiple_patterns() {
-        let rule = search_rule(
-            None,
-            Some(vec!["*.tk*", "*.exe*", "keyboard.*"]),
-        );
+        let rule = search_rule(None, Some(vec!["*.tk*", "*.exe*", "keyboard.*"]));
 
         assert!(rule_matches_pattern_unified(&rule, "malicious.tk"));
         assert!(rule_matches_pattern_unified(&rule, "bad.tk.com"));
@@ -186,7 +185,10 @@ mod pattern_matching_tests {
         assert!(match_any_pattern(&sql_injection_patterns, "execute"));
         assert!(match_any_pattern(&sql_injection_patterns, "cursor.execute"));
         assert!(match_any_pattern(&sql_injection_patterns, "db.execute"));
-        assert!(match_any_pattern(&sql_injection_patterns, "conn.execute_query"));
+        assert!(match_any_pattern(
+            &sql_injection_patterns,
+            "conn.execute_query"
+        ));
 
         // Strings that contain none of the patterns as a substring don't match.
         assert!(!match_any_pattern(&sql_injection_patterns, "fetchone"));
@@ -200,8 +202,14 @@ mod pattern_matching_tests {
         ];
 
         assert!(match_any_pattern(&command_injection_patterns, "os.system"));
-        assert!(match_any_pattern(&command_injection_patterns, "subprocess.call"));
-        assert!(match_any_pattern(&command_injection_patterns, "subprocess.Popen"));
+        assert!(match_any_pattern(
+            &command_injection_patterns,
+            "subprocess.call"
+        ));
+        assert!(match_any_pattern(
+            &command_injection_patterns,
+            "subprocess.Popen"
+        ));
         assert!(match_any_pattern(&command_injection_patterns, "shell=True"));
 
         let crypto_patterns = vec![
@@ -234,8 +242,16 @@ mod performance_tests {
         ];
 
         let test_strings = vec![
-            "print", "malware.exe", "hello", "os.system", "subprocess.call",
-            "safe_function", "file.txt", "HELLO", "os.path", "process.run",
+            "print",
+            "malware.exe",
+            "hello",
+            "os.system",
+            "subprocess.call",
+            "safe_function",
+            "file.txt",
+            "HELLO",
+            "os.path",
+            "process.run",
         ];
 
         let start = Instant::now();
@@ -248,7 +264,11 @@ mod performance_tests {
         }
         let duration = start.elapsed();
         println!("Pattern matching 50,000 times took: {:?}", duration);
-        assert!(duration.as_secs() < 30, "Pattern matching too slow: {:?}", duration);
+        assert!(
+            duration.as_secs() < 30,
+            "Pattern matching too slow: {:?}",
+            duration
+        );
     }
 
     #[test]
@@ -256,14 +276,30 @@ mod performance_tests {
         let rule = search_rule(
             None,
             Some(vec![
-                "print", "*.exe", "os.system", "subprocess.*", "*password*",
-                "regex:^[a-z]+$", "eval", "exec", "*.dll", "malloc",
+                "print",
+                "*.exe",
+                "os.system",
+                "subprocess.*",
+                "*password*",
+                "regex:^[a-z]+$",
+                "eval",
+                "exec",
+                "*.dll",
+                "malloc",
             ]),
         );
 
         let test_strings = vec![
-            "print", "malware.exe", "os.system", "subprocess.call", "get_password",
-            "hello", "eval", "exec", "library.dll", "malloc",
+            "print",
+            "malware.exe",
+            "os.system",
+            "subprocess.call",
+            "get_password",
+            "hello",
+            "eval",
+            "exec",
+            "library.dll",
+            "malloc",
         ];
 
         let start = Instant::now();
@@ -273,7 +309,14 @@ mod performance_tests {
             }
         }
         let duration = start.elapsed();
-        println!("Multiple pattern rule matching 10,000 times took: {:?}", duration);
-        assert!(duration.as_secs() < 30, "Multiple pattern matching too slow: {:?}", duration);
+        println!(
+            "Multiple pattern rule matching 10,000 times took: {:?}",
+            duration
+        );
+        assert!(
+            duration.as_secs() < 30,
+            "Multiple pattern matching too slow: {:?}",
+            duration
+        );
     }
 }

--- a/tests/unit/rule_deserialization_tests.rs
+++ b/tests/unit/rule_deserialization_tests.rs
@@ -1,6 +1,6 @@
 use sighthound::rules::Rules;
-use tempfile::NamedTempFile;
 use std::io::Write;
+use tempfile::NamedTempFile;
 
 #[cfg(test)]
 mod deserialization_tests {
@@ -53,17 +53,21 @@ mod deserialization_tests {
             ],
         )"#;
 
-        let rules: Rules = ron::from_str(ron_content).expect("Failed to parse multiple-patterns RON");
+        let rules: Rules =
+            ron::from_str(ron_content).expect("Failed to parse multiple-patterns RON");
 
         assert_eq!(rules.rules.len(), 1);
 
         let rule = &rules.rules[0];
         assert_eq!(rule.pattern, None);
-        assert_eq!(rule.patterns, Some(vec![
-            "pyperclip.paste".to_string(),
-            "pyperclip.copy".to_string(),
-            "*.to_clipboard".to_string(),
-        ]));
+        assert_eq!(
+            rule.patterns,
+            Some(vec![
+                "pyperclip.paste".to_string(),
+                "pyperclip.copy".to_string(),
+                "*.to_clipboard".to_string(),
+            ])
+        );
         assert_eq!(rule.finding_type, Some("clipboard_access".to_string()));
     }
 
@@ -79,7 +83,8 @@ mod deserialization_tests {
             ],
         )"#;
 
-        let rules: Rules = ron::from_str(ron_content).expect("Failed to parse RON without explicit mode");
+        let rules: Rules =
+            ron::from_str(ron_content).expect("Failed to parse RON without explicit mode");
         assert_eq!(rules.rules.len(), 1);
         assert_eq!(rules.rules[0].mode, "search");
         assert_eq!(rules.rules[0].pattern, Some("os.system".to_string()));
@@ -113,10 +118,13 @@ mod deserialization_tests {
         assert_eq!(rules.rules[0].patterns, None);
 
         assert_eq!(rules.rules[1].pattern, None);
-        assert_eq!(rules.rules[1].patterns, Some(vec![
-            "multi_pattern_1".to_string(),
-            "multi_pattern_2".to_string(),
-        ]));
+        assert_eq!(
+            rules.rules[1].patterns,
+            Some(vec![
+                "multi_pattern_1".to_string(),
+                "multi_pattern_2".to_string(),
+            ])
+        );
     }
 
     #[test]
@@ -164,18 +172,27 @@ mod deserialization_tests {
 
         assert_eq!(conditions[0].pattern, Some("shell=True".to_string()));
         assert_eq!(conditions[0].patterns, None);
-        assert_eq!(conditions[0].condition_type, Some("has_argument".to_string()));
+        assert_eq!(
+            conditions[0].condition_type,
+            Some("has_argument".to_string())
+        );
 
         assert_eq!(conditions[1].pattern, None);
-        assert_eq!(conditions[1].patterns, Some(vec![
-            "*.exe*".to_string(),
-            "*.bat*".to_string(),
-        ]));
+        assert_eq!(
+            conditions[1].patterns,
+            Some(vec!["*.exe*".to_string(), "*.bat*".to_string(),])
+        );
 
         let file_types = rule.file_types.as_ref().unwrap();
         assert_eq!(file_types.extensions, Some(vec![".py".to_string()]));
-        assert_eq!(file_types.include_patterns, Some(vec!["*test*".to_string()]));
-        assert_eq!(file_types.exclude_patterns, Some(vec!["*safe*".to_string()]));
+        assert_eq!(
+            file_types.include_patterns,
+            Some(vec!["*test*".to_string()])
+        );
+        assert_eq!(
+            file_types.exclude_patterns,
+            Some(vec!["*safe*".to_string()])
+        );
     }
 
     #[test]
@@ -217,11 +234,14 @@ mod deserialization_tests {
         assert_eq!(rules.rules.len(), 2);
 
         let keylogger_rule = &rules.rules[0];
-        assert_eq!(keylogger_rule.patterns, Some(vec![
-            "keyboard.hook".to_string(),
-            "keyboard.on_press".to_string(),
-            "pynput.*".to_string(),
-        ]));
+        assert_eq!(
+            keylogger_rule.patterns,
+            Some(vec![
+                "keyboard.hook".to_string(),
+                "keyboard.on_press".to_string(),
+                "pynput.*".to_string(),
+            ])
+        );
         assert_eq!(keylogger_rule.severity, Some("high".to_string()));
         assert_eq!(keylogger_rule.confidence, Some("medium".to_string()));
 
@@ -251,7 +271,8 @@ mod deserialization_tests {
             ],
         )"#;
 
-        let rules: Rules = ron::from_str(ron_content).expect("Failed to parse RON with omitted optionals");
+        let rules: Rules =
+            ron::from_str(ron_content).expect("Failed to parse RON with omitted optionals");
 
         assert_eq!(rules.rules.len(), 1);
 


### PR DESCRIPTION
## Summary

Major scanner engine refactor. **~4k lines changed, but a large share is `rustfmt`/import reordering in tests** — the functional changes are concentrated in `src/scanner/` and the new library/CLI surface.

**Merge order:** PR 1 of 2 — merge first. Rebased directly onto `feature/more_language_support`. PRs #20 (benchmark harness) and #21 (OSS release prep) were closed.

---

## Main engine changes

### Taint analysis (`src/scanner/core.rs` — bulk of the diff)
- **Assignment-based taint tracking** — records sources from assignment RHS values, not just direct source-pattern matches on call nodes (`scan_assignments`, `scan_node_for_assignments`)
- **Propagation through dependencies** — tracks variable-to-variable flow within a function (`record_tainted_variable`, dependency extraction)
- **Sanitizer-aware sink checks** — skips findings when sanitizers appear in the sink expression
- **Flow deduplication** — `is_flow_processed` / `mark_flow_processed` to avoid duplicate source→sink reports
- **DOM assignment detection** — flags JS patterns like `.innerHTML =` as taint-relevant assignments
- **Cross-file taint** — improved import resolution and multi-file chain analysis; **skips cross-file for frontend scans** (performance)
- Richer `TaintTrace` metadata (`operation`, `function`, `rule_name`)

### Scan orchestration (`src/scanner/modes.rs`, `src/scanner/utils.rs`)
- Refactored scan entry points and parallel file discovery
- Unified/simple/taint mode wiring cleanup

### Prefilter (`src/scanner/prefilter.rs`)
- Improved rule prefiltering before full AST walks

### Pattern matching (`src/common.rs`)
- `regex:` prefix support, `*.property` wildcard matching
- Better assignment variable extraction (`extract_variable_from_assignment`)
- Literal detection improvements (quoted strings, `__all__`, etc.)

### Code-type detection (`src/code_type_detector.rs`)
- New `FrameworkRegistry` with frontend/backend framework signatures (React, Next.js, Django, etc.)
- `detect_code_type()` for frontend vs backend classification

### Rules loading (`src/rules.rs`)
- Embedded JavaScript **backend** rules (`EMBEDDED_JAVASCRIPT_BACKEND`)
- Clearer embedded-vs-file rule loading and error messages

### CLI & library surface (`src/main.rs`, `src/lib.rs`, `src/models.rs`, `src/ui.rs`)
- **New public library API** — exports `VulnerabilityScanner`, `run_auto_detection_scan`, `run_taint_analysis`, etc.
- New CLI flags: `--format` (text/json/csv), `--summary-only`, `--taint-analysis`, `--code-type`, `--language`, `--rules-dir`, `--use-embedded-rules`, `--no-parallel`, `--threads`
- New `src/ui.rs` — TTY-aware ANSI styling and spinner helpers (no emojis)
- Better invalid-argument error messages and `--version` build metadata

### Language support (`src/language.rs`)
- Mostly formatting; minor `get_function_name` cleanup for Java/JS/TS call nodes

---

## Test changes (mostly formatting)

- **~1.1k test diff lines**, but most are `rustfmt` (import order, line wrapping, signature formatting) — not new assertions
- Fixture path tweaks in `tests/test_files/python/` (comment/header lines)
- E2E injection tests updated for new scan APIs
- No new test crate — existing unit/integration/e2e suites adjusted to compile against refactored APIs

---

## Files to focus review on

| Priority | Files |
|----------|-------|
| High | `src/scanner/core.rs`, `src/scanner/modes.rs`, `src/common.rs` |
| Medium | `src/scanner/prefilter.rs`, `src/scanner/utils.rs`, `src/rules.rs`, `src/code_type_detector.rs` |
| Low (formatting) | `src/language.rs`, `tests/unit/*.rs`, `tests/integration/*.rs` |

## Test plan

- [x] `cargo test` (82 tests)

---
**Integration branch:** Merges into [`feature/more_language_support`](https://github.com/Corgea/Sighthound/tree/feature/more_language_support) — **not** `main`.

**Merge order:** #16–#19 (merged) → **#22** → #23