### PR TITLE
Harden taint strictness and add boundary test suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,7 @@ path = "tests/integration/main.rs"
 [[test]]
 name = "end_to_end_tests"
 path = "tests/end_to_end/main.rs"
+
+[[test]]
+name = "strictness_tests"
+path = "tests/strictness/main.rs"

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -61,9 +61,8 @@
                 "e.data",
                 "message.data",
                 
-                // Network responses (external data)
+                // Network response text that may be rendered as HTML.
                 "*.responseText",
-                "*.response",
                 "fetch(*).then",
                 "XMLHttpRequest.responseText",
                 "axios.get",
@@ -92,10 +91,8 @@
                 "iframe.src",
                 "*.srcdoc",  // iframe srcdoc
                 
-                // Attribute manipulation
+                // Attribute manipulation that can inject executable markup.
                 "*.onclick",
-                "*.onload",
-                "*.onerror",
                 "*.setAttribute",
                 // Code execution
                 "eval(",
@@ -276,9 +273,8 @@
                 // PostMessage (external data)
                 "event.data",
                 
-                // Network responses (external data)
+                // Network response text that may be rendered as HTML.
                 "*.responseText",
-                "*.response",
                 "fetch(*).then",
                 "XMLHttpRequest.responseText",
                 "axios.*.then",
@@ -308,11 +304,8 @@
                 "*.formAction",
                 "*.setAttribute",
                 
-                // Event handlers
+                // Event handlers that execute attacker-controlled code.
                 "*.onclick",
-                "*.onload",
-                "*.onerror",
-                "addEventListener",
                 
                 // Template/rendering (dangerous)
                 "template.innerHTML",
@@ -1777,12 +1770,10 @@
                 "prompt(",
                 "confirm(",
                 
-                // Network responses
+                // Network response values that can carry executable code.
                 "*.responseText",
-                "*.response",
-                "fetch(",
-                "XMLHttpRequest",
-                "axios.*",
+                "*.response.data",
+                "*.responseJSON",
                 
                 // Storage (could contain user data)
                 "localStorage.getItem",
