### PR TITLE
build: ship license notices alongside the distributed binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,14 @@ FROM debian:bookworm-slim AS runtime
 RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/target/release/sighthound /usr/local/bin/sighthound
 COPY --from=builder /app/rules /rules
+# BSD-2-Clause (Oniguruma, statically linked) requires the notice to accompany
+# binary redistributions. /licenses is the OCI convention.
+COPY --from=builder /app/LICENSE /app/THIRD-PARTY-NOTICES.md /licenses/
 ENTRYPOINT ["/usr/local/bin/sighthound"]
 
 # Export stage - minimal stage with just the binary and required files
 FROM scratch AS export
 COPY --from=builder /app/target/release/sighthound /sighthound
 COPY --from=builder /app/rules /rules
+COPY --from=builder /app/LICENSE /LICENSE
+COPY --from=builder /app/THIRD-PARTY-NOTICES.md /THIRD-PARTY-NOTICES.md

--- a/build_all_platforms.sh
+++ b/build_all_platforms.sh
@@ -53,6 +53,8 @@ cargo build --release
 mkdir -p ./build/sighthound_macos/
 cp ./target/release/sighthound ./build/sighthound_macos/
 cp -r rules/ ./build/sighthound_macos/
+# The Linux dirs get these from the Dockerfile export stage; macOS builds natively.
+cp LICENSE THIRD-PARTY-NOTICES.md ./build/sighthound_macos/
 
 # Copy binaries to destination folder if specified
 if [ -n "$SIGHTHOUND_DESTINATION_FOLDER" ]; then


### PR DESCRIPTION
## Summary

Sighthound statically links **Oniguruma**, a 2-Clause BSD C library. It arrives via `syntect` → `onig` → `onig_sys`, which vendors the C source and compiles it in. Clause 2 of BSD-2 requires binary redistributions to reproduce the copyright notice *"in the documentation and/or other materials provided with the distribution."*

`THIRD-PARTY-NOTICES.md` carried that notice but **never left the repo.** The Dockerfile `export` stage and `build_all_platforms.sh` copied only the binary and `rules/`. The artifact is then vendored into `fusion/vendor/sighthound/<arch>/` and shipped to on-premise customers as a bare binary — so the notice satisfied anyone who cloned the repo, and nobody who received the product.

This carries `LICENSE` and `THIRD-PARTY-NOTICES.md` through both packaging paths:

- **Linux** dirs inherit them from the Dockerfile `export` stage.
- **macOS** builds natively, bypassing Docker, so it copies them explicitly.
- The **runtime image** places them at `/licenses`, the OCI convention.

Five added lines, no Rust touched.

## Related issue

None.

## Checklist

- [x] `cargo build --release` succeeds
- [x] Ran any test harness relevant to this change (note results; suite under repair)
- [x] Updated docs/rules where relevant — n/a, no doc or rule surface

### Verification

Exercised both packaging paths rather than reading the diff:

- `docker build --target export` → `LICENSE`, `THIRD-PARTY-NOTICES.md`, `sighthound`, `rules/` all land in the output dir.
- `docker build --target runtime` → `/licenses` holds both files with content intact; `docker run … --version` still prints `sighthound 0.1.1`, so the new `COPY` doesn't disturb the `ENTRYPOINT`.
- Ran the exact `cp` lines from the macOS branch plus the `cp -r ./build/…/*` destination copy — both files propagate to `$SIGHTHOUND_DESTINATION_FOLDER`.
- `bash -n build_all_platforms.sh` clean; pre-push gates (clippy, fmt, cucumber, arch) green.

## Notes for the reviewer

**This does not reach customers until the vendored binaries are rebuilt.** `fusion/vendor/sighthound/*/sighthound` is dated April 30 and well behind `main`. Re-running `build_all_platforms.sh` is what actually closes the gap.

**The notices file is still under-inclusive.** It names one dependency. `cargo tree -e normal` resolves **91 crates** linked into the shipped binary, and MIT's "include in all copies or substantial portions" arguably covers them too. Generating the full set with `cargo-about` is the follow-up; this PR fixes delivery, not completeness.

**Out of scope, spotted in passing:** `cp -r rules/ ./build/sighthound_macos/` uses BSD `cp` semantics, so the trailing slash flattens `rules/` contents to the top level on macOS while the Linux export stage nests them. Pre-existing, and harmless in practice since `include_dir` embeds the rules at compile time.

Not legal advice — engineering judgment. Worth a lawyer's eye on the notices story given this ships commercially on-prem.