### PR TITLE
output: braille summary visuals for scan Summary (TTY only)

### DIFF
--- a/src/scanner/output.rs
+++ b/src/scanner/output.rs
@@ -37,9 +37,9 @@ fn braille_bar(frac: f64, width: usize) -> String {
     let mut bar = String::with_capacity(width * 3);
     for cell in 0..width {
         let mut code = 0u32;
-        for col in 0..2 {
+        for (col, &mask) in FULL_COL.iter().enumerate() {
             if cell * 2 + col < lit {
-                code |= FULL_COL[col];
+                code |= mask;
             }
         }
         bar.push(char::from_u32(0x2800 + code).unwrap_or(' '));
@@ -115,9 +115,7 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
         *finding_types.entry(finding.finding_type.clone()).or_insert(0) += 1;
         *file_counts.entry(finding.file.clone()).or_insert(0) += 1;
         // Track the worst severity seen in each file, for the heat-bar colour.
-        let worst = file_worst
-            .entry(finding.file.clone())
-            .or_insert_with(|| sev.clone());
+        let worst = file_worst.entry(finding.file.clone()).or_insert_with(|| sev.clone());
         if severity_rank(&sev) > severity_rank(worst) {
             *worst = sev;
         }
@@ -142,10 +140,8 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
     // keeps just the line above, unchanged).
     if crate::ui::color_enabled() {
         const WIDTH: usize = 24;
-        let counts: Vec<usize> = severity_order
-            .iter()
-            .map(|s| severity_counts.get(*s).copied().unwrap_or(0))
-            .collect();
+        let counts: Vec<usize> =
+            severity_order.iter().map(|s| severity_counts.get(*s).copied().unwrap_or(0)).collect();
         if counts.iter().sum::<usize>() > 0 {
             let cells = severity_mix_cells(&counts, WIDTH);
             let mut mix = String::new();

--- a/src/scanner/output.rs
+++ b/src/scanner/output.rs
@@ -47,6 +47,53 @@ fn braille_bar(frac: f64, width: usize) -> String {
     bar
 }
 
+/// Allocate `width` bar cells across severities in proportion to `counts`,
+/// giving every severity with a non-zero count at least one cell while never
+/// exceeding `width` in total. Uses the largest-remainder method: reserving one
+/// cell per present severity keeps a lone critical visible, and sharing the rest
+/// by fractional remainder means independent rounding can't overflow the bar
+/// (e.g. counts 997/1/1/1 stay at `width`, not `width`+3). Absent severities
+/// get zero. Returns one cell count per input index.
+fn severity_mix_cells(counts: &[usize], width: usize) -> Vec<usize> {
+    let total: usize = counts.iter().sum();
+    let mut cells = vec![0usize; counts.len()];
+    if total == 0 || width == 0 {
+        return cells;
+    }
+    let present: Vec<usize> = (0..counts.len()).filter(|&i| counts[i] > 0).collect();
+    // More present severities than cells: give a single cell to the largest few.
+    if present.len() >= width {
+        let mut by_count = present.clone();
+        by_count.sort_by(|&a, &b| counts[b].cmp(&counts[a]).then(a.cmp(&b)));
+        for &i in by_count.iter().take(width) {
+            cells[i] = 1;
+        }
+        return cells;
+    }
+    // Reserve one cell per present severity (minority visibility), share the rest
+    // proportionally, and hand leftover cells to the largest fractional remainders.
+    let discretionary = width - present.len();
+    let mut used = 0;
+    let mut remainders: Vec<(f64, usize)> = Vec::with_capacity(present.len());
+    for &i in &present {
+        let exact = counts[i] as f64 * discretionary as f64 / total as f64;
+        let base = exact.floor() as usize;
+        cells[i] = 1 + base;
+        used += base;
+        remainders.push((exact - base as f64, i));
+    }
+    let mut leftover = discretionary - used;
+    remainders.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+    for (_, i) in remainders {
+        if leftover == 0 {
+            break;
+        }
+        cells[i] += 1;
+        leftover -= 1;
+    }
+    cells
+}
+
 pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
     crate::ui::section("Summary");
 
@@ -94,21 +141,22 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
     // Severity mix as a single stacked braille bar (TTY only; piped output
     // keeps just the line above, unchanged).
     if crate::ui::color_enabled() {
-        let total: usize = severity_counts.values().sum();
-        if total > 0 {
-            const WIDTH: usize = 24;
+        const WIDTH: usize = 24;
+        let counts: Vec<usize> = severity_order
+            .iter()
+            .map(|s| severity_counts.get(*s).copied().unwrap_or(0))
+            .collect();
+        if counts.iter().sum::<usize>() > 0 {
+            let cells = severity_mix_cells(&counts, WIDTH);
             let mut mix = String::new();
-            for sev in severity_order.iter() {
-                if let Some(&count) = severity_counts.get(*sev) {
-                    if count == 0 {
-                        continue;
-                    }
-                    let cells = ((count * WIDTH) as f64 / total as f64).round().max(1.0) as usize;
-                    mix.push_str(&crate::ui::paint(
-                        crate::ui::severity_code(sev),
-                        &braille_bar(1.0, cells),
-                    ));
+            for (idx, sev) in severity_order.iter().enumerate() {
+                if cells[idx] == 0 {
+                    continue;
                 }
+                mix.push_str(&crate::ui::paint(
+                    crate::ui::severity_code(sev),
+                    &braille_bar(1.0, cells[idx]),
+                ));
             }
             println!("  {}", mix);
         }
@@ -808,5 +856,51 @@ mod visual_tests {
         assert_eq!(bar[1], FULL);
         assert_eq!(bar[2], '\u{2847}', "partial cell lights the left sub-column");
         assert!(bar[3..].iter().all(|&c| c == BLANK));
+    }
+
+    #[test]
+    fn severity_mix_never_exceeds_width() {
+        // Reported in review: independent rounding + .max(1) put 997/1/1/1 at 27.
+        for counts in [
+            vec![1, 997, 1, 1],
+            vec![1, 1, 1, 1],
+            vec![5, 5, 5, 5],
+            vec![0, 60, 0, 0],
+            vec![3, 0, 0, 0],
+            vec![1, 0, 500, 0],
+            vec![0, 0, 0, 0],
+        ] {
+            let total: usize = severity_mix_cells(&counts, 24).iter().sum();
+            assert!(total <= 24, "counts {counts:?} produced {total} cells");
+        }
+    }
+
+    #[test]
+    fn severity_mix_fills_full_width_when_it_fits() {
+        // With <= width present severities, the bar spans exactly width.
+        for counts in [vec![1, 997, 1, 1], vec![5, 5, 5, 5], vec![0, 60, 0, 0]] {
+            assert_eq!(severity_mix_cells(&counts, 24).iter().sum::<usize>(), 24);
+        }
+    }
+
+    #[test]
+    fn severity_mix_keeps_every_present_severity_visible() {
+        // A lone critical among 997 highs must still get a cell — that sliver is
+        // the entire argument for the bar. Absent severities get none.
+        let counts = [1usize, 997, 1, 1];
+        let cells = severity_mix_cells(&counts, 24);
+        for (i, &c) in counts.iter().enumerate() {
+            if c > 0 {
+                assert!(cells[i] >= 1, "present severity {i} was dropped");
+            } else {
+                assert_eq!(cells[i], 0);
+            }
+        }
+        assert!(cells[1] > cells[0], "dominant severity should be the widest");
+    }
+
+    #[test]
+    fn severity_mix_absent_severities_get_no_cells() {
+        assert_eq!(severity_mix_cells(&[0, 60, 0, 0], 24), vec![0, 24, 0, 0]);
     }
 }

--- a/src/scanner/output.rs
+++ b/src/scanner/output.rs
@@ -15,6 +15,38 @@ use syntect::parsing::SyntaxSet;
 use crate::common::CommonUtils;
 use crate::models::Finding;
 
+/// Rank severities so the worst one per file can be tracked. Unknown -> 0.
+fn severity_rank(severity: &str) -> u8 {
+    match severity {
+        "critical" => 4,
+        "high" => 3,
+        "medium" => 2,
+        "low" => 1,
+        _ => 0,
+    }
+}
+
+/// A left-to-right braille fill bar, `width` cells wide. Each cell packs two
+/// sub-columns of dots, giving 2x the horizontal resolution of block glyphs.
+/// Unfilled cells use blank braille (U+2800) so every bar is exactly `width`
+/// glyphs and columns stay aligned. Dependency-free, like the other `ui` helpers.
+fn braille_bar(frac: f64, width: usize) -> String {
+    const FULL_COL: [u32; 2] = [0x47, 0xB8]; // fully-lit left / right sub-column
+    let frac = frac.clamp(0.0, 1.0);
+    let lit = (frac * (width * 2) as f64).round() as usize;
+    let mut bar = String::with_capacity(width * 3);
+    for cell in 0..width {
+        let mut code = 0u32;
+        for col in 0..2 {
+            if cell * 2 + col < lit {
+                code |= FULL_COL[col];
+            }
+        }
+        bar.push(char::from_u32(0x2800 + code).unwrap_or(' '));
+    }
+    bar
+}
+
 pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
     crate::ui::section("Summary");
 
@@ -28,11 +60,20 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
     let mut severity_counts: BTreeMap<String, usize> = BTreeMap::new();
     let mut finding_types: BTreeMap<String, usize> = BTreeMap::new();
     let mut file_counts: BTreeMap<String, usize> = BTreeMap::new();
+    let mut file_worst: BTreeMap<String, String> = BTreeMap::new();
 
     for finding in findings {
-        *severity_counts.entry(finding.severity.to_lowercase()).or_insert(0) += 1;
+        let sev = finding.severity.to_lowercase();
+        *severity_counts.entry(sev.clone()).or_insert(0) += 1;
         *finding_types.entry(finding.finding_type.clone()).or_insert(0) += 1;
         *file_counts.entry(finding.file.clone()).or_insert(0) += 1;
+        // Track the worst severity seen in each file, for the heat-bar colour.
+        let worst = file_worst
+            .entry(finding.file.clone())
+            .or_insert_with(|| sev.clone());
+        if severity_rank(&sev) > severity_rank(worst) {
+            *worst = sev;
+        }
     }
 
     // Severity breakdown, on a single line in fixed order
@@ -50,6 +91,29 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
         println!("  {}", parts.join("   "));
     }
 
+    // Severity mix as a single stacked braille bar (TTY only; piped output
+    // keeps just the line above, unchanged).
+    if crate::ui::color_enabled() {
+        let total: usize = severity_counts.values().sum();
+        if total > 0 {
+            const WIDTH: usize = 24;
+            let mut mix = String::new();
+            for sev in severity_order.iter() {
+                if let Some(&count) = severity_counts.get(*sev) {
+                    if count == 0 {
+                        continue;
+                    }
+                    let cells = ((count * WIDTH) as f64 / total as f64).round().max(1.0) as usize;
+                    mix.push_str(&crate::ui::paint(
+                        crate::ui::severity_code(sev),
+                        &braille_bar(1.0, cells),
+                    ));
+                }
+            }
+            println!("  {}", mix);
+        }
+    }
+
     // Top finding types
     let mut sorted_types: Vec<_> = finding_types.iter().collect();
     sorted_types.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
@@ -58,13 +122,27 @@ pub fn print_summary(findings: &[Finding], duration: std::time::Duration) {
         println!("  {:>4}  {}", count, finding_type);
     }
 
-    // Most affected files
+    // Most affected files. In a TTY this draws a braille heat bar per file
+    // (length = finding count, colour = worst severity in the file); piped or
+    // NO_COLOR output falls back to the original plain list, byte-for-byte.
     let mut sorted_files: Vec<_> = file_counts.iter().collect();
     sorted_files.sort_by(|a, b| b.1.cmp(a.1).then(a.0.cmp(b.0)));
     if sorted_files.len() > 1 {
         crate::ui::section("Most affected files");
-        for (file_path, count) in sorted_files.iter().take(5) {
-            println!("  {:>4}  {}", count, crate::ui::dim(file_path));
+        if crate::ui::color_enabled() {
+            let max = sorted_files.first().map(|(_, c)| **c).unwrap_or(1).max(1);
+            for (file_path, count) in sorted_files.iter().take(8) {
+                let worst = file_worst.get(*file_path).map(String::as_str).unwrap_or("");
+                let heat = crate::ui::paint(
+                    crate::ui::severity_code(worst),
+                    &braille_bar(**count as f64 / max as f64, 10),
+                );
+                println!("  {}  {:>4}  {}", heat, count, crate::ui::dim(file_path));
+            }
+        } else {
+            for (file_path, count) in sorted_files.iter().take(5) {
+                println!("  {:>4}  {}", count, crate::ui::dim(file_path));
+            }
         }
     }
 
@@ -666,4 +744,69 @@ pub fn print_findings_text(
         }
     }
     print_summary(findings, duration);
+}
+
+#[cfg(test)]
+mod visual_tests {
+    use super::*;
+
+    const BLANK: char = '\u{2800}'; // blank braille (unfilled cell)
+    const FULL: char = '\u{28ff}'; // fully-lit braille cell
+
+    #[test]
+    fn severity_rank_orders_all_levels() {
+        assert!(
+            severity_rank("critical") > severity_rank("high")
+                && severity_rank("high") > severity_rank("medium")
+                && severity_rank("medium") > severity_rank("low")
+                && severity_rank("low") > severity_rank("unknown")
+        );
+        assert_eq!(severity_rank("critical"), 4);
+        assert_eq!(severity_rank("low"), 1);
+        assert_eq!(severity_rank("nonsense"), 0);
+    }
+
+    #[test]
+    fn braille_bar_is_always_exactly_width_glyphs() {
+        // The alignment guarantee: char count == width, for any frac.
+        for width in [0usize, 1, 5, 10, 24] {
+            for frac in [-1.0, 0.0, 0.1, 0.25, 0.5, 0.75, 1.0, 2.0] {
+                assert_eq!(
+                    braille_bar(frac, width).chars().count(),
+                    width,
+                    "width={width} frac={frac}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn braille_bar_empty_and_full() {
+        assert_eq!(braille_bar(0.0, 10), BLANK.to_string().repeat(10));
+        assert_eq!(braille_bar(1.0, 10), FULL.to_string().repeat(10));
+    }
+
+    #[test]
+    fn braille_bar_clamps_out_of_range() {
+        assert_eq!(braille_bar(-5.0, 8), braille_bar(0.0, 8));
+        assert_eq!(braille_bar(9.0, 8), braille_bar(1.0, 8));
+    }
+
+    #[test]
+    fn braille_bar_half_fills_left_half() {
+        // frac 0.5 over width 10 => lit = round(0.5*20) = 10 => first 5 cells full.
+        let bar: Vec<char> = braille_bar(0.5, 10).chars().collect();
+        assert!(bar[..5].iter().all(|&c| c == FULL), "left half should be full");
+        assert!(bar[5..].iter().all(|&c| c == BLANK), "right half should be blank");
+    }
+
+    #[test]
+    fn braille_bar_partial_cell_lights_left_subcolumn() {
+        // frac 0.25 over width 10 => lit = 5 => cells 0,1 full, cell 2 left-only.
+        let bar: Vec<char> = braille_bar(0.25, 10).chars().collect();
+        assert_eq!(bar[0], FULL);
+        assert_eq!(bar[1], FULL);
+        assert_eq!(bar[2], '\u{2847}', "partial cell lights the left sub-column");
+        assert!(bar[3..].iter().all(|&c| c == BLANK));
+    }
 }


### PR DESCRIPTION
## What

Two small, dependency-free visual touches to the scan **Summary**, both **TTY-only**:

1. **Findings heat map** — the "Most affected files" list gains a per-file braille bar: **length** = finding count (normalized to the busiest file), **colour** = worst severity in that file (reusing `ui::severity_code`).
2. **Severity mix bar** — a single stacked braille bar under the `● N critical  ● N high  …` line, segments sized by each severity's share and coloured by severity.

## What it looks like

> Colour doesn't render in GitHub code blocks — run it in a terminal to see it. Below, bar **length** = count and bar **colour** = severity (critical = bold red, high = red, medium = yellow, low = green).

A real multi-file scan — heat map (per file) + severity mix bar (overall blend):

```
Summary
  ● 2 critical   ● 7 high   ● 1 medium   ● 1 low
  ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿

     7  Command Injection
     2  Unsafe Deserialization
     1  Dynamic Import
     1  Open Redirect

Most affected files
  ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿     4  ./app/api/handlers.py
  ⣿⣿⣿⣿⣿⣿⣿⡇⠀⠀     3  ./auth/session.py
  ⣿⣿⣿⣿⣿⠀⠀⠀⠀⠀     2  ./db/query.py
  ⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀     1  ./utils/format.py
  ⣿⣿⡇⠀⠀⠀⠀⠀⠀⠀     1  ./web/redirect.js
```

A balanced severity mix — the stacked bar reads the blend at a glance:

```
Summary
  ● 5 critical   ● 5 high   ● 5 medium   ● 5 low
  ⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿

     5  Command Injection
     5  Dynamic Import
     5  Open Redirect
     5  Unsafe Deserialization
```

The mix bar is normalized to the total, so it shows the **blend** of severities rather than the volume.

## Pipe-safety (the important guarantee)

Both visuals are gated behind `ui::color_enabled()` (TTY **and** `NO_COLOR` unset). When stdout is piped or `NO_COLOR` is set, the output falls back to the original plain list, **byte-for-byte unchanged**, and the JSON/CSV paths are untouched. Verified by diffing pre- vs post-change output:

- `sighthound sample | cat` — identical
- `NO_COLOR=1 sighthound sample` — identical
- `sighthound sample -o json` / `-o csv` — identical

## No new dependencies

Braille is packed by hand (`U+2800` base), in the spirit of the dependency-free `ui.rs`. `Cargo.toml` / `Cargo.lock` are untouched. Bars are padded to a fixed 10 glyphs so the count column stays aligned; deterministic ordering (BTreeMap + existing sorts) is preserved.

## Tests

Adds unit tests for the pure helpers in `output.rs`:
- `braille_bar` — the char-count == width alignment invariant (across widths/fracs), fill math, out-of-range clamping, and partial-cell behaviour.
- `severity_rank` — ordering including the unknown case.

Full suite green; no existing tests changed.

## Try it

```
cargo build --release
./target/release/sighthound <a directory with a few findings>
```

Any tree with findings across several files / severities will show both visuals in a colour terminal; piping it (`| cat`) shows the unchanged plain output.

Scope: a single file, `src/scanner/output.rs`.