@@ -1797,7 +1788,6 @@
             sinks: Some([
                 // Direct code execution
                 "eval(",
-                "Function(",
                 "new Function(",
                 
                 // Timed execution with string

--- a/rules/javascript/frontend_taint_security.ron
+++ b/rules/javascript/frontend_taint_security.ron
@@ -93,6 +93,8 @@
                 
                 // Attribute manipulation that can inject executable markup.
                 "*.onclick",
+                "*.onload",
+                "*.onerror",
                 "*.setAttribute",
                 // Code execution
                 "eval(",
@@ -148,7 +150,7 @@
                 // Exclude safe operations that commonly cause false positives
                 (
                     field: "pattern",
-                    operator: "not_contains", 
+                    operator: "not_contains",
                     value: "addEventListener",
                     condition_type: Some("exclude_safe_operations")
                 ),
@@ -306,7 +308,10 @@
                 
                 // Event handlers that execute attacker-controlled code.
                 "*.onclick",
-                
+                "*.onload",
+                "*.onerror",
+                "addEventListener",
+
                 // Template/rendering (dangerous)
                 "template.innerHTML",
                 "*.render",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use sighthound::scanner::core::{print_findings_csv, print_findings_json, print_findings_text};
 use sighthound::{
     run_auto_detection_scan, run_explicit_scan, run_taint_analysis,
@@ -23,12 +23,15 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Check if root_dir is provided (required for actual scanning)
-    let root_dir = cli.root_dir.as_ref().ok_or_else(|| {
-        anyhow::anyhow!(
-            "Root directory is required for scanning. Use --help for usage information."
-        )
-    })?;
+    // Show help when invoked without a scan target.
+    let root_dir = match cli.root_dir.as_ref() {
+        Some(root_dir) => root_dir,
+        None => {
+            Cli::command().print_help()?;
+            println!();
+            return Ok(());
+        }
+    };
 
     // Initialize logger (respect RUST_LOG or --verbose flag)
     env_logger::Builder::from_env(
@@ -97,6 +100,7 @@ fn main() -> Result<()> {
 
         // Combine findings
         simple_findings.append(&mut taint_findings);
+        deduplicate_findings(&mut simple_findings);
         simple_findings
     };
 
@@ -110,4 +114,17 @@ fn main() -> Result<()> {
     }
 
     Ok(())
+}
+
+fn deduplicate_findings(findings: &mut Vec<sighthound::Finding>) {
+    let mut seen = std::collections::BTreeSet::new();
+    findings.retain(|finding| {
+        seen.insert((
+            finding.file.clone(),
+            finding.line,
+            finding.end_line,
+            finding.finding_type.clone(),
+            finding.snippet.clone(),
+        ))
+    });
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,7 @@ fn main() -> Result<()> {
         ))?;
 
     // Handle all vulnerability scanning modes with unified flow
-    let findings = if cli.taint_analysis {
+    let mut findings = if cli.taint_analysis {
         // Only taint analysis
         run_taint_analysis(&cli, root_dir, show_progress)?
     } else if cli.simple_analysis {
@@ -100,9 +100,11 @@ fn main() -> Result<()> {
 
         // Combine findings
         simple_findings.append(&mut taint_findings);
-        deduplicate_findings(&mut simple_findings);
         simple_findings
     };
+
+    // Deduplicate findings across all analysis modes (keeps first occurrence order)
+    deduplicate_findings(&mut findings);
 
     // Output results
     let duration = start_time.elapsed();
@@ -125,6 +127,8 @@ fn deduplicate_findings(findings: &mut Vec<sighthound::Finding>) {
             finding.end_line,
             finding.finding_type.clone(),
             finding.snippet.clone(),
+            finding.severity.clone(),
+            finding.description.clone(),
         ))
     });
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -372,6 +372,13 @@ pub struct Cli {
     #[arg(long, help = "Skip minified JavaScript files during scanning")]
     pub skip_minified: Option<bool>,
 
+    /// Include directories normally skipped for test fixtures
+    #[arg(
+        long,
+        help = "Include test directories (tests/test) during file discovery for fixture validation"
+    )]
+    pub include_test_fixtures: bool,
+
     /// Filter by code type (frontend, backend, or both)
     #[arg(
         long,

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -28,7 +28,6 @@ use syntect::parsing::SyntaxSet;
 use walkdir::WalkDir;
 
 use crate::common::CommonUtils;
-use crate::config::filters::SKIP_DIRS;
 use crate::models::Finding;
 use crate::parser::LanguageParser;
 use crate::rules::Rules;
@@ -111,6 +110,12 @@ impl TaintRuleDeduplicator {
     fn matches_source_pattern(&self, text: &str) -> Option<String> {
         log::debug!("[SOURCE_MATCH] Checking text: '{}'", text);
         for pattern in &self.source_patterns {
+            if Self::is_bare_call_source_pattern(pattern)
+                && !Self::matches_bare_call_source(pattern, text)
+            {
+                continue;
+            }
+
             if CommonUtils::matches_taint_pattern(pattern, text) {
                 log::debug!(
                     "[SOURCE_MATCH] Matched pattern: '{}' in text: '{}'",
@@ -122,6 +127,32 @@ impl TaintRuleDeduplicator {
         }
         log::debug!("[SOURCE_MATCH] No patterns matched for text: '{}'", text);
         None
+    }
+
+    fn is_bare_call_source_pattern(pattern: &str) -> bool {
+        let Some(name) = pattern.strip_suffix('(') else {
+            return false;
+        };
+
+        !name.is_empty() && name.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+    }
+
+    fn matches_bare_call_source(pattern: &str, text: &str) -> bool {
+        let mut search_start = 0;
+        while let Some(relative_pos) = text[search_start..].find(pattern) {
+            let pos = search_start + relative_pos;
+            let before = text[..pos].chars().next_back();
+            let has_identifier_prefix =
+                before.is_some_and(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.');
+
+            if !has_identifier_prefix {
+                return true;
+            }
+
+            search_start = pos + pattern.len();
+        }
+
+        false
     }
 
     /// Check if a pattern matches any sink
@@ -139,6 +170,114 @@ impl TaintRuleDeduplicator {
         }
         log::debug!("[SINK_MATCH] No patterns matched for text: '{}'", text);
         None
+    }
+}
+
+struct TaintExpressionUtils;
+
+impl TaintExpressionUtils {
+    fn normalize_variable(expression: &str) -> String {
+        let trimmed = expression
+            .trim()
+            .trim_end_matches(';')
+            .split_whitespace()
+            .last()
+            .unwrap_or("")
+            .trim();
+        let trimmed = trimmed.trim_start_matches('$');
+        let name: String = trimmed
+            .chars()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == '_')
+            .collect();
+
+        if CommonUtils::is_valid_variable_name(&name) {
+            name
+        } else {
+            String::new()
+        }
+    }
+
+    fn extract_php_variables(expression: &str) -> Vec<String> {
+        let mut variables = Vec::new();
+        let chars: Vec<char> = expression.chars().collect();
+        let mut index = 0;
+
+        while index < chars.len() {
+            if chars[index] == '$' {
+                let start = index + 1;
+                let mut end = start;
+                while end < chars.len() && (chars[end].is_ascii_alphanumeric() || chars[end] == '_')
+                {
+                    end += 1;
+                }
+
+                if end > start {
+                    let name: String = chars[start..end].iter().collect();
+                    if CommonUtils::is_valid_variable_name(&name) {
+                        variables.push(name);
+                    }
+                }
+
+                index = end;
+            } else {
+                index += 1;
+            }
+        }
+
+        variables.sort();
+        variables.dedup();
+        variables
+    }
+
+    fn expression_has_sanitizer(rule: &crate::rules::UnifiedRule, expression: &str) -> bool {
+        rule.sanitizers.as_ref().is_some_and(|sanitizers| {
+            sanitizers.iter().any(|sanitizer| {
+                let matched = expression.contains(sanitizer);
+                if matched {
+                    log::debug!(
+                        "[SANITIZER_CHECK] Found sanitizer '{}' in sink: '{}'",
+                        sanitizer,
+                        expression
+                    );
+                }
+                matched
+            })
+        })
+    }
+
+    fn expression_has_any_sanitizer(
+        rules: &[&crate::rules::UnifiedRule],
+        expression: &str,
+    ) -> bool {
+        rules
+            .iter()
+            .any(|rule| Self::expression_has_sanitizer(rule, expression))
+    }
+
+    fn strip_inline_comment(expression: &str) -> &str {
+        expression
+            .split_once('#')
+            .map(|(code, _)| code.trim())
+            .unwrap_or_else(|| expression.trim())
+    }
+
+    fn expression_references_variable(expression: &str, variable: &str) -> bool {
+        let mut start = 0;
+        while let Some(relative_pos) = expression[start..].find(variable) {
+            let pos = start + relative_pos;
+            let before = expression[..pos].chars().next_back();
+            let after = expression[pos + variable.len()..].chars().next();
+            let before_boundary = before.is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+            let after_boundary = after.is_none_or(|c| !(c.is_ascii_alphanumeric() || c == '_'));
+
+            if before_boundary && after_boundary {
+                return true;
+            }
+
+            start = pos + variable.len();
+        }
+
+        false
     }
 }
 
@@ -912,7 +1051,7 @@ impl ScanningLogic {
         source: &[u8],
         tree: &tree_sitter::Tree,
         taint_rules: &[&crate::rules::UnifiedRule],
-        _language_support: &dyn crate::language::LanguageSupport,
+        language_support: &dyn crate::language::LanguageSupport,
     ) -> Vec<crate::models::Finding> {
         let mut findings = Vec::new();
 
@@ -998,8 +1137,8 @@ impl ScanningLogic {
 
             // Look for assignment patterns: var = source_call()
             if CommonUtils::is_valid_assignment_text(&node_text) {
-                if let Some(var_name) =
-                    CommonUtils::extract_variable_from_assignment(&node_text, false)
+                if let Some(var_name) = Self::extract_taint_assignment_target(&node_text)
+                    .or_else(|| CommonUtils::extract_variable_from_assignment(&node_text, false))
                 {
                     // Extract the right side of assignment for source matching
                     if let Some(eq_pos) = node_text.find('=') {
@@ -1010,6 +1149,17 @@ impl ScanningLogic {
                         if let Some(source_pattern) =
                             rule_deduplicator.matches_source_pattern(assignment_value)
                         {
+                            if TaintExpressionUtils::expression_has_any_sanitizer(
+                                &applicable_rules,
+                                assignment_value,
+                            ) {
+                                log::debug!(
+                                    "[ASSIGNMENT_ANALYSIS] Assignment value '{}' contains sanitizer; not recording taint",
+                                    assignment_value
+                                );
+                                continue;
+                            }
+
                             log::debug!("[ASSIGNMENT_ANALYSIS] Assignment value '{}' matches source pattern '{}'", assignment_value, source_pattern);
                             flow_tracker.record_tainted_variable(
                                 var_name,
@@ -1028,42 +1178,46 @@ impl ScanningLogic {
             }
 
             // Check for taint propagation through operations
-            if let Some((target_var, dependent_vars)) = Self::detect_taint_propagation(&node_text) {
-                log::debug!(
-                    "[TAINT_PROPAGATION] Detected propagation: '{}' depends on {:?} in '{}'",
-                    target_var,
-                    dependent_vars,
-                    node_text
-                );
-                flow_tracker.record_taint_propagation(&target_var, &dependent_vars);
+            if !TaintExpressionUtils::expression_has_any_sanitizer(&applicable_rules, &node_text) {
+                if let Some((target_var, dependent_vars)) =
+                    Self::detect_taint_propagation(&node_text)
+                {
+                    log::debug!(
+                        "[TAINT_PROPAGATION] Detected propagation: '{}' depends on {:?} in '{}'",
+                        target_var,
+                        dependent_vars,
+                        node_text
+                    );
+                    flow_tracker.record_taint_propagation(&target_var, &dependent_vars);
 
-                // Check if any dependent variables are tainted and propagate to target
-                for dep_var in &dependent_vars {
-                    if let Some(taint_info) = flow_tracker
-                        .is_variable_tainted(dep_var, &func_name)
-                        .cloned()
-                    {
-                        log::debug!(
-                            "[TAINT_PROPAGATION] Propagating taint from '{}' to '{}' ({})",
-                            dep_var,
-                            target_var,
-                            taint_info.source_pattern
-                        );
+                    // Check if any dependent variables are tainted and propagate to target
+                    for dep_var in &dependent_vars {
+                        if let Some(taint_info) = flow_tracker
+                            .is_variable_tainted(dep_var, &func_name)
+                            .cloned()
+                        {
+                            log::debug!(
+                                "[TAINT_PROPAGATION] Propagating taint from '{}' to '{}' ({})",
+                                dep_var,
+                                target_var,
+                                taint_info.source_pattern
+                            );
 
-                        // Mark target variable as tainted (inheriting from the dependent variable)
-                        flow_tracker.record_tainted_variable(
-                            target_var.clone(),
-                            TaintVariableInfo {
-                                source_line: taint_info.source_line,
-                                source_pattern: taint_info.source_pattern.clone(),
-                                source_function: taint_info.source_function.clone(),
-                                assignment_code: format!(
-                                    "Propagated from {} via: {}",
-                                    dep_var, node_text
-                                ),
-                            },
-                        );
-                        break; // Only need one tainted dependency to taint the target
+                            // Mark target variable as tainted (inheriting from the dependent variable)
+                            flow_tracker.record_tainted_variable(
+                                target_var.clone(),
+                                TaintVariableInfo {
+                                    source_line: taint_info.source_line,
+                                    source_pattern: taint_info.source_pattern.clone(),
+                                    source_function: taint_info.source_function.clone(),
+                                    assignment_code: format!(
+                                        "Propagated from {} via: {}",
+                                        dep_var, node_text
+                                    ),
+                                },
+                            );
+                            break; // Only need one tainted dependency to taint the target
+                        }
                     }
                 }
             }
@@ -1084,11 +1238,62 @@ impl ScanningLogic {
                     line
                 );
                 // Extract ALL variables used in this sink (enhanced extraction)
-                let used_variables = CommonUtils::extract_all_variables(&node_text);
+                let mut used_variables = if language_support.name() == "php" {
+                    TaintExpressionUtils::extract_php_variables(&node_text)
+                } else {
+                    CommonUtils::extract_all_variables(&node_text)
+                };
+                used_variables.sort();
+                used_variables.dedup();
                 log::debug!(
                     "[SINK_ANALYSIS] Extracted variables from sink: {:?}",
                     used_variables
                 );
+
+                if !used_variables.is_empty() && Self::is_actionable_sink_node(node.kind()) {
+                    if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(&node_text)
+                    {
+                        if let Some(rule) = rule_deduplicator
+                            .get_rule_for_combination(&source_pattern, &sink_pattern)
+                        {
+                            if !TaintExpressionUtils::expression_has_sanitizer(rule, &node_text)
+                                && !flow_tracker
+                                    .is_flow_processed(line, &source_pattern, &sink_pattern)
+                            {
+                                flow_tracker
+                                    .mark_flow_processed(line, &source_pattern, &sink_pattern);
+
+                                let taint_source = crate::models::TaintSource {
+                                    file: filepath.to_string(),
+                                    line,
+                                    function: func_name.clone(),
+                                    variable: source_pattern.clone(),
+                                    operation: source_pattern.clone(),
+                                    code: node_text.clone(),
+                                    branch_id: None,
+                                };
+
+                                let taint_sink = crate::models::TaintSink {
+                                    file: filepath.to_string(),
+                                    line,
+                                    function: func_name.clone(),
+                                    variable: source_pattern.clone(),
+                                    operation: sink_pattern.clone(),
+                                    code: node_text.clone(),
+                                    branch_id: None,
+                                };
+
+                                findings.push(Self::create_taint_finding(
+                                    &taint_source,
+                                    &taint_sink,
+                                    rule,
+                                    tree,
+                                    source,
+                                ));
+                            }
+                        }
+                    }
+                }
 
                 // Check if ANY of these variables are tainted
                 for used_variable in used_variables.clone() {
@@ -1101,24 +1306,12 @@ impl ScanningLogic {
                             .get_rule_for_combination(&taint_info.source_pattern, &sink_pattern)
                         {
                             // Check if the sink expression contains sanitizers before creating finding
-                            if let Some(sanitizers) = &rule.sanitizers {
-                                let mut is_sanitized = false;
-                                for sanitizer in sanitizers {
-                                    if node_text.contains(sanitizer) {
-                                        log::debug!(
-                                            "[SANITIZER_CHECK] Found sanitizer '{}' in sink: '{}'",
-                                            sanitizer,
-                                            node_text
-                                        );
-                                        is_sanitized = true;
-                                        break;
-                                    }
-                                }
-
-                                if is_sanitized {
-                                    log::debug!("[SANITIZER_CHECK] Skipping finding due to sanitization: '{}'", node_text);
-                                    continue; // Skip this finding as it's sanitized
-                                }
+                            if TaintExpressionUtils::expression_has_sanitizer(rule, &node_text) {
+                                log::debug!(
+                                    "[SANITIZER_CHECK] Skipping finding due to sanitization: '{}'",
+                                    node_text
+                                );
+                                continue; // Skip this finding as it's sanitized
                             }
 
                             // Ensure we haven't already processed this exact flow
@@ -1222,6 +1415,22 @@ impl ScanningLogic {
                         return Some((left_side.to_string(), dependent_vars));
                     }
                 }
+
+                let target_var = TaintExpressionUtils::normalize_variable(left_side);
+                let mut dependent_vars = CommonUtils::extract_all_variables(right_side);
+                dependent_vars.extend(TaintExpressionUtils::extract_php_variables(right_side));
+                dependent_vars.retain(|var| var != &target_var);
+                dependent_vars.sort();
+                dependent_vars.dedup();
+
+                if !target_var.is_empty() && !dependent_vars.is_empty() {
+                    log::debug!(
+                        "[PROPAGATION_CHECK] Assignment propagation detected: '{}' depends on {:?}",
+                        target_var,
+                        dependent_vars
+                    );
+                    return Some((target_var, dependent_vars));
+                }
             }
         }
 
@@ -1261,6 +1470,20 @@ impl ScanningLogic {
 
         log::debug!("[PROPAGATION_CHECK] No propagation detected");
         None
+    }
+
+    fn extract_taint_assignment_target(node_text: &str) -> Option<String> {
+        let eq_pos = node_text.find('=')?;
+        let left_side = node_text[..eq_pos].trim();
+        let variable = TaintExpressionUtils::normalize_variable(left_side);
+        (!variable.is_empty()).then_some(variable)
+    }
+
+    fn is_actionable_sink_node(node_kind: &str) -> bool {
+        node_kind == "call"
+            || node_kind == "expression_statement"
+            || node_kind.contains("call_expression")
+            || node_kind.contains("invocation")
     }
 
     /// Extract direct variable from simple expressions
@@ -1599,7 +1822,11 @@ impl VulnerabilityScanner {
         })
     }
 
-    fn discover_files(&self, root_dir: &str) -> Result<Vec<PathBuf>> {
+    fn discover_files_with_options(
+        &self,
+        root_dir: &str,
+        include_test_fixtures: bool,
+    ) -> Result<Vec<PathBuf>> {
         let mut files = Vec::new();
         // Get extension once using a fresh parser (cheap, happens only once)
         let parser = LanguageParser::new(&self.language)?;
@@ -1611,7 +1838,10 @@ impl VulnerabilityScanner {
             .filter_entry(|e| {
                 if e.file_type().is_dir() {
                     if let Some(name) = e.file_name().to_str() {
-                        return !SKIP_DIRS.contains(&name);
+                        return !crate::scanner::utils::should_skip_dir(
+                            name,
+                            include_test_fixtures,
+                        );
                     }
                 }
                 true
@@ -1694,7 +1924,22 @@ impl VulnerabilityScanner {
         language_name: &str,
         show_progress: bool,
     ) -> Result<Vec<Finding>> {
-        let files = self.discover_files(root_dir)?;
+        self.find_vulnerabilities_parallel_with_options(
+            root_dir,
+            language_name,
+            show_progress,
+            false,
+        )
+    }
+
+    pub fn find_vulnerabilities_parallel_with_options(
+        &self,
+        root_dir: &str,
+        language_name: &str,
+        show_progress: bool,
+        include_test_fixtures: bool,
+    ) -> Result<Vec<Finding>> {
+        let files = self.discover_files_with_options(root_dir, include_test_fixtures)?;
         if files.is_empty() {
             println!("No {} files found in {}", language_name, root_dir);
             return Ok(Vec::new());
@@ -1799,7 +2044,7 @@ impl VulnerabilityScanner {
             .num_threads(1)
             .build_global()
             .ok();
-        self.find_vulnerabilities_parallel(root_dir, language_name, true)
+        self.find_vulnerabilities_parallel_with_options(root_dir, language_name, true, false)
     }
 
     pub fn find_vulnerabilities_unified(
@@ -1808,12 +2053,13 @@ impl VulnerabilityScanner {
         language_name: &str,
         show_progress: bool,
     ) -> Result<Vec<Finding>> {
-        self.find_vulnerabilities_unified_with_filters(
+        self.find_vulnerabilities_unified_with_filters_and_options(
             root_dir,
             language_name,
             show_progress,
             None,
             None,
+            false,
         )
     }
 
@@ -1825,14 +2071,34 @@ impl VulnerabilityScanner {
         code_type_filter: Option<&str>,
         language_filter: Option<&str>,
     ) -> Result<Vec<Finding>> {
+        self.find_vulnerabilities_unified_with_filters_and_options(
+            root_dir,
+            language_name,
+            show_progress,
+            code_type_filter,
+            language_filter,
+            false,
+        )
+    }
+
+    pub fn find_vulnerabilities_unified_with_filters_and_options(
+        &self,
+        root_dir: &str,
+        language_name: &str,
+        show_progress: bool,
+        code_type_filter: Option<&str>,
+        language_filter: Option<&str>,
+        include_test_fixtures: bool,
+    ) -> Result<Vec<Finding>> {
         let files_by_language = if self.language.is_empty() {
-            crate::scanner::utils::discover_files_by_language_with_progress(
+            crate::scanner::utils::discover_files_by_language_with_progress_and_options(
                 root_dir,
                 true,
                 show_progress,
+                include_test_fixtures,
             )?
         } else {
-            let files = self.discover_files(root_dir)?;
+            let files = self.discover_files_with_options(root_dir, include_test_fixtures)?;
             let mut result = std::collections::BTreeMap::new();
             if !files.is_empty() {
                 result.insert(self.language.clone(), files);
@@ -2181,31 +2447,33 @@ impl ScanningLogic {
                 }
 
                 // Check for taint propagation through operations
-                if let Some((target_var, dependent_vars)) =
-                    ScanningLogic::detect_taint_propagation(&node_text)
-                {
-                    flow_tracker.record_taint_propagation(&target_var, &dependent_vars);
+                if !TaintExpressionUtils::expression_has_any_sanitizer(taint_rules, &node_text) {
+                    if let Some((target_var, dependent_vars)) =
+                        ScanningLogic::detect_taint_propagation(&node_text)
+                    {
+                        flow_tracker.record_taint_propagation(&target_var, &dependent_vars);
 
-                    // Check if any dependent variables are tainted and propagate to target
-                    for dep_var in &dependent_vars {
-                        if let Some(taint_info) = flow_tracker
-                            .is_variable_tainted(dep_var, &func_name)
-                            .cloned()
-                        {
-                            // Mark target variable as tainted (inheriting from the dependent variable)
-                            flow_tracker.record_tainted_variable(
-                                target_var.to_string(),
-                                TaintVariableInfo {
-                                    source_line: taint_info.source_line,
-                                    source_pattern: taint_info.source_pattern.clone(),
-                                    source_function: taint_info.source_function.clone(),
-                                    assignment_code: format!(
-                                        "Propagated from {} via: {}",
-                                        dep_var, node_text
-                                    ),
-                                },
-                            );
-                            break; // Only need one tainted dependency to taint the target
+                        // Check if any dependent variables are tainted and propagate to target
+                        for dep_var in &dependent_vars {
+                            if let Some(taint_info) = flow_tracker
+                                .is_variable_tainted(dep_var, &func_name)
+                                .cloned()
+                            {
+                                // Mark target variable as tainted (inheriting from the dependent variable)
+                                flow_tracker.record_tainted_variable(
+                                    target_var.to_string(),
+                                    TaintVariableInfo {
+                                        source_line: taint_info.source_line,
+                                        source_pattern: taint_info.source_pattern.clone(),
+                                        source_function: taint_info.source_function.clone(),
+                                        assignment_code: format!(
+                                            "Propagated from {} via: {}",
+                                            dep_var, node_text
+                                        ),
+                                    },
+                                );
+                                break; // Only need one tainted dependency to taint the target
+                            }
                         }
                     }
                 }
@@ -2900,6 +3168,10 @@ enum VariableSource {
         source_expression: String,
         line: usize,
     },
+    KnownSafe {
+        reason: String,
+        line: usize,
+    },
     FunctionParameter {
         parameter_index: usize,
     },
@@ -2915,6 +3187,13 @@ enum AnalysisResult {
     DefinitelyTainted { flow: VerifiedTaintFlow },
     DefinitelySafe,
     Unknown { reason: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ValueSourceClassification {
+    Safe(String),
+    Tainted(String),
+    Unknown,
 }
 
 /// Multi-file taint analysis infrastructure for cross-file data flow tracking
@@ -3507,6 +3786,15 @@ impl DataFlowTracer {
         );
 
         match variable_source {
+            VariableSource::KnownSafe { reason, line } => {
+                log::debug!(
+                    "[DATA_FLOW_TRACER] Variable proven safe at line {}: {}",
+                    line,
+                    reason
+                );
+                AnalysisResult::DefinitelySafe
+            }
+
             VariableSource::DirectTaintSource { pattern, line } => {
                 log::debug!(
                     "[DATA_FLOW_TRACER] Direct taint source found: {} at line {}",
@@ -3554,9 +3842,10 @@ impl DataFlowTracer {
                     parameter_index
                 );
 
-                // Check if the parameter name matches any taint source patterns
-                if let Some(source_pattern) =
-                    rule_deduplicator.matches_source_pattern(sink_variable)
+                // Only treat parameters as sources when the parameter shape is
+                // explicitly user controlled; broad names like `token` are too noisy.
+                if let ValueSourceClassification::Tainted(source_pattern) =
+                    self.classify_value_source(sink_variable, rule_deduplicator)
                 {
                     log::debug!(
                         "[DATA_FLOW_TRACER] Function parameter '{}' matches source pattern '{}'",
@@ -3697,12 +3986,38 @@ impl DataFlowTracer {
         for (line_num, line) in source_text.lines().enumerate() {
             let line = line.trim();
             if line.starts_with(&format!("{} =", variable_name)) {
-                let rhs = line.split('=').nth(1).unwrap_or("").trim();
+                let rhs = TaintExpressionUtils::strip_inline_comment(
+                    line.split('=').nth(1).unwrap_or("").trim(),
+                );
                 log::debug!(
                     "[COMPUTE_VARIABLE_SOURCE] Found assignment: {} = {}",
                     variable_name,
                     rhs
                 );
+
+                match self.classify_value_source(rhs, rule_deduplicator) {
+                    ValueSourceClassification::Safe(reason) => {
+                        log::debug!(
+                            "[COMPUTE_VARIABLE_SOURCE] Proven-safe assignment: {}",
+                            reason
+                        );
+                        return VariableSource::KnownSafe {
+                            reason,
+                            line: line_num + 1,
+                        };
+                    }
+                    ValueSourceClassification::Tainted(source_pattern) => {
+                        log::debug!(
+                            "[COMPUTE_VARIABLE_SOURCE] Direct taint source: '{}'",
+                            source_pattern
+                        );
+                        return VariableSource::DirectTaintSource {
+                            pattern: source_pattern,
+                            line: line_num + 1,
+                        };
+                    }
+                    ValueSourceClassification::Unknown => {}
+                }
 
                 // Check if RHS is a direct taint source
                 if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(rhs) {
@@ -3770,6 +4085,175 @@ impl DataFlowTracer {
         VariableSource::FunctionParameter { parameter_index: 0 }
     }
 
+    fn classify_value_source(
+        &self,
+        expression: &str,
+        rule_deduplicator: &TaintRuleDeduplicator,
+    ) -> ValueSourceClassification {
+        let expr = expression.trim();
+
+        if expr.is_empty() {
+            return ValueSourceClassification::Unknown;
+        }
+
+        if expr.starts_with('#') || expr.starts_with("\"\"\"") || expr.starts_with("'''") {
+            return ValueSourceClassification::Safe("comment or docstring".to_string());
+        }
+
+        if self.is_safe_literal_expression(expr) {
+            return ValueSourceClassification::Safe("literal expression".to_string());
+        }
+
+        if expr.contains("setdefault(") {
+            return ValueSourceClassification::Safe(
+                "environment default/configuration write".to_string(),
+            );
+        }
+
+        if Self::is_safe_static_file_read(expr) {
+            return ValueSourceClassification::Safe("static config/template file read".to_string());
+        }
+
+        if let Some(env_key) = Self::extract_env_key(expr) {
+            if Self::is_user_controlled_env_key(&env_key) {
+                let source_pattern = rule_deduplicator
+                    .matches_source_pattern(expr)
+                    .unwrap_or_else(|| format!("env:{}", env_key));
+                return ValueSourceClassification::Tainted(source_pattern);
+            }
+
+            if Self::is_config_env_key(&env_key) {
+                return ValueSourceClassification::Safe(format!(
+                    "static configuration environment key {}",
+                    env_key
+                ));
+            }
+        }
+
+        let lower_expr = expr.to_ascii_lowercase();
+        if lower_expr.contains("input(")
+            || lower_expr.contains("raw_input(")
+            || lower_expr.contains("sys.argv")
+            || lower_expr.contains("request.")
+            || lower_expr.contains("flask.request")
+        {
+            if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(expr) {
+                return ValueSourceClassification::Tainted(source_pattern);
+            }
+        }
+
+        if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(expr) {
+            return ValueSourceClassification::Tainted(source_pattern);
+        }
+
+        ValueSourceClassification::Unknown
+    }
+
+    fn is_safe_literal_expression(&self, expression: &str) -> bool {
+        let expr = expression.trim();
+
+        if Self::is_string_literal(expr)
+            || matches!(expr, "True" | "False" | "None" | "true" | "false" | "null")
+            || expr.parse::<f64>().is_ok()
+        {
+            return true;
+        }
+
+        let literal_concat = expr
+            .split('+')
+            .map(str::trim)
+            .filter(|part| !part.is_empty())
+            .all(Self::is_string_literal);
+
+        literal_concat && expr.contains('+')
+    }
+
+    fn is_string_literal(expression: &str) -> bool {
+        let expr = expression.trim();
+        (expr.len() >= 2 && expr.starts_with('"') && expr.ends_with('"'))
+            || (expr.len() >= 2 && expr.starts_with('\'') && expr.ends_with('\''))
+    }
+
+    fn is_safe_static_file_read(expression: &str) -> bool {
+        if !expression.contains("open(") {
+            return false;
+        }
+
+        let Some(start) = expression.find("open(") else {
+            return false;
+        };
+        let after = expression[start + "open(".len()..].trim_start();
+        let Some(quote) = after.chars().next() else {
+            return false;
+        };
+        if quote != '"' && quote != '\'' {
+            return false;
+        }
+
+        let rest = &after[quote.len_utf8()..];
+        let Some(end) = rest.find(quote) else {
+            return false;
+        };
+        let filename = rest[..end].to_ascii_lowercase();
+
+        filename.contains("config")
+            || filename.contains("template")
+            || filename.ends_with(".json")
+            || filename.ends_with(".yaml")
+            || filename.ends_with(".yml")
+            || filename.ends_with(".toml")
+    }
+
+    fn extract_env_key(expression: &str) -> Option<String> {
+        let patterns = [
+            "os.environ.get(",
+            "os.getenv(",
+            "os.environ.setdefault(",
+            "os.environ[",
+        ];
+
+        for pattern in patterns {
+            if let Some(start) = expression.find(pattern) {
+                let after = &expression[start + pattern.len()..];
+                let after = after.trim_start();
+                let quote = after.chars().next()?;
+                if quote != '"' && quote != '\'' {
+                    return None;
+                }
+                let rest = &after[quote.len_utf8()..];
+                if let Some(end) = rest.find(quote) {
+                    return Some(rest[..end].to_ascii_uppercase());
+                }
+            }
+        }
+
+        None
+    }
+
+    fn is_user_controlled_env_key(key: &str) -> bool {
+        let key = key.to_ascii_uppercase();
+        key == "USER_COMMAND"
+            || key == "USER_INPUT_FILE"
+            || key == "REQUEST_DATA"
+            || key.starts_with("REQUEST_")
+            || key.starts_with("USER_INPUT")
+            || key.ends_with("_INPUT")
+            || key.ends_with("_COMMAND")
+            || key.ends_with("_PAYLOAD")
+    }
+
+    fn is_config_env_key(key: &str) -> bool {
+        let key = key.to_ascii_uppercase();
+        key.starts_with("APP_")
+            || key.starts_with("DJANGO_")
+            || key.starts_with("FLASK_")
+            || key.ends_with("_MODE")
+            || key.ends_with("_VERSION")
+            || key == "DEBUG"
+            || key == "LOG_LEVEL"
+            || key == "SECRET_KEY"
+    }
+
     fn trace_local_assignment_taint(
         &mut self,
         file_path: &str,
@@ -3787,6 +4271,38 @@ impl DataFlowTracer {
             file_path,
             function_name
         );
+
+        match self.classify_value_source(source_expression, rule_deduplicator) {
+            ValueSourceClassification::Safe(reason) => {
+                log::debug!("[TRACE_LOCAL] Proven-safe expression: {}", reason);
+                return AnalysisResult::DefinitelySafe;
+            }
+            ValueSourceClassification::Tainted(source_pattern) => {
+                log::debug!(
+                    "[TRACE_LOCAL] Classified direct taint source: '{}'",
+                    source_pattern
+                );
+
+                let flow = VerifiedTaintFlow {
+                    source_file: file_path.to_string(),
+                    source_function: function_name.to_string(),
+                    source_pattern: source_pattern.clone(),
+                    source_line: assignment_line,
+
+                    sink_file: file_path.to_string(),
+                    sink_function: function_name.to_string(),
+                    sink_pattern: sink_pattern.to_string(),
+                    sink_line,
+                    sink_variable: sink_variable.to_string(),
+
+                    call_chain_len: 0,
+                };
+
+                self.verified_flows.push(flow.clone());
+                return AnalysisResult::DefinitelyTainted { flow };
+            }
+            ValueSourceClassification::Unknown => {}
+        }
 
         // Check if the source expression is a direct taint source
         if let Some(source_pattern) = rule_deduplicator.matches_source_pattern(source_expression) {
@@ -3820,17 +4336,36 @@ impl DataFlowTracer {
             log::debug!("[TRACE_LOCAL] Source is function call: '{}'", function_name);
 
             // Find the source file for this function
-            if let Some(source_file) = self.find_function_source_file(&function_name, file_path) {
+            let resolved_function = if let Some(source_file) =
+                self.find_function_source_file(&function_name, file_path)
+            {
+                Some((function_name.clone(), source_file))
+            } else if let Some(method_name) = function_name.rsplit('.').next() {
+                if method_name != function_name {
+                    self.find_function_source_file(method_name, file_path)
+                        .or_else(|| {
+                            self.file_contains_function(file_path, method_name)
+                                .then(|| file_path.to_string())
+                        })
+                        .map(|source_file| (method_name.to_string(), source_file))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            if let Some((resolved_function_name, source_file)) = resolved_function {
                 log::debug!(
                     "[TRACE_LOCAL] Found function '{}' in '{}'",
-                    function_name,
+                    resolved_function_name,
                     source_file
                 );
 
                 // Analyze the function to see if it returns tainted data
                 match self.analyze_function_taint_behavior(
                     &source_file,
-                    &function_name,
+                    &resolved_function_name,
                     rule_deduplicator,
                 ) {
                     AnalysisResult::DefinitelyTainted { flow } => {
@@ -3874,10 +4409,62 @@ impl DataFlowTracer {
             return AnalysisResult::DefinitelySafe;
         }
 
+        if CommonUtils::is_valid_variable_name(source_expression)
+            && source_expression != sink_variable
+            && !CommonUtils::is_keyword_or_builtin(source_expression)
+        {
+            log::debug!(
+                "[TRACE_LOCAL] Source is variable alias '{}', tracing dependency",
+                source_expression
+            );
+            return self.analyze_sink_variable(
+                file_path,
+                function_name,
+                source_expression,
+                sink_pattern,
+                sink_line,
+                rule_deduplicator,
+            );
+        }
+
         // If it's an f-string or complex expression, we need more analysis
         if source_expression.starts_with("f\"") || source_expression.contains('{') {
             log::debug!("[TRACE_LOCAL] Complex expression - requires variable dependency analysis");
-            // TODO: Implement variable dependency tracking for complex expressions
+            for variable in CommonUtils::extract_all_variables(source_expression) {
+                if variable == sink_variable
+                    || CommonUtils::is_keyword_or_builtin(&variable)
+                    || variable == "f"
+                {
+                    continue;
+                }
+
+                match self.analyze_sink_variable(
+                    file_path,
+                    function_name,
+                    &variable,
+                    sink_pattern,
+                    sink_line,
+                    rule_deduplicator,
+                ) {
+                    AnalysisResult::DefinitelyTainted { flow } => {
+                        let derived_flow = VerifiedTaintFlow {
+                            source_file: flow.source_file,
+                            source_function: flow.source_function,
+                            source_pattern: flow.source_pattern,
+                            source_line: flow.source_line,
+                            sink_file: file_path.to_string(),
+                            sink_function: function_name.to_string(),
+                            sink_pattern: sink_pattern.to_string(),
+                            sink_line,
+                            sink_variable: sink_variable.to_string(),
+                            call_chain_len: flow.call_chain_len,
+                        };
+                        self.verified_flows.push(derived_flow.clone());
+                        return AnalysisResult::DefinitelyTainted { flow: derived_flow };
+                    }
+                    AnalysisResult::DefinitelySafe | AnalysisResult::Unknown { .. } => {}
+                }
+            }
         }
 
         log::debug!("[TRACE_LOCAL] Could not determine taint status of assignment");
@@ -4009,8 +4596,69 @@ impl DataFlowTracer {
         if let Some(function_body) = self.extract_function_body(&source_text, function_name) {
             log::debug!("[ANALYZE_FUNCTION] Function body found, analyzing...");
 
+            let mut tainted_locals: std::collections::BTreeMap<String, VerifiedTaintFlow> =
+                std::collections::BTreeMap::new();
+            let mut ambient_taint: Option<VerifiedTaintFlow> = None;
+
             for (line_num, line) in function_body.lines().enumerate() {
                 let line = line.trim();
+
+                if ambient_taint.is_none() {
+                    if let ValueSourceClassification::Tainted(source_pattern) =
+                        self.classify_value_source(line, rule_deduplicator)
+                    {
+                        ambient_taint = Some(VerifiedTaintFlow {
+                            source_file: file_path.to_string(),
+                            source_function: function_name.to_string(),
+                            source_line: line_num + 1,
+                            source_pattern,
+                            sink_file: file_path.to_string(),
+                            sink_function: function_name.to_string(),
+                            sink_line: line_num + 1,
+                            sink_variable: "return_value".to_string(),
+                            sink_pattern: "function_return".to_string(),
+                            call_chain_len: 0,
+                        });
+                    }
+                }
+
+                if CommonUtils::is_valid_assignment_text(line) {
+                    if let Some(eq_pos) = line.find('=') {
+                        let lhs = line[..eq_pos].trim();
+                        let rhs =
+                            TaintExpressionUtils::strip_inline_comment(line[eq_pos + 1..].trim());
+                        if CommonUtils::is_valid_variable_name(lhs) {
+                            match self.trace_local_assignment_taint(
+                                file_path,
+                                function_name,
+                                rhs,
+                                line_num + 1,
+                                "function_return",
+                                line_num + 1,
+                                lhs,
+                                rule_deduplicator,
+                            ) {
+                                AnalysisResult::DefinitelyTainted { flow } => {
+                                    tainted_locals.insert(lhs.to_string(), flow);
+                                }
+                                AnalysisResult::DefinitelySafe => {
+                                    tainted_locals.remove(lhs);
+                                }
+                                AnalysisResult::Unknown { .. } => {
+                                    for (tainted_var, flow) in &tainted_locals {
+                                        if TaintExpressionUtils::expression_references_variable(
+                                            rhs,
+                                            tainted_var,
+                                        ) {
+                                            tainted_locals.insert(lhs.to_string(), flow.clone());
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
 
                 if line.starts_with("return ") {
                     let return_expr = line.strip_prefix("return ").unwrap_or("").trim();
@@ -4018,6 +4666,57 @@ impl DataFlowTracer {
                         "[ANALYZE_FUNCTION] Found return statement: \"{}\"",
                         return_expr
                     );
+
+                    match self.classify_value_source(return_expr, rule_deduplicator) {
+                        ValueSourceClassification::Safe(reason) => {
+                            log::debug!(
+                                "[ANALYZE_FUNCTION] Function return is proven safe: {}",
+                                reason
+                            );
+                            continue;
+                        }
+                        ValueSourceClassification::Tainted(source_pattern) => {
+                            log::debug!(
+                                "[ANALYZE_FUNCTION] Function returns direct taint source: \"{}\"",
+                                source_pattern
+                            );
+
+                            let flow = VerifiedTaintFlow {
+                                source_file: file_path.to_string(),
+                                source_function: function_name.to_string(),
+                                source_line: line_num + 1,
+                                source_pattern: source_pattern.clone(),
+                                sink_file: file_path.to_string(),
+                                sink_function: function_name.to_string(),
+                                sink_line: line_num + 1,
+                                sink_variable: "return_value".to_string(),
+                                sink_pattern: "function_return".to_string(),
+                                call_chain_len: 0,
+                            };
+                            return AnalysisResult::DefinitelyTainted { flow };
+                        }
+                        ValueSourceClassification::Unknown => {}
+                    }
+
+                    for (var_name, flow) in &tainted_locals {
+                        if TaintExpressionUtils::expression_references_variable(
+                            return_expr,
+                            var_name,
+                        ) {
+                            log::debug!(
+                                "[ANALYZE_FUNCTION] Return expression references tainted local '{}'",
+                                var_name
+                            );
+                            return AnalysisResult::DefinitelyTainted { flow: flow.clone() };
+                        }
+                    }
+
+                    if let Some(flow) = ambient_taint.clone() {
+                        log::debug!(
+                            "[ANALYZE_FUNCTION] Return expression follows earlier source access"
+                        );
+                        return AnalysisResult::DefinitelyTainted { flow };
+                    }
 
                     // Check if return expression is a direct taint source
                     if let Some(source_pattern) =

--- a/src/scanner/core.rs
+++ b/src/scanner/core.rs
@@ -138,14 +138,21 @@ impl TaintRuleDeduplicator {
     }
 
     fn matches_bare_call_source(pattern: &str, text: &str) -> bool {
+        // Module qualifiers that alias Python builtins (e.g. `builtins.input(`,
+        // `six.moves.input(`). These read as the bare source even though they
+        // carry a dotted prefix, so they must survive the identifier-prefix guard.
+        const BUILTIN_QUALIFIERS: [&str; 2] = ["builtins.", "six.moves."];
+
         let mut search_start = 0;
         while let Some(relative_pos) = text[search_start..].find(pattern) {
             let pos = search_start + relative_pos;
-            let before = text[..pos].chars().next_back();
-            let has_identifier_prefix =
-                before.is_some_and(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.');
+            let before = &text[..pos];
+            let has_identifier_prefix = before
+                .chars()
+                .next_back()
+                .is_some_and(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.');
 
-            if !has_identifier_prefix {
+            if !has_identifier_prefix || Self::has_builtin_qualifier(before, &BUILTIN_QUALIFIERS) {
                 return true;
             }
 
@@ -153,6 +160,19 @@ impl TaintRuleDeduplicator {
         }
 
         false
+    }
+
+    /// Whether the text preceding a bare-call pattern ends with a whitelisted
+    /// builtin module qualifier that is itself bare. `builtins.input(` and
+    /// `six.moves.input(` match; `obj.input(` and `mybuiltins.input(` do not.
+    fn has_builtin_qualifier(before: &str, qualifiers: &[&str]) -> bool {
+        qualifiers.iter().any(|qualifier| {
+            before.strip_suffix(qualifier).is_some_and(|head| {
+                head.chars()
+                    .next_back()
+                    .is_none_or(|c| !c.is_ascii_alphanumeric() && c != '_' && c != '.')
+            })
+        })
     }
 
     /// Check if a pattern matches any sink
@@ -4104,11 +4124,15 @@ impl DataFlowTracer {
             return ValueSourceClassification::Safe("literal expression".to_string());
         }
 
-        if expr.contains("setdefault(") {
-            return ValueSourceClassification::Safe(
-                "environment default/configuration write".to_string(),
-            );
-        }
+        // `setdefault(key, default)` returns `default` when the key is absent, so a
+        // tainted default (e.g. `d.setdefault("k", request.args["x"])` or
+        // `os.environ.setdefault(k, input())`) propagates taint through the result.
+        // We deliberately do NOT short-circuit `setdefault(` to Safe. Robustly parsing
+        // out the 2nd argument (nested calls, commas, and quotes) is not worth the
+        // complexity, so we drop the blanket guard and let normal classification run:
+        // `os.environ.setdefault(...)` is handled by the env-key path below (which
+        // separates user-controlled keys from config keys), and any inline taint source
+        // in the default argument is caught by the source-pattern checks further down.
 
         if Self::is_safe_static_file_read(expr) {
             return ValueSourceClassification::Safe("static config/template file read".to_string());
@@ -4169,9 +4193,32 @@ impl DataFlowTracer {
     }
 
     fn is_string_literal(expression: &str) -> bool {
-        let expr = expression.trim();
-        (expr.len() >= 2 && expr.starts_with('"') && expr.ends_with('"'))
-            || (expr.len() >= 2 && expr.starts_with('\'') && expr.ends_with('\''))
+        // Returns true only for a SINGLE atomic quoted literal. The opening quote's
+        // matching closing quote must be the final character; otherwise the expression
+        // is a top-level concatenation like `"x" + tainted + "y"` (which starts and ends
+        // with a quote but is not one literal) and must fall through to the per-operand
+        // concat check in `is_safe_literal_expression`.
+        let bytes = expression.trim().as_bytes();
+        if bytes.len() < 2 {
+            return false;
+        }
+        let quote = bytes[0];
+        if quote != b'"' && quote != b'\'' {
+            return false;
+        }
+        // Quotes and `\` are ASCII, so byte scanning is safe even with multibyte
+        // UTF-8 content (continuation bytes are all >= 0x80 and never match).
+        let mut escaped = false;
+        for (i, &b) in bytes.iter().enumerate().skip(1) {
+            if escaped {
+                escaped = false;
+            } else if b == b'\\' {
+                escaped = true;
+            } else if b == quote {
+                return i == bytes.len() - 1;
+            }
+        }
+        false
     }
 
     fn is_safe_static_file_read(expression: &str) -> bool {
@@ -4195,6 +4242,16 @@ impl DataFlowTracer {
             return false;
         };
         let filename = rest[..end].to_ascii_lowercase();
+
+        // The path must be a SINGLE string literal. After the literal's closing
+        // quote the only thing allowed is the argument terminator (`)` or `,` for
+        // the mode arg). A `+` (concatenation) or any other token means the real
+        // path is built from a tainted value — e.g. `open("config/" + user_input)`
+        // — which must NOT be treated as a safe static read.
+        let remainder = rest[end + quote.len_utf8()..].trim_start();
+        if !matches!(remainder.chars().next(), Some(')') | Some(',')) {
+            return false;
+        }
 
         filename.contains("config")
             || filename.contains("template")
@@ -4249,9 +4306,11 @@ impl DataFlowTracer {
             || key.starts_with("FLASK_")
             || key.ends_with("_MODE")
             || key.ends_with("_VERSION")
+            || key.ends_with("_API_KEY")
             || key == "DEBUG"
             || key == "LOG_LEVEL"
             || key == "SECRET_KEY"
+            || key == "API_KEY"
     }
 
     fn trace_local_assignment_taint(

--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -25,11 +25,13 @@ impl ScanContext {
         let discovery_start = std::time::Instant::now();
 
         let parallel = !cli.single_threaded;
-        let files_by_language = crate::scanner::utils::discover_files_by_language_with_progress(
-            root_dir,
-            parallel,
-            show_progress,
-        )?;
+        let files_by_language =
+            crate::scanner::utils::discover_files_by_language_with_progress_and_options(
+                root_dir,
+                parallel,
+                show_progress,
+                cli.include_test_fixtures,
+            )?;
         let discovery_time = discovery_start.elapsed();
 
         if files_by_language.is_empty() {
@@ -225,15 +227,21 @@ pub fn run_explicit_scan(cli: &Cli, root_dir: &str, show_progress: bool) -> Resu
 
     // Use the new filtering method if filters are specified
     if cli.code_type.is_some() || cli.language_filter.is_some() {
-        scanner.find_vulnerabilities_unified_with_filters(
+        scanner.find_vulnerabilities_unified_with_filters_and_options(
             root_dir,
             language,
             show_progress,
             cli.code_type.as_deref(),
             cli.language_filter.as_deref(),
+            cli.include_test_fixtures,
         )
     } else {
-        scanner.find_vulnerabilities_parallel(root_dir, language, show_progress)
+        scanner.find_vulnerabilities_parallel_with_options(
+            root_dir,
+            language,
+            show_progress,
+            cli.include_test_fixtures,
+        )
     }
 }
 
@@ -263,9 +271,19 @@ pub fn run_auto_detection_scan(
 
     // Rediscover files by language for actual processing (context only used for validation)
     let files_by_language = if cli.single_threaded {
-        crate::scanner::utils::discover_files_by_language_sequential_with_progress(root_dir, false)?
+        crate::scanner::utils::discover_files_by_language_with_progress_and_options(
+            root_dir,
+            false,
+            false,
+            cli.include_test_fixtures,
+        )?
     } else {
-        crate::scanner::utils::discover_files_by_language_parallel_with_progress(root_dir, false)?
+        crate::scanner::utils::discover_files_by_language_with_progress_and_options(
+            root_dir,
+            true,
+            false,
+            cli.include_test_fixtures,
+        )?
     };
 
     let total_findings = Arc::new(AtomicUsize::new(0));
@@ -361,15 +379,21 @@ pub fn run_auto_detection_scan(
                     .expect("scanner");
 
             let findings_result = if cli.code_type.is_some() || cli.language_filter.is_some() {
-                scanner.find_vulnerabilities_unified_with_filters(
+                scanner.find_vulnerabilities_unified_with_filters_and_options(
                     root_dir,
                     &language,
                     false, // Never show progress for individual languages in auto-detection
                     cli.code_type.as_deref(),
                     cli.language_filter.as_deref(),
+                    cli.include_test_fixtures,
                 )
             } else {
-                scanner.find_vulnerabilities_parallel(root_dir, &language, false)
+                scanner.find_vulnerabilities_parallel_with_options(
+                    root_dir,
+                    &language,
+                    false,
+                    cli.include_test_fixtures,
+                )
             };
 
             match findings_result {
@@ -457,15 +481,23 @@ pub fn run_taint_analysis_with_verbosity(
     };
 
     let all_findings = if cli.code_type.is_some() || cli.language_filter.is_some() {
-        scanner.find_vulnerabilities_unified_with_filters(
+        scanner.find_vulnerabilities_unified_with_filters_and_options(
             root_dir,
             language,
             report,
             cli.code_type.as_deref(),
             cli.language_filter.as_deref(),
+            cli.include_test_fixtures,
         )?
     } else {
-        scanner.find_vulnerabilities_unified(root_dir, language, report)?
+        scanner.find_vulnerabilities_unified_with_filters_and_options(
+            root_dir,
+            language,
+            report,
+            None,
+            None,
+            cli.include_test_fixtures,
+        )?
     };
 
     if let Some(mut spinner) = spinner.take() {

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -21,34 +21,49 @@ pub fn matches_glob_pattern(pattern: &str, file_path: &str) -> bool {
 }
 
 pub fn is_git_ignored(path: &Path) -> bool {
+    let target_path = normalize_for_ignore_check(path);
     {
         // Try to get from cache first
         let cache = GIT_IGNORE_CACHE.lock().unwrap();
-        if let Some(cached) = cache.get(path) {
+        if let Some(cached) = cache.get(&target_path) {
             return *cached;
         }
     }
 
     // Compute the result
-    let result = if !is_within_git_repo(path) {
+    let result = if !is_within_git_repo(&target_path) {
         false
-    } else if let Some(repo_root) = find_git_repo_root(path) {
+    } else if let Some(repo_root) = find_git_repo_root(&target_path) {
         let mut walker = WalkBuilder::new(&repo_root)
             .git_ignore(true)
             .git_global(false)
             .git_exclude(false)
             .build();
 
-        !walker.any(|entry| entry.map(|e| e.path() == path).unwrap_or(false))
+        !walker.any(|entry| {
+            entry
+                .map(|e| normalize_for_ignore_check(e.path()) == target_path)
+                .unwrap_or(false)
+        })
     } else {
         false
     };
 
     // Store the result in the cache
     let mut cache = GIT_IGNORE_CACHE.lock().unwrap();
-    cache.insert(path.to_path_buf(), result);
+    cache.insert(target_path, result);
 
     result
+}
+
+fn normalize_for_ignore_check(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else if let Ok(cwd) = std::env::current_dir() {
+        cwd.join(path)
+    } else {
+        path.to_path_buf()
+    }
 }
 
 /// Check if a path is within a Git repository
@@ -206,7 +221,7 @@ pub fn discover_files_by_language(
     root_dir: &str,
     parallel: bool,
 ) -> Result<BTreeMap<String, Vec<PathBuf>>> {
-    discover_files_by_language_with_progress(root_dir, parallel, true)
+    discover_files_by_language_with_progress_and_options(root_dir, parallel, true, false)
 }
 
 pub fn discover_files_by_language_with_progress(
@@ -214,12 +229,31 @@ pub fn discover_files_by_language_with_progress(
     parallel: bool,
     show_progress: bool,
 ) -> Result<BTreeMap<String, Vec<PathBuf>>> {
+    discover_files_by_language_with_progress_and_options(root_dir, parallel, show_progress, false)
+}
+
+pub fn discover_files_by_language_with_progress_and_options(
+    root_dir: &str,
+    parallel: bool,
+    show_progress: bool,
+    include_test_fixtures: bool,
+) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     let estimated_languages = crate::config::ScanDefaults::ESTIMATED_LANGUAGES;
 
     if parallel {
-        discover_files_parallel(root_dir, estimated_languages, show_progress)
+        discover_files_parallel(
+            root_dir,
+            estimated_languages,
+            show_progress,
+            include_test_fixtures,
+        )
     } else {
-        discover_files_sequential(root_dir, estimated_languages, show_progress)
+        discover_files_sequential(
+            root_dir,
+            estimated_languages,
+            show_progress,
+            include_test_fixtures,
+        )
     }
 }
 
@@ -228,6 +262,7 @@ fn discover_files_parallel(
     root_dir: &str,
     estimated_languages: usize,
     _show_progress: bool,
+    include_test_fixtures: bool,
 ) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     let all_paths: Vec<PathBuf> = WalkDir::new(root_dir)
         .follow_links(false)
@@ -235,7 +270,7 @@ fn discover_files_parallel(
         .filter_entry(|e| {
             if e.file_type().is_dir() {
                 if let Some(name) = e.file_name().to_str() {
-                    return !SKIP_DIRS.contains(&name);
+                    return !should_skip_dir(name, include_test_fixtures);
                 }
             }
             true
@@ -286,6 +321,7 @@ fn discover_files_sequential(
     root_dir: &str,
     _estimated_languages: usize,
     _show_progress: bool,
+    include_test_fixtures: bool,
 ) -> Result<BTreeMap<String, Vec<PathBuf>>> {
     let mut files_by_language = BTreeMap::new();
 
@@ -295,7 +331,7 @@ fn discover_files_sequential(
         .filter_entry(|e| {
             if e.file_type().is_dir() {
                 if let Some(name) = e.file_name().to_str() {
-                    return !SKIP_DIRS.contains(&name);
+                    return !should_skip_dir(name, include_test_fixtures);
                 }
             }
             true
@@ -341,7 +377,7 @@ pub fn discover_files_by_language_parallel_with_progress(
     root_dir: &str,
     show_progress: bool,
 ) -> Result<BTreeMap<String, Vec<PathBuf>>> {
-    discover_files_by_language_with_progress(root_dir, true, show_progress)
+    discover_files_by_language_with_progress_and_options(root_dir, true, show_progress, false)
 }
 
 /// Sequential file discovery with progress control
@@ -349,7 +385,14 @@ pub fn discover_files_by_language_sequential_with_progress(
     root_dir: &str,
     show_progress: bool,
 ) -> Result<BTreeMap<String, Vec<PathBuf>>> {
-    discover_files_by_language_with_progress(root_dir, false, show_progress)
+    discover_files_by_language_with_progress_and_options(root_dir, false, show_progress, false)
+}
+
+pub fn should_skip_dir(name: &str, include_test_fixtures: bool) -> bool {
+    if include_test_fixtures && (name == "tests" || name == "test") {
+        return false;
+    }
+    SKIP_DIRS.contains(&name)
 }
 
 // =========================================================================

--- a/tests/README.md
+++ b/tests/README.md
@@ -18,6 +18,15 @@ This directory contains all tests for Sighthound, organized into three suites.
 - **end_to_end/**: Full scanner flows
   - `end_to_end_injection_tests.rs`: End-to-end injection detection
 
+- **strictness/**: Boundary and strictness contracts (Tier 1 + Tier 2)
+  - `cross_file_taint.rs`: Phantom flows, config safety, valid chains
+  - `taint_true_negatives.rs` / `taint_true_positives.rs`: Accuracy corpus
+  - `false_positive_regressions.rs`: Documented FP regressions (e.g. cleartext)
+  - `search_conditions.rs`: `shell=True`, Java XSS `Html.escape`
+  - `sanitizer_and_scope.rs`: Sanitizer respect, scope boundaries
+  - `django_security.rs`: Django fixture with production rules
+  - `language_coverage.rs`: PHP taint, Go/Ruby non-secret checks, C# mode parity, fixture-discovery flag
+
 ## Test Fixtures
 
 Sample code and scenarios live under `tests/test_files/`:
@@ -25,6 +34,7 @@ Sample code and scenarios live under `tests/test_files/`:
 - `python/`, `javascript/`, etc. — language-specific fixtures
 - `false_positives/` — patterns that must not be flagged
 - `multi_file_taint_tests/` — cross-file taint scenarios
+- `strictness_languages/` — focused PHP/Go/Ruby/C# strictness fixtures
 
 ## Running Tests
 
@@ -33,5 +43,26 @@ cargo test                       # all suites
 cargo test --test unit_tests
 cargo test --test integration_tests
 cargo test --test end_to_end_tests
+cargo test --test strictness_tests
 cargo test pattern_matching      # filter by test name
 ```
+
+Strictness tests stage fixtures into temp directories with neutral module names
+so the test/migration prefilter does not skip files whose imports contain `test`.
+
+For direct CLI validation against checked-in fixtures under `tests/`, use:
+
+```bash
+sighthound tests <language> <rules_path> --use-file-rules --include-test-fixtures
+```
+
+## Benchmark Gates
+
+```bash
+python3 tests/test_files/multi_file_taint_tests/run_comprehensive_tests.py
+python3 tests/test_files/accuracy_tests/run_accuracy_tests.py
+```
+
+Both benchmark runners stage fixtures into temporary directories, parse the
+scanner's current JSON finding array, and exit non-zero on expectation
+mismatches. The accuracy benchmark reports precision, recall, F1, and accuracy.

--- a/tests/strictness/cross_file_taint.rs
+++ b/tests/strictness/cross_file_taint.rs
@@ -1,0 +1,151 @@
+//! Tier 1: cross-file taint strictness — phantom flows, config safety, valid chains.
+
+use super::helpers::*;
+
+const CMD_TAINT_RULES: &str = "tests/strictness/fixtures/command_injection_taint.ron";
+
+#[test]
+#[cfg(feature = "python")]
+fn phantom_flow_without_import_is_rejected() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category2_invalid/test2_1_module_a.py",
+        "module_a.py",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category2_invalid/test2_1_module_b.py",
+        "module_b.py",
+        &[],
+    );
+
+    let findings = scan_python_taint(staging.path(), CMD_TAINT_RULES);
+    assert_no_cross_file_findings(&findings, "phantom flow (no import between modules)");
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn safe_configuration_patterns_are_not_taint_sources() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category4_config/test4_1_config_manager.py",
+        "config_manager.py",
+        &[("test4_1_config_manager", "config_manager")],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category4_config/test4_1_app_initializer.py",
+        "app_initializer.py",
+        &[("test4_1_config_manager", "config_manager")],
+    );
+
+    let findings = scan_python_taint(staging.path(), CMD_TAINT_RULES);
+    assert!(
+        findings.is_empty(),
+        "os.environ.setdefault configuration should not produce taint findings, got {}: {:?}",
+        findings.len(),
+        findings
+            .iter()
+            .map(|f| (f.file.as_str(), f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn user_controlled_environment_variable_is_detected() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category4_config/test4_2_env_reader.py",
+        "env_reader.py",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category4_config/test4_2_command_executor.py",
+        "command_executor.py",
+        &[("test4_2_env_reader", "env_reader")],
+    );
+
+    let findings = scan_python_taint(staging.path(), CMD_TAINT_RULES);
+    assert_has_cross_file_finding_near(
+        &findings,
+        "command_executor.py",
+        23,
+        3,
+        "user-controlled os.environ.get flow",
+    );
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn direct_import_cross_file_flow_is_detected() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category1_valid/test1_1_source_module.py",
+        "source_module.py",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category1_valid/test1_1_sink_module.py",
+        "sink_module.py",
+        &[("test1_1_source_module", "source_module")],
+    );
+
+    let findings = scan_python_taint(staging.path(), CMD_TAINT_RULES);
+    assert_has_cross_file_finding_near(
+        &findings,
+        "sink_module.py",
+        13,
+        3,
+        "input() -> os.system() via import",
+    );
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn three_file_taint_chain_is_detected() {
+    let staging = stage_dir();
+    let rewrite = &[
+        ("test5_1_user_input", "user_input"),
+        ("test5_1_data_processor", "data_processor"),
+    ];
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category5_complex/test5_1_user_input.py",
+        "user_input.py",
+        rewrite,
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category5_complex/test5_1_data_processor.py",
+        "data_processor.py",
+        rewrite,
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/multi_file_taint_tests/category5_complex/test5_1_command_runner.py",
+        "command_runner.py",
+        rewrite,
+    );
+
+    let findings = scan_python_taint(staging.path(), CMD_TAINT_RULES);
+    assert_has_cross_file_finding_near(
+        &findings,
+        "command_runner.py",
+        15,
+        3,
+        "three-file input -> processor -> os.system chain",
+    );
+}

--- a/tests/strictness/django_security.rs
+++ b/tests/strictness/django_security.rs
@@ -1,0 +1,64 @@
+//! Tier 2: Django fixture scanning with production rules.
+
+use super::helpers::*;
+
+#[test]
+#[cfg(feature = "python")]
+fn django_views_fixture_detects_known_vulnerabilities() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/python/django/django_views.py",
+        "views.py",
+        &[],
+    );
+
+    let findings = scan_python_simple_with_rules(staging.path(), load_production_python_rules());
+    let types: std::collections::BTreeSet<_> =
+        findings.iter().map(|f| f.finding_type.as_str()).collect();
+
+    assert!(
+        types.contains("Code Injection"),
+        "eval(user_code) should be detected, findings: {:?}",
+        findings
+            .iter()
+            .map(|f| (f.line, &f.finding_type))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        types.contains("Unsafe Deserialization"),
+        "pickle.loads(user data) should be detected"
+    );
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn django_escaped_response_is_not_flagged_as_xss() {
+    let staging = stage_dir();
+
+    write_staged_file(
+        staging.path(),
+        "views.py",
+        r#"
+from django.http import HttpResponse
+from django.utils.html import escape
+
+def safe_response(request):
+    user_input = request.GET.get("data", "")
+    return HttpResponse(escape(user_input))
+"#,
+    );
+
+    let findings = scan_python_simple_with_rules(staging.path(), load_production_python_rules());
+    let xss: Vec<_> = findings
+        .iter()
+        .filter(|f| f.finding_type.contains("Scripting") || f.finding_type.contains("XSS"))
+        .collect();
+
+    assert!(
+        xss.is_empty(),
+        "escaped HttpResponse should not produce XSS findings, got {:?}",
+        xss
+    );
+}

--- a/tests/strictness/false_positive_regressions.rs
+++ b/tests/strictness/false_positive_regressions.rs
@@ -1,0 +1,36 @@
+//! Tier 1: documented false-positive regressions must not reappear.
+
+use super::helpers::*;
+
+#[test]
+#[cfg(feature = "javascript")]
+fn cleartext_transmission_regression_fixture() {
+    let staging = stage_dir();
+
+    // Stage under a neutral name so prefilter heuristics do not skip the file.
+    stage_file(
+        staging.path(),
+        "tests/test_files/false_positives/cleartext_transmission_false_positives.js",
+        "cleartext_regression.js",
+        &[],
+    );
+
+    let findings = scan_javascript_frontend_taint(staging.path());
+
+    // TRUE POSITIVES section: lines 39–62 (HTTP + sensitive DOM sources)
+    assert_findings_in_range(
+        &findings,
+        39,
+        62,
+        2,
+        "cleartext regression true-positive section",
+    );
+
+    // FALSE POSITIVES section: library constants, params, THREE.js patterns (line 68+)
+    assert_no_findings_in_range(
+        &findings,
+        68,
+        220,
+        "cleartext regression false-positive section",
+    );
+}

--- a/tests/strictness/fixtures/accuracy_taint.ron
+++ b/tests/strictness/fixtures/accuracy_taint.ron
@@ -1,0 +1,31 @@
+(
+    rules: [
+        (
+            id: Some("strictness-accuracy-taint"),
+            name: Some("Accuracy Taint (strictness fixtures)"),
+            mode: "taint",
+            sources: Some([
+                "input(",
+                "os.environ.get",
+                "os.environ",
+                "sys.argv",
+                "os.getenv",
+                "open(",
+            ]),
+            sinks: Some([
+                "os.system",
+                "eval(",
+                "exec(",
+                "compile(",
+                "subprocess.call",
+                "subprocess.run",
+            ]),
+            finding_type: Some("Command Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            file_types: Some((
+                extensions: Some([".py"])
+            )),
+        ),
+    ]
+)

--- a/tests/strictness/fixtures/command_injection_taint.ron
+++ b/tests/strictness/fixtures/command_injection_taint.ron
@@ -1,0 +1,25 @@
+(
+    rules: [
+        (
+            id: Some("strictness-cmd-taint"),
+            name: Some("Command Injection Taint (strictness fixtures)"),
+            mode: "taint",
+            sources: Some([
+                "input(",
+                "os.environ.get",
+            ]),
+            sinks: Some([
+                "os.system",
+                "eval(",
+                "exec(",
+                "compile(",
+            ]),
+            finding_type: Some("Command Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            file_types: Some((
+                extensions: Some([".py"])
+            )),
+        ),
+    ]
+)

--- a/tests/strictness/fixtures/sanitizer_taint.ron
+++ b/tests/strictness/fixtures/sanitizer_taint.ron
@@ -1,0 +1,24 @@
+(
+    rules: [
+        (
+            id: Some("strictness-sanitizer-taint"),
+            name: Some("Command Injection with Sanitizer (strictness fixtures)"),
+            mode: "taint",
+            sources: Some([
+                "input(",
+            ]),
+            sinks: Some([
+                "os.system",
+            ]),
+            sanitizers: Some([
+                "shlex.quote",
+            ]),
+            finding_type: Some("Command Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            file_types: Some((
+                extensions: Some([".py"])
+            )),
+        ),
+    ]
+)

--- a/tests/strictness/helpers.rs
+++ b/tests/strictness/helpers.rs
@@ -1,0 +1,242 @@
+use sighthound::models::Finding;
+use sighthound::rules::Rules;
+use sighthound::VulnerabilityScanner;
+use std::fs;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+pub fn manifest_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+}
+
+pub fn fixture_path(relative: &str) -> PathBuf {
+    manifest_dir().join(relative)
+}
+
+pub fn load_rules(relative: &str) -> Rules {
+    Rules::load_from_file(fixture_path(relative).to_str().unwrap())
+        .unwrap_or_else(|e| panic!("failed to load rules {}: {e}", relative))
+}
+
+pub fn load_production_python_rules() -> Rules {
+    Rules::load_from_directory("rules/python/").expect("failed to load production python rules")
+}
+
+#[cfg(feature = "javascript")]
+pub fn load_production_javascript_rules() -> Rules {
+    Rules::load_from_directory("rules/javascript/")
+        .expect("failed to load production javascript rules")
+}
+
+pub fn stage_dir() -> TempDir {
+    TempDir::new().expect("failed to create temp directory")
+}
+
+/// Copy a fixture file into a staging directory, optionally rewriting content.
+pub fn stage_file(
+    staging: &Path,
+    source_relative: &str,
+    dest_name: &str,
+    replacements: &[(&str, &str)],
+) -> PathBuf {
+    let source = fixture_path(source_relative);
+    let mut content = fs::read_to_string(&source)
+        .unwrap_or_else(|e| panic!("failed to read {}: {e}", source.display()));
+    for (from, to) in replacements {
+        content = content.replace(from, to);
+    }
+    let dest = staging.join(dest_name);
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).ok();
+    }
+    fs::write(&dest, content).expect("failed to write staged file");
+    dest
+}
+
+pub fn write_staged_file(staging: &Path, name: &str, content: &str) -> PathBuf {
+    let dest = staging.join(name);
+    if let Some(parent) = dest.parent() {
+        fs::create_dir_all(parent).ok();
+    }
+    fs::write(&dest, content).expect("failed to write staged file");
+    dest
+}
+
+pub fn scan_python_taint_with_rules(staging: &Path, rules: Rules) -> Vec<Finding> {
+    let scanner = VulnerabilityScanner::new("python", rules).expect("failed to create scanner");
+    let findings = scanner
+        .find_vulnerabilities_unified(staging.to_str().unwrap(), "python", false)
+        .expect("scan failed");
+    taint_findings(&findings)
+}
+
+pub fn scan_python_taint(staging: &Path, rules_relative: &str) -> Vec<Finding> {
+    scan_python_taint_with_rules(staging, load_rules(rules_relative))
+}
+
+pub fn scan_python_simple_with_rules(staging: &Path, rules: Rules) -> Vec<Finding> {
+    let scanner = VulnerabilityScanner::new("python", rules).expect("failed to create scanner");
+    scanner
+        .find_vulnerabilities_single_threaded(staging.to_str().unwrap(), "python")
+        .expect("scan failed")
+}
+
+pub fn scan_language_simple_with_rules(
+    staging: &Path,
+    language: &str,
+    rules: Rules,
+) -> Vec<Finding> {
+    let scanner = VulnerabilityScanner::new(language, rules).expect("failed to create scanner");
+    scanner
+        .find_vulnerabilities_single_threaded(staging.to_str().unwrap(), language)
+        .expect("scan failed")
+}
+
+pub fn scan_language_unified_with_rules(
+    staging: &Path,
+    language: &str,
+    rules: Rules,
+) -> Vec<Finding> {
+    let scanner = VulnerabilityScanner::new(language, rules).expect("failed to create scanner");
+    scanner
+        .find_vulnerabilities_unified(staging.to_str().unwrap(), language, false)
+        .expect("scan failed")
+}
+
+#[cfg(feature = "javascript")]
+pub fn scan_javascript_frontend_taint_with_rules(staging: &Path, rules: Rules) -> Vec<Finding> {
+    let scanner = VulnerabilityScanner::new("javascript", rules).expect("failed to create scanner");
+    let findings = scanner
+        .find_vulnerabilities_unified_with_filters(
+            staging.to_str().unwrap(),
+            "javascript",
+            false,
+            Some("frontend"),
+            None,
+        )
+        .expect("scan failed");
+    taint_findings(&findings)
+}
+
+#[cfg(feature = "javascript")]
+pub fn scan_javascript_frontend_taint(staging: &Path) -> Vec<Finding> {
+    scan_javascript_frontend_taint_with_rules(staging, load_production_javascript_rules())
+}
+
+#[cfg(feature = "java")]
+pub fn scan_java_simple_with_rules(staging: &Path, rules: Rules) -> Vec<Finding> {
+    let scanner = VulnerabilityScanner::new("java", rules).expect("failed to create scanner");
+    scanner
+        .find_vulnerabilities_single_threaded(staging.to_str().unwrap(), "java")
+        .expect("scan failed")
+}
+
+pub fn taint_findings(findings: &[Finding]) -> Vec<Finding> {
+    findings
+        .iter()
+        .filter(|f| {
+            f.tags
+                .as_ref()
+                .is_some_and(|tags| tags.iter().any(|t| t == "taint_analysis"))
+        })
+        .cloned()
+        .collect()
+}
+
+pub fn cross_file_findings(findings: &[Finding]) -> Vec<&Finding> {
+    findings
+        .iter()
+        .filter(|f| {
+            f.tags
+                .as_ref()
+                .is_some_and(|tags| tags.iter().any(|t| t == "cross_file"))
+        })
+        .collect()
+}
+
+pub fn findings_in_file<'a>(findings: &'a [Finding], filename: &str) -> Vec<&'a Finding> {
+    findings
+        .iter()
+        .filter(|f| f.file.ends_with(filename))
+        .collect()
+}
+
+pub fn findings_in_line_range(
+    findings: &[Finding],
+    min_line: usize,
+    max_line: usize,
+) -> Vec<&Finding> {
+    findings
+        .iter()
+        .filter(|f| f.line >= min_line && f.line <= max_line)
+        .collect()
+}
+
+pub fn assert_no_findings_in_range(
+    findings: &[Finding],
+    min_line: usize,
+    max_line: usize,
+    context: &str,
+) {
+    let hits = findings_in_line_range(findings, min_line, max_line);
+    assert!(
+        hits.is_empty(),
+        "{context}: expected no findings between lines {min_line}-{max_line}, got {}: {:?}",
+        hits.len(),
+        hits.iter()
+            .map(|f| (f.line, &f.finding_type, &f.file))
+            .collect::<Vec<_>>()
+    );
+}
+
+pub fn assert_findings_in_range(
+    findings: &[Finding],
+    min_line: usize,
+    max_line: usize,
+    min_count: usize,
+    context: &str,
+) {
+    let hits = findings_in_line_range(findings, min_line, max_line);
+    assert!(
+        hits.len() >= min_count,
+        "{context}: expected at least {min_count} findings between lines {min_line}-{max_line}, got {}: {:?}",
+        hits.len(),
+        hits.iter()
+            .map(|f| (f.line, &f.finding_type))
+            .collect::<Vec<_>>()
+    );
+}
+
+pub fn assert_no_cross_file_findings(findings: &[Finding], context: &str) {
+    let hits = cross_file_findings(findings);
+    assert!(
+        hits.is_empty(),
+        "{context}: expected no cross-file taint findings, got {}: {:?}",
+        hits.len(),
+        hits.iter()
+            .map(|f| (f.file.as_str(), f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+pub fn assert_has_cross_file_finding_near(
+    findings: &[Finding],
+    filename: &str,
+    line: usize,
+    tolerance: usize,
+    context: &str,
+) {
+    let hits: Vec<_> = cross_file_findings(findings)
+        .into_iter()
+        .filter(|f| f.file.ends_with(filename))
+        .filter(|f| f.line.abs_diff(line) <= tolerance)
+        .collect();
+    assert!(
+        !hits.is_empty(),
+        "{context}: expected cross-file finding in {filename} near line {line} (±{tolerance}), got: {:?}",
+        cross_file_findings(findings)
+            .iter()
+            .map(|f| (f.file.as_str(), f.line))
+            .collect::<Vec<_>>()
+    );
+}

--- a/tests/strictness/language_coverage.rs
+++ b/tests/strictness/language_coverage.rs
@@ -1,0 +1,289 @@
+//! Tier 2: language-focused strictness checks for scanner robustness.
+
+use super::helpers::*;
+use serde_json::Value;
+use sighthound::rules::Rules;
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use std::process::Command;
+
+#[cfg(feature = "php")]
+#[test]
+fn php_taint_detects_unsafe_and_skips_sanitized_variants() {
+    let staging = stage_dir();
+    stage_file(
+        staging.path(),
+        "tests/test_files/strictness_languages/php/unsafe.php",
+        "php_case_unsafe.php",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/strictness_languages/php/safe.php",
+        "php_case_safe.php",
+        &[],
+    );
+
+    let rules =
+        Rules::load_from_file("rules/php/taint.ron").expect("failed to load php taint rule");
+    let findings = scan_language_unified_with_rules(staging.path(), "php", rules);
+
+    let unsafe_findings = findings_in_file(&findings, "php_case_unsafe.php");
+    let safe_findings = findings_in_file(&findings, "php_case_safe.php");
+
+    assert!(
+        unsafe_findings.len() >= 2,
+        "unsafe.php should trigger taint findings, got {}: {:?}",
+        unsafe_findings.len(),
+        unsafe_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str(), f.snippet.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        safe_findings.is_empty(),
+        "safe.php should be clean under taint sanitizers, got {}: {:?}",
+        safe_findings.len(),
+        safe_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str(), f.snippet.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[cfg(feature = "go")]
+#[test]
+fn go_rules_detect_unsafe_patterns_without_secret_findings() {
+    let staging = stage_dir();
+    stage_file(
+        staging.path(),
+        "tests/test_files/strictness_languages/go/unsafe.go",
+        "go_case_unsafe.go",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/strictness_languages/go/safe.go",
+        "go_case_safe.go",
+        &[],
+    );
+
+    let rules = Rules::load_from_directory("rules/go/").expect("failed to load go rules");
+    let findings = scan_language_simple_with_rules(staging.path(), "go", rules);
+
+    let unsafe_findings = findings_in_file(&findings, "go_case_unsafe.go");
+    let safe_findings = findings_in_file(&findings, "go_case_safe.go");
+
+    assert!(
+        unsafe_findings.len() >= 2,
+        "unsafe.go should trigger command/sql findings, got {}: {:?}",
+        unsafe_findings.len(),
+        unsafe_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        safe_findings.is_empty(),
+        "safe.go should be clean, got {}: {:?}",
+        safe_findings.len(),
+        safe_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str(), f.snippet.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|f| !f.finding_type.to_ascii_lowercase().contains("secret")),
+        "go findings should not include hardcoded-secret types: {:?}",
+        findings
+            .iter()
+            .map(|f| (f.file.as_str(), f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[cfg(feature = "ruby")]
+#[test]
+fn ruby_rules_detect_unsafe_patterns_without_secret_findings() {
+    let staging = stage_dir();
+    stage_file(
+        staging.path(),
+        "tests/test_files/strictness_languages/ruby/unsafe.rb",
+        "ruby_case_unsafe.rb",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/strictness_languages/ruby/safe.rb",
+        "ruby_case_safe.rb",
+        &[],
+    );
+
+    let rules = Rules::load_from_directory("rules/ruby/").expect("failed to load ruby rules");
+    let findings = scan_language_simple_with_rules(staging.path(), "ruby", rules);
+
+    let unsafe_findings = findings_in_file(&findings, "ruby_case_unsafe.rb");
+    let safe_findings = findings_in_file(&findings, "ruby_case_safe.rb");
+
+    assert!(
+        unsafe_findings.len() >= 2,
+        "unsafe.rb should trigger command/sql findings, got {}: {:?}",
+        unsafe_findings.len(),
+        unsafe_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        safe_findings.is_empty(),
+        "safe.rb should be clean, got {}: {:?}",
+        safe_findings.len(),
+        safe_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str(), f.snippet.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        findings
+            .iter()
+            .all(|f| !f.finding_type.to_ascii_lowercase().contains("secret")),
+        "ruby findings should not include hardcoded-secret types: {:?}",
+        findings
+            .iter()
+            .map(|f| (f.file.as_str(), f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[cfg(feature = "csharp")]
+#[test]
+fn csharp_explicit_and_filtered_cli_results_match() {
+    let staging = stage_dir();
+    stage_file(
+        staging.path(),
+        "tests/test_files/strictness_languages/csharp/parity.cs",
+        "parity.cs",
+        &[],
+    );
+    let root = staging.path().to_str().unwrap();
+
+    let explicit = run_cli_json(&[
+        root,
+        "csharp",
+        "rules/csharp",
+        "--use-file-rules",
+        "--output-format",
+        "json",
+    ]);
+    let filtered = run_cli_json(&[
+        root,
+        "--language-filter",
+        "csharp",
+        "--use-file-rules",
+        "--rules-dir",
+        "rules",
+        "--output-format",
+        "json",
+    ]);
+
+    assert!(
+        !explicit.is_empty(),
+        "explicit csharp scan should produce at least one finding"
+    );
+
+    assert_eq!(
+        finding_key_set(&explicit),
+        finding_key_set(&filtered),
+        "explicit and --language-filter csharp findings diverged"
+    );
+}
+
+#[cfg(feature = "go")]
+#[test]
+fn include_test_fixtures_flag_enables_scanning_tests_directory() {
+    let without_flag = run_cli_json(&[
+        "tests",
+        "go",
+        "rules/go",
+        "--use-file-rules",
+        "--simple-analysis",
+        "--output-format",
+        "json",
+    ]);
+    assert!(
+        without_flag.is_empty(),
+        "without --include-test-fixtures, tests/ should remain skipped, got {:?}",
+        without_flag
+    );
+
+    let with_flag = run_cli_json(&[
+        "tests",
+        "go",
+        "rules/go",
+        "--use-file-rules",
+        "--simple-analysis",
+        "--include-test-fixtures",
+        "--output-format",
+        "json",
+    ]);
+    assert!(
+        !with_flag.is_empty(),
+        "with --include-test-fixtures, tests/ fixtures should be scanned"
+    );
+    assert!(
+        with_flag.iter().any(|f| {
+            f["file"]
+                .as_str()
+                .is_some_and(|path| path.contains("strictness_languages/go/unsafe.go"))
+        }),
+        "expected finding from strictness go fixture, got: {:?}",
+        with_flag
+    );
+}
+
+fn run_cli_json(args: &[&str]) -> Vec<Value> {
+    let output = Command::new(sighthound_binary())
+        .args(args)
+        .output()
+        .expect("failed to run sighthound binary");
+    assert!(
+        output.status.success(),
+        "sighthound failed with status {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    match serde_json::from_slice(&output.stdout) {
+        Ok(findings) => findings,
+        Err(_) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.trim().is_empty() || stdout.trim_start().starts_with("No ") {
+                Vec::new()
+            } else {
+                panic!("failed to parse scanner JSON output: {stdout}");
+            }
+        }
+    }
+}
+
+fn sighthound_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_sighthound") {
+        return PathBuf::from(path);
+    }
+    fixture_path("target/debug/sighthound")
+}
+
+fn finding_key_set(findings: &[Value]) -> BTreeSet<(String, u64, String, String)> {
+    findings
+        .iter()
+        .map(|f| {
+            (
+                f["file"].as_str().unwrap_or("").to_string(),
+                f["line"].as_u64().unwrap_or(0),
+                f["finding_type"].as_str().unwrap_or("").to_string(),
+                f["snippet"].as_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect()
+}

--- a/tests/strictness/main.rs
+++ b/tests/strictness/main.rs
@@ -1,0 +1,16 @@
+//! Strictness boundary tests — real-world scenarios that must not cross normal limits.
+//!
+//! Fixtures under `tests/test_files/` are staged into temp directories with neutral
+//! module names so the test/migration prefilter (which keys off import text containing
+//! "test") does not exclude them.
+
+mod helpers;
+
+mod cross_file_taint;
+mod django_security;
+mod false_positive_regressions;
+mod language_coverage;
+mod sanitizer_and_scope;
+mod search_conditions;
+mod taint_true_negatives;
+mod taint_true_positives;

--- a/tests/strictness/sanitizer_and_scope.rs
+++ b/tests/strictness/sanitizer_and_scope.rs
@@ -1,0 +1,114 @@
+//! Tier 2: sanitizer respect and single-file scope boundaries.
+
+use super::helpers::*;
+
+const SANITIZER_RULES: &str = "tests/strictness/fixtures/sanitizer_taint.ron";
+const ACCURACY_TAINT_RULES: &str = "tests/strictness/fixtures/accuracy_taint.ron";
+
+#[test]
+#[cfg(feature = "python")]
+fn shlex_quote_sanitizer_suppresses_taint_finding() {
+    let staging_safe = stage_dir();
+    write_staged_file(
+        staging_safe.path(),
+        "app.py",
+        r#"
+import os
+import shlex
+user = input("prompt")
+os.system(shlex.quote(user))
+"#,
+    );
+    let staging_unsafe = stage_dir();
+    write_staged_file(
+        staging_unsafe.path(),
+        "app.py",
+        r#"
+import os
+user = input("prompt")
+os.system(user)
+"#,
+    );
+
+    let safe_findings = scan_python_taint(staging_safe.path(), SANITIZER_RULES);
+    let unsafe_findings = scan_python_taint(staging_unsafe.path(), SANITIZER_RULES);
+
+    assert!(
+        safe_findings.is_empty(),
+        "shlex.quote in sink should suppress finding, got {:?}",
+        safe_findings
+    );
+    assert_eq!(
+        unsafe_findings.len(),
+        1,
+        "unsanitized os.system(user) should produce exactly one finding, got {:?}",
+        unsafe_findings
+    );
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn same_name_different_scope_does_not_create_false_taint() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/accuracy_tests/edge_cases/tricky_source.py",
+        "edge_source.py",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/accuracy_tests/edge_cases/tricky_sink.py",
+        "edge_sink.py",
+        &[("tricky_source", "edge_source")],
+    );
+
+    let findings = scan_python_taint(staging.path(), ACCURACY_TAINT_RULES);
+
+    // EC9: local_user_data has no connection to imported taint sources.
+    assert_no_findings_in_range(
+        &findings,
+        87,
+        92,
+        "test_false_positive (similar name, no taint connection)",
+    );
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn taint_does_not_leak_across_function_boundaries_in_single_file() {
+    let staging = stage_dir();
+
+    write_staged_file(
+        staging.path(),
+        "app.py",
+        r#"
+import os
+
+def uses_taint():
+    data = os.environ.get("USER_INPUT", "")
+    eval(data)
+
+def uses_safe_name_only():
+    local_user_data = "safe_local_data"
+    eval(local_user_data)
+"#,
+    );
+
+    let findings = scan_python_taint(staging.path(), ACCURACY_TAINT_RULES);
+
+    assert_findings_in_range(
+        &findings,
+        4,
+        7,
+        1,
+        "os.environ.get -> eval in same function",
+    );
+    assert_no_findings_in_range(
+        &findings,
+        9,
+        12,
+        "literal local_user_data eval must not be flagged",
+    );
+}

--- a/tests/strictness/search_conditions.rs
+++ b/tests/strictness/search_conditions.rs
@@ -1,0 +1,93 @@
+//! Tier 2: search-mode condition strictness (subprocess shell=True, Java XSS escaping).
+
+use super::helpers::*;
+use sighthound::rules::Rules;
+
+#[test]
+#[cfg(feature = "python")]
+fn subprocess_without_shell_true_is_not_flagged() {
+    let staging = stage_dir();
+
+    write_staged_file(
+        staging.path(),
+        "app.py",
+        r#"
+import subprocess
+
+def safe_list_arg(user_input):
+    subprocess.run(["ls", user_input])
+
+def safe_no_shell(user_input):
+    subprocess.Popen(["echo", user_input], shell=False)
+
+def unsafe_shell(user_input):
+    subprocess.Popen(user_input, shell=True)
+
+def safe_literal():
+    subprocess.Popen(["echo", "hi"])
+"#,
+    );
+
+    let findings = scan_python_simple_with_rules(staging.path(), load_production_python_rules());
+    let cmd_findings: Vec<_> = findings
+        .iter()
+        .filter(|f| f.finding_type.contains("Command Injection"))
+        .collect();
+
+    assert_eq!(
+        cmd_findings.len(),
+        1,
+        "only shell=True subprocess should be flagged, got: {:?}",
+        cmd_findings
+            .iter()
+            .map(|f| (f.line, f.snippet.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        cmd_findings[0].line, 11,
+        "unsafe_shell should be on line 11"
+    );
+}
+
+#[test]
+#[cfg(feature = "java")]
+fn java_xss_html_escape_suppresses_finding() {
+    let rules = Rules::load_from_file("rules/java/xss.ron").expect("load java xss rules");
+    let staging = stage_dir();
+
+    write_staged_file(
+        staging.path(),
+        "src/views/UserView.java",
+        r#"
+public class UserView {
+    public void renderUnsafe(String userInput, StringBuilder sb) {
+        sb.append(userInput);
+    }
+
+    public void renderSafe(String userInput, StringBuilder sb) {
+        sb.append(Html.escape(userInput));
+    }
+
+    public void renderLiteral(StringBuilder sb) {
+        sb.append("<div>static</div>");
+    }
+}
+"#,
+    );
+
+    let findings = scan_java_simple_with_rules(staging.path(), rules);
+    let xss: Vec<_> = findings
+        .iter()
+        .filter(|f| f.finding_type.contains("Cross-Site Scripting"))
+        .collect();
+
+    assert_eq!(
+        xss.len(),
+        1,
+        "only unescaped dynamic append should be flagged, got: {:?}",
+        xss.iter()
+            .map(|f| (f.line, f.snippet.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(xss[0].line, 4, "unsafe append should be on line 4");
+}

--- a/tests/strictness/taint_true_negatives.rs
+++ b/tests/strictness/taint_true_negatives.rs
@@ -1,0 +1,37 @@
+//! Tier 1: safe cross-file sources must stay silent under taint analysis.
+
+use super::helpers::*;
+
+const ACCURACY_TAINT_RULES: &str = "tests/strictness/fixtures/accuracy_taint.ron";
+
+#[test]
+#[cfg(feature = "python")]
+fn safe_cross_file_sources_produce_no_taint_findings() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/accuracy_tests/true_negatives/safe_source.py",
+        "safe_source.py",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/accuracy_tests/true_negatives/safe_sink.py",
+        "safe_sink.py",
+        &[],
+    );
+
+    let findings = scan_python_taint(staging.path(), ACCURACY_TAINT_RULES);
+    let sink_findings = findings_in_file(&findings, "safe_sink.py");
+
+    assert!(
+        sink_findings.is_empty(),
+        "safe_sink.py should have zero taint findings (10 labeled safe functions), got {}: {:?}",
+        sink_findings.len(),
+        sink_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str(), f.snippet.as_str()))
+            .collect::<Vec<_>>()
+    );
+}

--- a/tests/strictness/taint_true_positives.rs
+++ b/tests/strictness/taint_true_positives.rs
@@ -1,0 +1,69 @@
+//! Tier 1: verified cross-file taint chains must be reported.
+
+use super::helpers::*;
+
+const ACCURACY_TAINT_RULES: &str = "tests/strictness/fixtures/accuracy_taint.ron";
+
+#[test]
+#[cfg(feature = "python")]
+fn cross_file_accuracy_fixtures_report_real_vulnerabilities() {
+    let staging = stage_dir();
+
+    for name in ["module_a.py", "module_b.py", "module_c.py"] {
+        stage_file(
+            staging.path(),
+            &format!("tests/test_files/accuracy_tests/cross_file/{name}"),
+            name,
+            &[],
+        );
+    }
+
+    let findings = scan_python_taint(staging.path(), ACCURACY_TAINT_RULES);
+    let cross = cross_file_findings(&findings);
+    let module_c: Vec<_> = cross
+        .into_iter()
+        .filter(|f| f.file.ends_with("module_c.py"))
+        .collect();
+
+    assert!(
+        module_c.len() >= 4,
+        "cross_file/module_c.py should have multiple cross-file command-injection flows, got {}: {:?}",
+        module_c.len(),
+        module_c
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+#[cfg(feature = "python")]
+fn true_positive_cross_file_sinks_are_detected() {
+    let staging = stage_dir();
+
+    stage_file(
+        staging.path(),
+        "tests/test_files/accuracy_tests/true_positives/source.py",
+        "source.py",
+        &[],
+    );
+    stage_file(
+        staging.path(),
+        "tests/test_files/accuracy_tests/true_positives/sink.py",
+        "sink.py",
+        &[],
+    );
+
+    let findings = scan_python_taint(staging.path(), ACCURACY_TAINT_RULES);
+    let sink_findings = findings_in_file(&findings, "sink.py");
+
+    assert!(
+        sink_findings.len() >= 4,
+        "true_positives/sink.py should report multiple cross-file flows, got {}: {:?}",
+        sink_findings.len(),
+        sink_findings
+            .iter()
+            .map(|f| (f.line, f.finding_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+}

--- a/tests/test_files/accuracy_tests/run_accuracy_tests.py
+++ b/tests/test_files/accuracy_tests/run_accuracy_tests.py
@@ -1,334 +1,292 @@
 #!/usr/bin/env python3
-"""
-Accuracy Test Runner - Comprehensive analysis of taint analysis accuracy
-"""
+"""Accuracy benchmark for taint analysis strictness."""
 
-import subprocess
+from __future__ import annotations
+
 import json
-import os
+import re
+import subprocess
 import sys
-from typing import Dict, List, Set, Tuple
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
 
 
-class AccuracyTestRunner:
-    def __init__(self):
-        self.test_results = {}
-        self.expected_detections = {}
-        self.setup_expected_results()
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = Path(__file__).resolve().parent
+RULES_PATH = "tests/strictness/fixtures/accuracy_taint.ron"
 
-    def setup_expected_results(self):
-        """Define expected detection results for each test case"""
+REPLACEMENTS: dict[str, list[tuple[str, str]]] = {
+    "edge_cases": [("get_comment_test", "get_comment_case")],
+}
 
-        # TRUE POSITIVES: Should detect these vulnerabilities
-        self.expected_detections["true_positives"] = {
-            "should_detect": {
-                "sink.py": [
-                    "vulnerable_eval",  # TP1: Cross-file eval
-                    "vulnerable_exec",  # TP2: Cross-file exec
-                    "vulnerable_system",  # TP3: Cross-file system
-                    "vulnerable_compile",  # TP4: Cross-file compile
-                    "vulnerable_chain",  # TP5: Chained cross-file
-                    "vulnerable_processed",  # TP6: Processed cross-file
-                    "vulnerable_multiple",  # TP7: Multiple sources
-                    "vulnerable_assignment",  # TP8: Local assignment with cross-file
-                ]
-            },
-            "should_not_detect": {},
-        }
 
-        # TRUE NEGATIVES: Should NOT detect these (safe code)
-        self.expected_detections["true_negatives"] = {
-            "should_detect": {},
-            "should_not_detect": {
-                "safe_sink.py": [
-                    "safe_eval_constant",  # TN1: Safe constant
-                    "safe_exec_computed",  # TN2: Safe computed
-                    "safe_system_version",  # TN3: Safe version
-                    "safe_compile_version",  # TN4: Safe Python version
-                    "safe_eval_hash",  # TN5: Safe hash
-                    "safe_template_usage",  # TN6: Safe template
-                    "safe_app_config",  # TN7: Safe app config
-                    "safe_validated",  # TN8: Safe validated
-                    "safe_literals",  # TN9: Safe literals
-                    "safe_no_input",  # TN10: No user input
-                ]
-            },
-        }
+EXPECTED: dict[str, dict[str, dict[str, list[str]]]] = {
+    "true_positives": {
+        "should_detect": {
+            "sink.py": [
+                "vulnerable_eval",
+                "vulnerable_exec",
+                "vulnerable_system",
+                "vulnerable_compile",
+                "vulnerable_chain",
+                "vulnerable_processed",
+                "vulnerable_multiple",
+                "vulnerable_assignment",
+            ]
+        },
+        "should_not_detect": {},
+    },
+    "true_negatives": {
+        "should_detect": {},
+        "should_not_detect": {
+            "safe_sink.py": [
+                "safe_eval_constant",
+                "safe_exec_computed",
+                "safe_system_version",
+                "safe_compile_version",
+                "safe_eval_hash",
+                "safe_template_usage",
+                "safe_app_config",
+                "safe_validated",
+                "safe_literals",
+                "safe_no_input",
+            ]
+        },
+    },
+    "edge_cases": {
+        "should_detect": {
+            "tricky_sink.py": [
+                "test_variable_scope",
+                "test_conditional",
+                "test_nested",
+                "test_multi_return",
+                "test_reassignment",
+                "test_mixed",
+                "test_aliasing",
+                "test_assignment_chain",
+            ]
+        },
+        "should_not_detect": {
+            "tricky_sink.py": [
+                "test_comments",
+                "test_false_positive",
+                "test_string_literals",
+                "test_name_confusion",
+            ]
+        },
+    },
+    "cross_file": {
+        "should_detect": {
+            "module_c.py": [
+                "test_direct_a_to_c",
+                "test_a_to_b_to_c",
+                "test_combined_sources",
+                "test_class_taint",
+                "test_mixed_flow",
+                "test_local_b_taint",
+                "test_complex_chain",
+                "test_class_instance",
+                "test_multiple_hops",
+                "test_subprocess_taint",
+                "test_multi_import",
+            ]
+        },
+        "should_not_detect": {
+            "module_c.py": [
+                "test_safe_flow",
+                "test_safe_direct",
+                "test_false_positive",
+                "test_string_literals",
+            ]
+        },
+    },
+}
 
-        # EDGE CASES: Complex scenarios
-        self.expected_detections["edge_cases"] = {
-            "should_detect": {
-                "tricky_sink.py": [
-                    "test_variable_scope",  # EC1: Tainted user_data
-                    "test_conditional",  # EC2: Conditional taint
-                    "test_nested",  # EC3: Nested taint
-                    "test_multi_return",  # EC4: Multi return paths
-                    "test_reassignment",  # EC5: Reassigned tainted
-                    "test_mixed",  # EC6: Mixed data
-                    "test_aliasing",  # EC8: Aliased taint
-                    "test_assignment_chain",  # EC12: Assignment chain
-                ]
-            },
-            "should_not_detect": {
-                "tricky_sink.py": [
-                    "test_comments",  # EC7: Comments shouldn't confuse
-                    "test_false_positive",  # EC9: No actual connection
-                    "test_string_literals",  # EC10: String literals
-                    "test_name_confusion",  # EC11: Variable name confusion
-                ]
-            },
-        }
 
-        # CROSS-FILE: Complex multi-file scenarios
-        self.expected_detections["cross_file"] = {
-            "should_detect": {
-                "module_c.py": [
-                    "test_direct_a_to_c",  # CF-C1: Direct A->C
-                    "test_a_to_b_to_c",  # CF-C2: A->B->C
-                    "test_combined_sources",  # CF-C3: Combined sources
-                    "test_class_taint",  # CF-C4: Class-based
-                    "test_mixed_flow",  # CF-C6: Mixed safe/tainted
-                    "test_local_b_taint",  # CF-C7: Local B taint
-                    "test_complex_chain",  # CF-C8: Complex chain
-                    "test_class_instance",  # CF-C9: Class instance
-                    "test_multiple_hops",  # CF-C10: Multiple hops
-                    "test_subprocess_taint",  # CF-C14: Subprocess
-                    "test_multi_import",  # CF-C15: Multi-import
-                ]
-            },
-            "should_not_detect": {
-                "module_c.py": [
-                    "test_safe_flow",  # CF-C5: Safe data flow
-                    "test_safe_direct",  # CF-C11: Safe direct from A
-                    "test_false_positive",  # CF-C12: No connection
-                    "test_string_literals",  # CF-C13: String literals
-                ]
-            },
-        }
+def parse_functions(file_path: Path) -> list[tuple[int, str]]:
+    functions: list[tuple[int, str]] = []
+    for line_number, line in enumerate(file_path.read_text().splitlines(), start=1):
+        match = re.match(r"\s*def\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(", line)
+        if match:
+            functions.append((line_number, match.group(1)))
+    return functions
 
-    def run_test_suite(self, test_dir: str) -> Dict:
-        """Run taint analysis on a test directory"""
-        print(f"\n🧪 Running accuracy tests on: {test_dir}")
 
+def function_for_line(functions: list[tuple[int, str]], line: int) -> str | None:
+    current: str | None = None
+    for function_line, name in functions:
+        if function_line <= line:
+            current = name
+        else:
+            break
+    return current
+
+
+def stage_category(category: str, temp_path: Path) -> dict[str, list[tuple[int, str]]]:
+    function_maps: dict[str, list[tuple[int, str]]] = {}
+    replacements = REPLACEMENTS.get(category, [])
+    for source in (FIXTURE_ROOT / category).glob("*.py"):
+        dest = temp_path / source.name
+        content = source.read_text()
+        for old, new in replacements:
+            content = content.replace(old, new)
+        dest.write_text(content)
+        function_maps[source.name] = parse_functions(dest)
+    return function_maps
+
+
+def parse_findings(output: str) -> list[dict[str, Any]]:
+    output = output.strip()
+    if not output:
+        return []
+    parsed = json.loads(output)
+    if not isinstance(parsed, list):
+        raise ValueError("expected scanner JSON output to be a list of findings")
+    return parsed
+
+
+def run_category(category: str) -> tuple[set[str], float]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        function_maps = stage_category(category, temp_path)
         cmd = [
             "cargo",
             "run",
+            "--quiet",
             "--",
+            str(temp_path),
+            "python",
+            RULES_PATH,
+            "--use-file-rules",
             "--taint-analysis",
             "--output-format",
             "json",
-            f"tests/test_files/accuracy_tests/{test_dir}",
-            "python",
-            "rules/python/general_security.ron",
         ]
-
-        try:
-            result = subprocess.run(cmd, capture_output=True, text=True, cwd="../..")
-            if result.returncode != 0:
-                print(f"❌ Error running test: {result.stderr}")
-                return {"vulnerabilities": []}
-
-            # Parse JSON output - find the JSON structure
-            output = result.stdout.strip()
-
-            # Look for the JSON structure (starts with { and contains flows)
-            json_start = output.find("{")
-            if json_start != -1:
-                json_content = output[json_start:]
-                # Clean up any trailing non-JSON content
-                json_end = json_content.rfind("}")
-                if json_end != -1:
-                    json_line = json_content[: json_end + 1]
-                else:
-                    json_line = None
-            else:
-                json_line = None
-
-            if json_line:
-                return json.loads(json_line)
-            else:
-                print(f"❌ No JSON output found")
-                return {"flows": []}
-
-        except Exception as e:
-            print(f"❌ Exception running test: {e}")
-            return {"flows": []}
-
-    def analyze_results(self, test_category: str, results: Dict) -> Dict:
-        """Analyze test results for accuracy"""
-        print(f"\n📊 Analyzing {test_category} results...")
-
-        expected = self.expected_detections.get(test_category, {})
-        should_detect = expected.get("should_detect", {})
-        should_not_detect = expected.get("should_not_detect", {})
-
-        # Extract detected vulnerabilities
-        detected_vulns = set()
-        flows = results.get("flows", [])
-
-        for flow in flows:
-            # Extract sink information from taint flow
-            if "sink" in flow:
-                sink = flow["sink"]
-                sink_file = os.path.basename(sink.get("file", ""))
-                sink_function = sink.get("function", "")
-                detected_vulns.add(f"{sink_file}:{sink_function}")
-
-        print(f"   Detected {len(detected_vulns)} total vulnerabilities")
-
-        # Analyze true positives
-        true_positives = 0
-        false_negatives = 0
-
-        for file, functions in should_detect.items():
-            for func in functions:
-                detection_key = f"{file}:{func}"
-                if any(detection_key in str(vuln) for vuln in detected_vulns):
-                    true_positives += 1
-                    print(f"   ✅ Correctly detected: {func} in {file}")
-                else:
-                    false_negatives += 1
-                    print(f"   ❌ MISSED (False Negative): {func} in {file}")
-
-        # Analyze true negatives
-        true_negatives = 0
-        false_positives = 0
-
-        for file, functions in should_not_detect.items():
-            for func in functions:
-                detection_key = f"{file}:{func}"
-                if any(detection_key in str(vuln) for vuln in detected_vulns):
-                    false_positives += 1
-                    print(
-                        f"   ❌ INCORRECTLY detected (False Positive): {func} in {file}"
-                    )
-                else:
-                    true_negatives += 1
-                    print(f"   ✅ Correctly ignored: {func} in {file}")
-
-        return {
-            "true_positives": true_positives,
-            "false_negatives": false_negatives,
-            "true_negatives": true_negatives,
-            "false_positives": false_positives,
-            "total_detected": len(detected_vulns),
-        }
-
-    def calculate_metrics(self, analysis: Dict) -> Dict:
-        """Calculate accuracy metrics"""
-        tp = analysis["true_positives"]
-        fp = analysis["false_positives"]
-        tn = analysis["true_negatives"]
-        fn = analysis["false_negatives"]
-
-        # Precision = TP / (TP + FP)
-        precision = tp / (tp + fp) if (tp + fp) > 0 else 0
-
-        # Recall = TP / (TP + FN)
-        recall = tp / (tp + fn) if (tp + fn) > 0 else 0
-
-        # F1 Score = 2 * (precision * recall) / (precision + recall)
-        f1_score = (
-            2 * (precision * recall) / (precision + recall)
-            if (precision + recall) > 0
-            else 0
+        start = time.time()
+        result = subprocess.run(
+            cmd,
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=45,
         )
+        elapsed = time.time() - start
 
-        # Accuracy = (TP + TN) / (TP + TN + FP + FN)
-        accuracy = (tp + tn) / (tp + tn + fp + fn) if (tp + tn + fp + fn) > 0 else 0
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"{category} scanner failed with {result.returncode}: {result.stderr}"
+            )
 
-        return {
-            "precision": precision,
-            "recall": recall,
-            "f1_score": f1_score,
-            "accuracy": accuracy,
-        }
+        detected: set[str] = set()
+        for finding in parse_findings(result.stdout):
+            if "taint_analysis" not in finding.get("tags", []):
+                continue
+            file_name = Path(finding.get("file", "")).name
+            line = int(finding.get("line", 0))
+            function = function_for_line(function_maps.get(file_name, []), line)
+            if function:
+                detected.add(f"{file_name}:{function}")
+        return detected, elapsed
 
-    def run_comprehensive_tests(self):
-        """Run all accuracy tests and generate comprehensive report"""
-        print("🚀 Starting Comprehensive Taint Analysis Accuracy Tests")
-        print("=" * 60)
 
-        test_categories = [
-            ("true_positives", "True Positives (Real Vulnerabilities)"),
-            ("true_negatives", "True Negatives (Safe Code)"),
-            ("edge_cases", "Edge Cases (Complex Scenarios)"),
-            ("cross_file", "Cross-File (Multi-Module Flows)"),
-        ]
+def analyze_category(category: str) -> dict[str, int | float]:
+    expected = EXPECTED[category]
+    detected, elapsed = run_category(category)
 
-        overall_results = {
-            "true_positives": 0,
-            "false_negatives": 0,
-            "true_negatives": 0,
-            "false_positives": 0,
-        }
+    tp = fp = tn = fn = 0
+    print(f"\n{category}")
+    print("-" * len(category))
 
-        for test_dir, description in test_categories:
-            print(f"\n{'=' * 20} {description} {'=' * 20}")
+    for file_name, functions in expected["should_detect"].items():
+        for function in functions:
+            key = f"{file_name}:{function}"
+            if key in detected:
+                tp += 1
+                print(f"PASS detect {key}")
+            else:
+                fn += 1
+                print(f"FAIL missed {key}")
 
-            # Run tests
-            results = self.run_test_suite(test_dir)
+    for file_name, functions in expected["should_not_detect"].items():
+        for function in functions:
+            key = f"{file_name}:{function}"
+            if key in detected:
+                fp += 1
+                print(f"FAIL false-positive {key}")
+            else:
+                tn += 1
+                print(f"PASS ignore {key}")
 
-            # Analyze results
-            analysis = self.analyze_results(test_dir, results)
+    expected_keys = {
+        f"{file_name}:{function}"
+        for bucket in ("should_detect", "should_not_detect")
+        for file_name, functions in expected[bucket].items()
+        for function in functions
+    }
+    extra = detected - expected_keys
+    for key in sorted(extra):
+        fp += 1
+        print(f"FAIL unexpected {key}")
 
-            # Calculate metrics
-            metrics = self.calculate_metrics(analysis)
+    return {
+        "true_positives": tp,
+        "false_positives": fp,
+        "true_negatives": tn,
+        "false_negatives": fn,
+        "elapsed": elapsed,
+        "detected": len(detected),
+    }
 
-            # Print metrics
-            print(f"\n📈 {test_dir.upper()} METRICS:")
-            print(f"   Precision: {metrics['precision']:.2%}")
-            print(f"   Recall:    {metrics['recall']:.2%}")
-            print(f"   F1 Score:  {metrics['f1_score']:.2%}")
-            print(f"   Accuracy:  {metrics['accuracy']:.2%}")
 
-            # Add to overall results
-            for key in overall_results:
-                overall_results[key] += analysis[key]
+def ratio(numerator: int, denominator: int) -> float:
+    return numerator / denominator if denominator else 0.0
 
-        # Calculate overall metrics
-        print(f"\n{'=' * 60}")
-        print("🎯 OVERALL ACCURACY RESULTS")
-        print(f"{'=' * 60}")
 
-        overall_metrics = self.calculate_metrics(overall_results)
+def main() -> int:
+    totals = {
+        "true_positives": 0,
+        "false_positives": 0,
+        "true_negatives": 0,
+        "false_negatives": 0,
+    }
+    category_results: dict[str, dict[str, int | float]] = {}
 
-        print(f"True Positives:   {overall_results['true_positives']}")
-        print(f"False Negatives:  {overall_results['false_negatives']}")
-        print(f"True Negatives:   {overall_results['true_negatives']}")
-        print(f"False Positives:  {overall_results['false_positives']}")
-        print()
-        print(f"Overall Precision: {overall_metrics['precision']:.2%}")
-        print(f"Overall Recall:    {overall_metrics['recall']:.2%}")
-        print(f"Overall F1 Score:  {overall_metrics['f1_score']:.2%}")
-        print(f"Overall Accuracy:  {overall_metrics['accuracy']:.2%}")
+    for category in EXPECTED:
+        result = analyze_category(category)
+        category_results[category] = result
+        for key in totals:
+            totals[key] += int(result[key])
 
-        # Quality assessment
-        print(f"\n🏆 QUALITY ASSESSMENT:")
-        if overall_metrics["precision"] >= 0.9:
-            print("✅ EXCELLENT precision - Very low false positive rate")
-        elif overall_metrics["precision"] >= 0.8:
-            print("✅ GOOD precision - Acceptable false positive rate")
-        else:
-            print("❌ POOR precision - High false positive rate")
+    precision = ratio(
+        totals["true_positives"],
+        totals["true_positives"] + totals["false_positives"],
+    )
+    recall = ratio(
+        totals["true_positives"],
+        totals["true_positives"] + totals["false_negatives"],
+    )
+    f1 = ratio(2 * precision * recall, precision + recall)
+    accuracy = ratio(
+        totals["true_positives"] + totals["true_negatives"],
+        sum(totals.values()),
+    )
 
-        if overall_metrics["recall"] >= 0.9:
-            print("✅ EXCELLENT recall - Very low false negative rate")
-        elif overall_metrics["recall"] >= 0.8:
-            print("✅ GOOD recall - Acceptable false negative rate")
-        else:
-            print("❌ POOR recall - High false negative rate")
+    print("\nAccuracy benchmark summary")
+    print("=" * 40)
+    print(f"True positives:  {totals['true_positives']}")
+    print(f"False positives: {totals['false_positives']}")
+    print(f"True negatives:  {totals['true_negatives']}")
+    print(f"False negatives: {totals['false_negatives']}")
+    print(f"Precision:       {precision:.2%}")
+    print(f"Recall:          {recall:.2%}")
+    print(f"F1:              {f1:.2%}")
+    print(f"Accuracy:        {accuracy:.2%}")
 
-        return overall_results, overall_metrics
+    failed = totals["false_positives"] + totals["false_negatives"]
+    return 0 if failed == 0 else 1
 
 
 if __name__ == "__main__":
-    # Change to script directory
-    script_dir = os.path.dirname(os.path.abspath(__file__))
-    os.chdir(script_dir)
-
-    runner = AccuracyTestRunner()
-    results, metrics = runner.run_comprehensive_tests()
-
-    print(f"\n🎉 Accuracy testing complete!")
-    print(f"Overall Score: {metrics['f1_score']:.1%} F1")
+    sys.exit(main())

--- a/tests/test_files/multi_file_taint_tests/run_comprehensive_tests.py
+++ b/tests/test_files/multi_file_taint_tests/run_comprehensive_tests.py
@@ -1,421 +1,207 @@
 #!/usr/bin/env python3
-"""
-Comprehensive Multi-File Taint Analysis Test Runner
+"""Multi-file taint benchmark for strictness regressions."""
 
-This script executes the testing strategy defined in TAINT_TESTING_STRATEGY.md
-and validates that our taint analysis fixes work correctly.
-"""
+from __future__ import annotations
 
-import subprocess
 import json
-import time
-import os
+import subprocess
+import sys
 import tempfile
-import shutil
-from pathlib import Path
+import time
 from dataclasses import dataclass
-from typing import List, Dict, Any
+from pathlib import Path
+from typing import Any
 
 
-@dataclass
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+FIXTURE_ROOT = Path(__file__).resolve().parent
+RULES_PATH = "tests/strictness/fixtures/command_injection_taint.ron"
+
+
+@dataclass(frozen=True)
 class TestCase:
     name: str
     category: str
-    files: List[str]
-    expected_result: str  # "DETECT" or "REJECT"
+    files: list[tuple[str, str]]
+    replacements: list[tuple[str, str]]
+    expected_result: str
     description: str
 
 
-@dataclass
+@dataclass(frozen=True)
 class TestResult:
     test_case: TestCase
     actual_result: str
     execution_time: float
-    details: Dict[str, Any]
+    findings: list[dict[str, Any]]
     is_correct: bool
 
 
-class TaintTestSuite:
-    def __init__(self):
-        self.test_cases = self._define_test_cases()
-        self.results = []
+def test_cases() -> list[TestCase]:
+    return [
+        TestCase(
+            name="test1_1_direct_import_flow",
+            category="valid_flows",
+            files=[
+                ("category1_valid/test1_1_source_module.py", "source_module.py"),
+                ("category1_valid/test1_1_sink_module.py", "sink_module.py"),
+            ],
+            replacements=[("test1_1_source_module", "source_module")],
+            expected_result="DETECT",
+            description="Direct function import flow: input() -> os.system()",
+        ),
+        TestCase(
+            name="test2_1_phantom_no_import",
+            category="phantom_flows",
+            files=[
+                ("category2_invalid/test2_1_module_a.py", "module_a.py"),
+                ("category2_invalid/test2_1_module_b.py", "module_b.py"),
+            ],
+            replacements=[],
+            expected_result="REJECT",
+            description="No import relationship should not create a phantom flow",
+        ),
+        TestCase(
+            name="test4_1_safe_config",
+            category="configuration_safety",
+            files=[
+                ("category4_config/test4_1_config_manager.py", "config_manager.py"),
+                ("category4_config/test4_1_app_initializer.py", "app_initializer.py"),
+            ],
+            replacements=[("test4_1_config_manager", "config_manager")],
+            expected_result="REJECT",
+            description="Configuration defaults should not be taint sources",
+        ),
+        TestCase(
+            name="test4_2_real_env_vuln",
+            category="real_environment_vulnerabilities",
+            files=[
+                ("category4_config/test4_2_env_reader.py", "env_reader.py"),
+                ("category4_config/test4_2_command_executor.py", "command_executor.py"),
+            ],
+            replacements=[("test4_2_env_reader", "env_reader")],
+            expected_result="DETECT",
+            description="User-controlled environment variable reaches command sink",
+        ),
+        TestCase(
+            name="test5_1_three_file_chain",
+            category="complex_chains",
+            files=[
+                ("category5_complex/test5_1_user_input.py", "user_input.py"),
+                ("category5_complex/test5_1_data_processor.py", "data_processor.py"),
+                ("category5_complex/test5_1_command_runner.py", "command_runner.py"),
+            ],
+            replacements=[
+                ("test5_1_user_input", "user_input"),
+                ("test5_1_data_processor", "data_processor"),
+            ],
+            expected_result="DETECT",
+            description="Three-file input -> processor -> os.system chain",
+        ),
+    ]
 
-    def _define_test_cases(self) -> List[TestCase]:
-        """Define all test cases according to the testing strategy"""
-        return [
-            # Category 1: Valid Cross-File Flows (Should DETECT)
-            TestCase(
-                name="test1_1_direct_import_flow",
-                category="Category 1: Valid Flows",
-                files=[
-                    "category1_valid/test1_1_source_module.py",
-                    "category1_valid/test1_1_sink_module.py",
-                ],
-                expected_result="DETECT",
-                description="Direct function import flow: input() -> os.system()",
-            ),
-            # Category 2: Invalid Cross-File Flows (Should REJECT)
-            TestCase(
-                name="test2_1_phantom_no_import",
-                category="Category 2: Phantom Flows",
-                files=[
-                    "category2_invalid/test2_1_module_a.py",
-                    "category2_invalid/test2_1_module_b.py",
-                ],
-                expected_result="REJECT",
-                description="No import relationship - should not create phantom flow",
-            ),
-            # Category 4: Configuration vs Vulnerability
-            TestCase(
-                name="test4_1_safe_config",
-                category="Category 4: Configuration Safety",
-                files=[
-                    "category4_config/test4_1_config_manager.py",
-                    "category4_config/test4_1_app_initializer.py",
-                ],
-                expected_result="REJECT",
-                description="Configuration patterns should not be flagged",
-            ),
-            TestCase(
-                name="test4_2_real_env_vuln",
-                category="Category 4: Real Vulnerabilities",
-                files=[
-                    "category4_config/test4_2_env_reader.py",
-                    "category4_config/test4_2_command_executor.py",
-                ],
-                expected_result="DETECT",
-                description="Real environment variable vulnerability",
-            ),
-            # Category 5: Complex Multi-File Scenarios
-            TestCase(
-                name="test5_1_three_file_chain",
-                category="Category 5: Complex Scenarios",
-                files=[
-                    "category5_complex/test5_1_user_input.py",
-                    "category5_complex/test5_1_data_processor.py",
-                    "category5_complex/test5_1_command_runner.py",
-                ],
-                expected_result="DETECT",
-                description="Three-file chain: input() -> processor -> os.system()",
-            ),
+
+def stage_case(case: TestCase, temp_dir: Path) -> None:
+    for source_rel, dest_name in case.files:
+        content = (FIXTURE_ROOT / source_rel).read_text()
+        for old, new in case.replacements:
+            content = content.replace(old, new)
+        (temp_dir / dest_name).write_text(content)
+
+
+def parse_findings(output: str) -> list[dict[str, Any]]:
+    output = output.strip()
+    if not output:
+        return []
+    parsed = json.loads(output)
+    if not isinstance(parsed, list):
+        raise ValueError("expected scanner JSON output to be a list of findings")
+    return parsed
+
+
+def run_case(case: TestCase) -> TestResult:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        stage_case(case, temp_path)
+
+        cmd = [
+            "cargo",
+            "run",
+            "--quiet",
+            "--",
+            str(temp_path),
+            "python",
+            RULES_PATH,
+            "--use-file-rules",
+            "--taint-analysis",
+            "--output-format",
+            "json",
         ]
 
-    def run_taint_analysis(self, test_files: List[str]) -> Dict[str, Any]:
-        """Run taint analysis on test files and return results"""
+        start = time.time()
+        result = subprocess.run(
+            cmd,
+            cwd=PROJECT_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        elapsed = time.time() - start
 
-        # Create a temporary directory for this specific test
-        with tempfile.TemporaryDirectory() as temp_dir:
-            temp_path = Path(temp_dir)
-            test_dir = Path(__file__).parent
-
-            # Copy only the specific test files to the temporary directory
-            for test_file in test_files:
-                source_file = test_dir / test_file
-
-                # Create subdirectory structure in temp dir
-                dest_file = temp_path / test_file
-                dest_file.parent.mkdir(parents=True, exist_ok=True)
-
-                # Copy the file
-                shutil.copy2(source_file, dest_file)
-
-            # Run taint analysis on the temporary directory
-            cmd = [
-                "cargo",
-                "run",
-                "--",
-                str(
-                    temp_path
-                ),  # Root directory to scan (temp dir with only test files)
-                "--taint-analysis",
-            ]
-
-            start_time = time.time()
-
-            try:
-                # Get the project root directory (where Cargo.toml is located)
-                project_root = Path(__file__).parent.parent.parent
-
-                result = subprocess.run(
-                    cmd,
-                    cwd=str(project_root),  # Run from project root
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                )
-
-                execution_time = time.time() - start_time
-
-                return {
-                    "success": result.returncode == 0,
-                    "stdout": result.stdout,
-                    "stderr": result.stderr,
-                    "execution_time": execution_time,
-                    "return_code": result.returncode,
-                }
-
-            except subprocess.TimeoutExpired:
-                return {
-                    "success": False,
-                    "stdout": "",
-                    "stderr": "Timeout after 30 seconds",
-                    "execution_time": 30.0,
-                    "return_code": -1,
-                }
-            except Exception as e:
-                return {
-                    "success": False,
-                    "stdout": "",
-                    "stderr": f"Error: {str(e)}",
-                    "execution_time": time.time() - start_time,
-                    "return_code": -2,
-                }
-
-    def analyze_taint_result(self, output: str) -> str:
-        """Analyze taint analysis output to determine DETECT or REJECT"""
-
-        # Look for taint flow indicators in output
-        taint_indicators = [
-            "taint flow",
-            "vulnerability found",
-            "cross-file flow",
-            "flows found:",
-            "flows detected",
-        ]
-
-        output_lower = output.lower()
-
-        # Check for explicit flow detection
-        for indicator in taint_indicators:
-            if indicator in output_lower:
-                return "DETECT"
-
-        # Check for flow count
-        if "flows found: 0" in output_lower or "no flows" in output_lower:
-            return "REJECT"
-
-        # Look for specific vulnerability patterns
-        if "command injection" in output_lower or "sql injection" in output_lower:
-            return "DETECT"
-
-        # Check for JSON output format
-        try:
-            if output.strip().startswith("{"):
-                data = json.loads(output)
-                if "flows" in data and len(data.get("flows", [])) > 0:
-                    return "DETECT"
-                else:
-                    return "REJECT"
-        except:
-            pass
-
-        # Default: if no clear indicators, assume REJECT
-        return "REJECT"
-
-    def run_single_test(self, test_case: TestCase) -> TestResult:
-        """Run a single test case and return results"""
-
-        print(f"\n🧪 Running {test_case.name}...")
-        print(f"   📁 Files: {test_case.files}")
-        print(f"   🎯 Expected: {test_case.expected_result}")
-
-        # Run taint analysis
-        analysis_result = self.run_taint_analysis(test_case.files)
-
-        # Analyze results
-        if analysis_result["success"] or analysis_result["return_code"] == 0:
-            # Even if there are warnings in stderr, if return code is 0, analyze the output
-            actual_result = self.analyze_taint_result(analysis_result["stdout"])
-        else:
-            actual_result = "ERROR"
-
-        is_correct = actual_result == test_case.expected_result
-
-        # Print immediate result
-        status_emoji = "✅" if is_correct else "❌"
-        print(f"   📊 Actual: {actual_result} {status_emoji}")
-
-        if not is_correct and actual_result != "ERROR":
-            print(
-                f"   ⚠️  MISMATCH: Expected {test_case.expected_result}, got {actual_result}"
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"{case.name} scanner failed with {result.returncode}: {result.stderr}"
             )
 
-        # Only show stderr if it's actually an error (not just warnings)
-        if actual_result == "ERROR" and analysis_result.get("stderr"):
-            print(f"   🚨 Error: {analysis_result['stderr'][:200]}...")
+        findings = parse_findings(result.stdout)
+        taint_findings = [
+            finding
+            for finding in findings
+            if "taint_analysis" in finding.get("tags", [])
+        ]
+        actual = "DETECT" if taint_findings else "REJECT"
 
         return TestResult(
-            test_case=test_case,
-            actual_result=actual_result,
-            execution_time=analysis_result["execution_time"],
-            details=analysis_result,
-            is_correct=is_correct,
+            test_case=case,
+            actual_result=actual,
+            execution_time=elapsed,
+            findings=taint_findings,
+            is_correct=actual == case.expected_result,
         )
 
-    def run_all_tests(self) -> List[TestResult]:
-        """Run all test cases and return results"""
 
-        print("🚀 Starting Comprehensive Multi-File Taint Analysis Test Suite")
-        print("=" * 70)
+def main() -> int:
+    results = [run_case(case) for case in test_cases()]
 
-        results = []
+    passed = sum(1 for result in results if result.is_correct)
+    failed = len(results) - passed
+    total_time = sum(result.execution_time for result in results)
 
-        for test_case in self.test_cases:
-            result = self.run_single_test(test_case)
-            results.append(result)
-            self.results.append(result)
-
-        return results
-
-    def generate_report(self, results: List[TestResult]) -> Dict[str, Any]:
-        """Generate comprehensive test report"""
-
-        total_tests = len(results)
-        passed_tests = sum(1 for r in results if r.is_correct)
-        failed_tests = total_tests - passed_tests
-
-        # Category breakdown
-        category_stats = {}
-        for result in results:
-            category = result.test_case.category
-            if category not in category_stats:
-                category_stats[category] = {"total": 0, "passed": 0}
-            category_stats[category]["total"] += 1
-            if result.is_correct:
-                category_stats[category]["passed"] += 1
-
-        # Performance stats
-        total_time = sum(r.execution_time for r in results)
-        avg_time = total_time / total_tests if total_tests > 0 else 0
-
-        # Critical failures
-        critical_failures = []
-        for result in results:
-            if not result.is_correct:
-                if "phantom" in result.test_case.name.lower():
-                    critical_failures.append(
-                        f"PHANTOM FLOW DETECTED: {result.test_case.name}"
-                    )
-                elif (
-                    "config" in result.test_case.name.lower()
-                    and result.test_case.expected_result == "REJECT"
-                ):
-                    critical_failures.append(
-                        f"CONFIG FALSE POSITIVE: {result.test_case.name}"
-                    )
-
-        return {
-            "summary": {
-                "total_tests": total_tests,
-                "passed_tests": passed_tests,
-                "failed_tests": failed_tests,
-                "success_rate": round((passed_tests / total_tests) * 100, 2)
-                if total_tests > 0
-                else 0,
-            },
-            "performance": {
-                "total_time": round(total_time, 3),
-                "average_time": round(avg_time, 3),
-                "meets_performance_target": avg_time < 0.2,  # 200ms target
-            },
-            "category_breakdown": category_stats,
-            "critical_failures": critical_failures,
-            "detailed_results": [
-                {
-                    "name": r.test_case.name,
-                    "category": r.test_case.category,
-                    "expected": r.test_case.expected_result,
-                    "actual": r.actual_result,
-                    "correct": r.is_correct,
-                    "time": round(r.execution_time, 3),
-                    "description": r.test_case.description,
-                }
-                for r in results
-            ],
-        }
-
-    def print_final_report(self, report: Dict[str, Any]):
-        """Print comprehensive final report"""
-
-        print("\n" + "=" * 70)
-        print("📊 COMPREHENSIVE TAINT ANALYSIS TEST RESULTS")
-        print("=" * 70)
-
-        # Summary
-        summary = report["summary"]
-        print(f"\n🎯 OVERALL RESULTS:")
-        print(f"   Total Tests: {summary['total_tests']}")
-        print(f"   Passed: {summary['passed_tests']} ✅")
-        print(f"   Failed: {summary['failed_tests']} ❌")
-        print(f"   Success Rate: {summary['success_rate']}%")
-
-        # Success criteria check
-        meets_criteria = summary["success_rate"] >= 95
-        criteria_emoji = "✅" if meets_criteria else "❌"
-        print(f"   Meets Success Criteria (>95%): {criteria_emoji}")
-
-        # Performance
-        perf = report["performance"]
-        print(f"\n⚡ PERFORMANCE:")
-        print(f"   Total Time: {perf['total_time']}s")
-        print(f"   Average Time: {perf['average_time']}s")
-        perf_emoji = "✅" if perf["meets_performance_target"] else "❌"
-        print(f"   Meets Performance Target (<200ms): {perf_emoji}")
-
-        # Category breakdown
-        print(f"\n📂 CATEGORY BREAKDOWN:")
-        for category, stats in report["category_breakdown"].items():
-            rate = round((stats["passed"] / stats["total"]) * 100, 2)
-            print(f"   {category}: {stats['passed']}/{stats['total']} ({rate}%)")
-
-        # Critical failures
-        if report["critical_failures"]:
-            print(f"\n🚨 CRITICAL FAILURES:")
-            for failure in report["critical_failures"]:
-                print(f"   ❌ {failure}")
-        else:
-            print(f"\n✅ NO CRITICAL FAILURES")
-
-        # Detailed results
-        print(f"\n📋 DETAILED RESULTS:")
-        for result in report["detailed_results"]:
-            status = "✅" if result["correct"] else "❌"
-            print(
-                f"   {status} {result['name']}: {result['expected']} -> {result['actual']} ({result['time']}s)"
-            )
-
-        # Final verdict
-        print(f"\n" + "=" * 70)
-        overall_success = (
-            summary["success_rate"] >= 95
-            and len(report["critical_failures"]) == 0
-            and perf["meets_performance_target"]
+    print("Multi-file taint benchmark")
+    print("=" * 40)
+    for result in results:
+        status = "PASS" if result.is_correct else "FAIL"
+        print(
+            f"{status} {result.test_case.name}: "
+            f"expected={result.test_case.expected_result} "
+            f"actual={result.actual_result} "
+            f"findings={len(result.findings)} "
+            f"time={result.execution_time:.3f}s"
         )
+        if not result.is_correct:
+            for finding in result.findings[:5]:
+                print(
+                    "  "
+                    f"{Path(finding.get('file', '')).name}:"
+                    f"{finding.get('line')} "
+                    f"{finding.get('finding_type')}"
+                )
 
-        if overall_success:
-            print("🎉 COMPREHENSIVE TEST SUITE: ✅ PASSED")
-            print("🚀 Taint analysis fixes are working correctly!")
-        else:
-            print("💥 COMPREHENSIVE TEST SUITE: ❌ FAILED")
-            print("🔧 Taint analysis needs additional fixes.")
-
-        print("=" * 70)
-
-
-def main():
-    """Main test execution"""
-    suite = TaintTestSuite()
-    results = suite.run_all_tests()
-    report = suite.generate_report(results)
-    suite.print_final_report(report)
-
-    # Save detailed report
-    report_file = Path(__file__).parent / "test_report.json"
-    with open(report_file, "w") as f:
-        json.dump(report, f, indent=2)
-
-    print(f"\n📄 Detailed report saved to: {report_file}")
+    print("=" * 40)
+    print(f"Passed: {passed}/{len(results)}")
+    print(f"Average time: {round(total_time / len(results), 3)}s")
+    return 0 if failed == 0 else 1
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/tests/test_files/strictness_languages/csharp/parity.cs
+++ b/tests/test_files/strictness_languages/csharp/parity.cs
@@ -1,0 +1,9 @@
+using System.Diagnostics;
+
+public class ReportRunner
+{
+    public void Run(string cmd)
+    {
+        var psi = new ProcessStartInfo("/bin/sh", $"-c {cmd}");
+    }
+}

--- a/tests/test_files/strictness_languages/go/safe.go
+++ b/tests/test_files/strictness_languages/go/safe.go
@@ -1,0 +1,7 @@
+package main
+
+import "database/sql"
+
+func safe(user string, db *sql.DB) {
+	db.Query("SELECT * FROM users WHERE id = ?", user)
+}

--- a/tests/test_files/strictness_languages/go/unsafe.go
+++ b/tests/test_files/strictness_languages/go/unsafe.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"database/sql"
+	"os/exec"
+)
+
+func unsafe(user string, db *sql.DB) {
+	exec.Command("sh", "-c", user).Run()
+	db.Query("SELECT * FROM users WHERE id = " + user)
+}

--- a/tests/test_files/strictness_languages/php/safe.php
+++ b/tests/test_files/strictness_languages/php/safe.php
@@ -1,0 +1,7 @@
+<?php
+
+$safe_cmd = escapeshellarg($_GET["cmd"]);
+system($safe_cmd);
+
+$safe_id = intval($_POST["id"]);
+$db->query("SELECT * FROM users WHERE id = $safe_id");

--- a/tests/test_files/strictness_languages/php/unsafe.php
+++ b/tests/test_files/strictness_languages/php/unsafe.php
@@ -1,0 +1,7 @@
+<?php
+
+$cmd = $_GET["cmd"];
+system($cmd);
+
+$id = $_POST["id"];
+$db->query("SELECT * FROM users WHERE id = $id");

--- a/tests/test_files/strictness_languages/ruby/safe.rb
+++ b/tests/test_files/strictness_languages/ruby/safe.rb
@@ -1,0 +1,6 @@
+require "shellwords"
+
+def safe(params)
+  system("ls", Shellwords.escape(params[:cmd]))
+  User.where("id = ?", params[:id].to_i)
+end

--- a/tests/test_files/strictness_languages/ruby/unsafe.rb
+++ b/tests/test_files/strictness_languages/ruby/unsafe.rb
@@ -1,0 +1,6 @@
+require "shellwords"
+
+def unsafe(params)
+  system("sh -c #{params[:cmd]}")
+  User.where("id = #{params[:id]}")
+end


### PR DESCRIPTION
## Summary

Taint strictness hardening and a new boundary test suite. Builds on #22.

**Merge order:** PR 2 of 2 — merge after #22. PRs #20 and #21 were closed.

---

## Main engine changes

### Safe-value classification (`src/scanner/core.rs`)
- **`classify_value_source()`** — decides whether an expression is a proven-safe literal, a taint source, or unknown
- **`is_safe_literal_expression()`** — string literals, safe static file reads
- **Environment variable awareness** — `extract_env_key()` distinguishes user-controlled keys (`USER_INPUT`, `REQUEST_DATA`) from config/secret keys (`API_KEY`, `DATABASE_URL`, `PORT`); `os.environ.setdefault` is config-safe unless its default value is itself tainted

### Sanitizer-aware assignments & sinks
- **`expression_has_sanitizer()` / `expression_has_any_sanitizer()`** — checks sanitizers in assignment RHS before recording taint (e.g. `shlex.quote(user)` suppresses flow)
- **Actionable sink filtering** — `is_actionable_sink_node()` limits sink matching to real call/invocation nodes
- **Bare-call source matching** — `is_bare_call_source_pattern()` / `matches_bare_call_source()` for patterns like `input(` without false-matching substrings

### PHP & variable handling
- **`extract_php_variables()`**, **`normalize_variable()`** — proper `$var` tracking in PHP taint flows

### File discovery & CLI (`src/scanner/modes.rs`, `src/scanner/utils.rs`, `src/models.rs`, `src/main.rs`)
- **`--include-test-fixtures`** — scans `tests/` / `test/` dirs normally skipped by prefilter (for fixture validation)
- New `*_with_options` scan APIs threading the flag through discovery and scanning
- **`deduplicate_findings()`** — collapses duplicate reports (same file, line, type, snippet)
- Show `--help` when invoked without a scan target

---

## Rule changes

### `rules/javascript/frontend_taint_security.ron`
Tightened overly-broad patterns that caused false positives:
- **Removed sources:** `*.response`, `fetch(`, `XMLHttpRequest`, `axios.*`
- **Removed sinks:** `*.onload`, `*.onerror`, `addEventListener`, `Function(` (kept `new Function(`)
- **Narrowed to:** `*.responseText`, `*.response.data`, `*.responseJSON`

---

## New test suite: `tests/strictness/` (21 tests)

| Module | What it guards |
|--------|----------------|
| `cross_file_taint` | Phantom flows rejected; valid 1–3 file chains detected; config env vars safe |
| `taint_true_positives` | Cross-file accuracy fixtures report real vulns |
| `taint_true_negatives` | Safe cross-file sources stay silent |
| `sanitizer_and_scope` | `shlex.quote` suppresses findings; no scope leakage across functions |
| `search_conditions` | `subprocess` only flagged with `shell=True`; Java `Html.escape` suppresses XSS |
| `django_security` | Django fixture vulns detected; escaped `HttpResponse` not flagged |
| `false_positive_regressions` | Cleartext transmission fixture — TP section flagged, FP section silent |
| `language_coverage` | Go/Ruby/PHP/C# parity fixtures; `--include-test-fixtures` flag works |

Fixtures staged into temp dirs with neutral module names so the test-directory prefilter doesn't skip them.

### Test runner refactors
- `tests/test_files/accuracy_tests/run_accuracy_tests.py` — simplified
- `tests/test_files/multi_file_taint_tests/run_comprehensive_tests.py` — simplified

---

## Files to focus review on

| Priority | Files |
|----------|-------|
| High | `src/scanner/core.rs` (safe literals, sanitizers, env keys) |
| Medium | `src/main.rs`, `src/scanner/modes.rs`, `src/scanner/utils.rs`, `rules/javascript/frontend_taint_security.ron` |
| Tests | `tests/strictness/` (new), accuracy runner diffs |

## Test plan

- [x] `cargo test --test strictness_tests` (21 tests)
- [x] `cargo test` (82 tests total)
- [ ] `python3 tests/test_files/multi_file_taint_tests/run_comprehensive_tests.py`
- [ ] `python3 tests/test_files/accuracy_tests/run_accuracy_tests.py`

---
**Integration branch:** Merges into [`feature/more_language_support`](https://github.com/Corgea/Sighthound/tree/feature/more_language_support) — **not** `main`.

**Merge order:** #16–#19 (merged) → #22 → **#23**
