### PR TITLE
docs: correct outdated claims across Sighthound READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A high-performance vulnerability scanner for source code using tree-sitter parsing and advanced taint flow analysis.
 
-[![Rust](https://img.shields.io/badge/rust-1.70+-orange.svg)](https://www.rust-lang.org)
+[![Rust](https://img.shields.io/badge/rust-1.85+-orange.svg)](https://www.rust-lang.org)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![CI](https://github.com/Corgea/Sighthound/actions/workflows/ci.yml/badge.svg)](https://github.com/Corgea/Sighthound/actions/workflows/ci.yml)
 
@@ -29,13 +29,13 @@ A high-performance vulnerability scanner for source code using tree-sitter parsi
 | Python (`.py`)            | ✅ | ✅ |
 | JavaScript (`.js`)        | ✅ | ✅ |
 | Java (`.java`)            | ✅ | — (parser only; bring your own rules) |
-| TypeScript / TSX (`.tsx`) | ✅ | — (parser only) |
+| TypeScript / TSX (`.tsx`) | ✅ | ✅ (shares JavaScript rules) |
 | HTML (`.html`)            | ✅ | — (parser only) |
 | Django templates          | ✅ | — (parser only) |
 
-Python and JavaScript ship with curated rule sets. The remaining languages have
-working tree-sitter parsers but no bundled rules yet — point Sighthound at your
-own `.ron` rules to scan them.
+Python, JavaScript, and TypeScript/TSX ship with curated rule sets (TSX reuses the
+JavaScript rules). The remaining languages have working tree-sitter parsers but no
+bundled rules yet — point Sighthound at your own `.ron` rules to scan them.
 
 ### Scanning Modes
 - **Auto-Detection Mode**: Automatically detects languages and loads appropriate rules
@@ -45,7 +45,7 @@ own `.ron` rules to scan them.
 ## 📦 Installation
 
 ### Prerequisites
-- Rust 1.70+ (install from [rustup.rs](https://rustup.rs/))
+- Rust 1.85+ (install from [rustup.rs](https://rustup.rs/))
 - Git
 
 ### Build from Source
@@ -67,23 +67,23 @@ DOCKER_BUILDKIT=1 docker build \
   --output type=local,dest=./sighthound_release \
   .
 ```
-Then binary `sighthound` would be exported at the current folder.
+The `sighthound` binary (plus the bundled `rules/`) is exported to `./sighthound_release/`.
 
 ## 🎯 Quick Start
 
 ### Basic Usage
 ```bash
 # Auto-detect languages and scan with default rules
-cargo run -- /path/to/your/project
+cargo run --bin sighthound -- /path/to/your/project
 
 # Scan specific language with custom rules
-cargo run -- /path/to/project python rules/python/command_injection.ron
+cargo run --bin sighthound -- /path/to/project python rules/python/command_injection.ron
 
 # Enable taint analysis for deep vulnerability detection
-cargo run -- --taint-analysis /path/to/project
+cargo run --bin sighthound -- --taint-analysis /path/to/project
 
 # Output results in JSON format
-cargo run -- --output-format json /path/to/project > results.json
+cargo run --bin sighthound -- --output-format json /path/to/project > results.json
 ```
 
 ### Example Output
@@ -128,10 +128,18 @@ OPTIONS:
     -s, --summary-only              Only show vulnerability summary
         --single-threaded           Disable parallel processing
         --threads <NUM>             Number of threads for parallel processing
-        --taint-analysis            Enable taint analysis for data flow tracking
-        --skip-minified             Skip minified JavaScript files [default: true]
+        --taint-analysis            Run only taint analysis (data flow tracking)
+        --simple-analysis           Run only pattern-based search
+        --skip-minified <BOOL>      Skip minified JavaScript files (default: true)
+        --code-type <TYPE>          Filter by code type: frontend, backend, or both
+        --language-filter <LANG>    Restrict scanning to a single language
+        --rules-dir <PATH>          Custom rules directory (used with --use-file-rules)
+        --use-file-rules            Load rules from files instead of embedded rules
     -h, --help                      Print help information
+        --version                   Print version, commit hash, and build date
 ```
+
+With no analysis flag, Sighthound runs both pattern search and taint analysis.
 
 ### Environment Variables
 ```bash
@@ -228,6 +236,7 @@ See [Rule Writing Guide](rules/RULE_WRITING_GUIDE.md) for detailed instructions 
 ```
 src/
 ├── main.rs              # CLI entry point and orchestration
+├── cli.rs               # CLI argument definitions (re-exported from models)
 ├── lib.rs               # Library interface and exports
 ├── models.rs            # Core data structures (Finding, TaintFlow, etc.)
 ├── language.rs          # Language-specific parsers and support
@@ -235,6 +244,7 @@ src/
 ├── parser.rs            # Tree-sitter AST parsing utilities
 ├── common.rs            # Shared utilities and helpers
 ├── config.rs            # Configuration and defaults
+├── code_type_detector.rs  # Frontend/backend code-type detection
 └── scanner/
     ├── core.rs          # Main scanning engine and algorithms
     ├── modes.rs         # Scanning mode implementations
@@ -277,16 +287,11 @@ graph TD
 ### Optimization Features
 - **Memory Mapping**: Efficient file reading for large files
 - **Prefiltering**: Skip irrelevant files and functions early
-- **Incremental Analysis**: Cache results for unchanged files
 - **Smart Threading**: Avoid over-subscription and contention
 
 ## 🧪 Testing
 
 ### Running Tests
-
-> Note: the test harnesses are being realigned to the refactored rule API and
-> are not yet fully green. `cargo build --release` is the verified, CI-gated
-> command; the commands below are the intended test entry points.
 
 ```bash
 # Run all tests
@@ -298,7 +303,7 @@ cargo test --test integration_tests
 cargo test --test end_to_end_tests
 
 # Test with specific files
-cargo run -- tests/test_files/python/comprehensive_taint_test.py
+cargo run --bin sighthound -- tests/test_files/python/comprehensive_taint_test.py
 ```
 
 ### Test Coverage
@@ -323,7 +328,7 @@ We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) f
 1. Fork the repository
 2. Create a feature branch: `git checkout -b feature/amazing-feature`
 3. Make your changes and add tests
-4. Confirm the build: `cargo build --release` (the test suite is under repair)
+4. Confirm the build and tests: `cargo build --release && cargo test`
 5. Submit a pull request
 
 ### Areas for Contribution

--- a/tests/README.md
+++ b/tests/README.md
@@ -39,12 +39,15 @@ cargo test pattern_matching
 
 ## Test Fixtures
 
-Test fixtures (sample code and rule files) are located in the `test_fixtures/` directory at the project root.
+Sample code fixtures live under `tests/test_files/`, organized by language:
 
-- `test_fixtures/python/`: Python test files
-- `test_fixtures/java/`: Java test files
-- `test_fixtures/rules/`: Rule files for testing
+- `tests/test_files/python/`: Python test files
+- `tests/test_files/java/`: Java test files
+- `tests/test_files/javascript/`: JavaScript/TypeScript test files
+
+Rule files used by the scanner live in the top-level `rules/` directory.
 
 ## Test Scripts
 
-Test scripts and utilities are located in the `test_scripts/` directory at the project root. 
+Helper scripts (e.g. `run_comprehensive_tests.py`) live alongside the fixtures they
+exercise, such as `tests/test_files/multi_file_taint_tests/`. 

--- a/tests/test_files/multi_file_taint_tests/README.md
+++ b/tests/test_files/multi_file_taint_tests/README.md
@@ -4,7 +4,7 @@ This directory contains a comprehensive test suite designed to validate the mult
 
 ## 🎯 **Test Strategy Overview**
 
-The test suite implements the testing strategy defined in `../../TAINT_TESTING_STRATEGY.md` and focuses on 5 critical categories:
+The test suite focuses on 5 critical categories:
 
 ### **Category 1: Valid Cross-File Flows** (Should DETECT ✅)
 - **Test 1.1**: Direct function import flow
@@ -46,13 +46,13 @@ python3 run_comprehensive_tests.py
 ### **Manual Individual Tests**
 ```bash
 # Test valid flow detection
-cargo run -- --taint-analysis category1_valid/test1_1_source_module.py category1_valid/test1_1_sink_module.py
+cargo run --bin sighthound -- --taint-analysis category1_valid/test1_1_source_module.py category1_valid/test1_1_sink_module.py
 
 # Test phantom flow rejection  
-cargo run -- --taint-analysis category2_invalid/test2_1_module_a.py category2_invalid/test2_1_module_b.py
+cargo run --bin sighthound -- --taint-analysis category2_invalid/test2_1_module_a.py category2_invalid/test2_1_module_b.py
 
 # Test configuration safety
-cargo run -- --taint-analysis category4_config/test4_1_config_manager.py category4_config/test4_1_app_initializer.py
+cargo run --bin sighthound -- --taint-analysis category4_config/test4_1_config_manager.py category4_config/test4_1_app_initializer.py
 ```
 
 ## 📊 **Success Criteria**
@@ -94,7 +94,6 @@ tests/test_files/multi_file_taint_tests/
 │   ├── test5_1_data_processor.py
 │   └── test5_1_command_runner.py
 ├── run_comprehensive_tests.py # Test runner
-├── TAINT_TESTING_STRATEGY.md  # Full strategy document
 └── README.md                  # This file
 ```
 


### PR DESCRIPTION
## What

Surgical corrections to outdated/incorrect claims across the three Sighthound README files. Every change was verified against the actual code, `Cargo.toml`/`Cargo.lock`, CI config, and git history — no speculative edits.

## Why / changes

**README.md**
- **Rust `1.70+` → `1.85+`** (badge + prerequisites): the `harness` bin is `edition = "2024"`, which `cargo build --release` builds, so the real floor is Rust 1.85 (Dockerfile pins `rust:1.89`).
- **Broken `cargo run -- …` examples fixed → `cargo run --bin sighthound -- …`**: the crate now has two bins (`sighthound` + `harness`) and no `default-run`, so bare `cargo run` errors with "could not determine which binary to run." Verified the corrected form runs.
- **TSX language row**: `— (parser only)` → `✅ (shares JavaScript rules)` — `rules.rs` `load_embedded_rules` serves the JS embedded frontend+taint rules for `tsx`.
- **CLI options block**: documented the real but previously-missing flags (`--simple-analysis`, `--code-type`, `--language-filter`, `--rules-dir`, `--use-file-rules`, `--version`); corrected `--skip-minified` to take a `<BOOL>` value and noted `--rules-dir` pairs with `--use-file-rules`; added the "no flag → runs both" note.
- **Removed `Incremental Analysis: Cache results for unchanged files`** from Optimization Features — no such code exists; it's already listed as a roadmap TODO (self-contradiction).
- **Dropped the "tests under repair / not yet green" caveats** — the test-harness-repair work landed and CI runs the full `make ci` pipeline (which includes tests).
- **Architecture tree**: added the real `cli.rs` and `code_type_detector.rs` modules.
- **Docker export note**: corrected to `./sighthound_release/` and noted `rules/` is exported alongside the binary.

**tests/README.md** — repointed fixtures to `tests/test_files/`; `test_fixtures/`, `test_scripts/`, and `test_data/` do not exist.

**tests/test_files/multi_file_taint_tests/README.md** — removed references to `TAINT_TESTING_STRATEGY.md`, which is not on disk.

## Verification
- Cross-checked each claim against `src/models.rs` (clap CLI), `src/rules.rs`, `Cargo.toml`, `Cargo.lock`, `.github/workflows/ci.yml`, and the on-disk tree.
- Confirmed `cargo run --bin sighthound -- --version` works (`sighthound 0.1.1`).
- Docs-only change; no source touched.

## Deliberately left (not doc-rot, flagged for follow-up)
- Performance/accuracy benchmarks (unverifiable, but not stale).
- "Built-in Rule Categories" list is non-exhaustive vs. the full rule set — expanding it is a separate task.
