### PR TITLE
fix: add --fail-on-severity / --error-on-findings CI gate flags (#36)

### DIFF
--- a/harness.rs
+++ b/harness.rs
@@ -1119,7 +1119,7 @@ fi
 /// Write `path` with `content` only if it does not already exist. Returns true
 /// when it created the file. Never clobbers an existing file — preserves any
 /// local customization; `check_stop_hook_present` then reports the result.
-fn write_if_missing(path: &Path, content: &str, executable: bool) -> bool {
+fn write_if_missing(path: &Path, content: &str, _executable: bool) -> bool {
     if path.exists() {
         return false;
     }
@@ -1130,7 +1130,7 @@ fn write_if_missing(path: &Path, content: &str, executable: bool) -> bool {
         return false;
     }
     #[cfg(unix)]
-    if executable {
+    if _executable {
         use std::os::unix::fs::PermissionsExt;
         let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o755));
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,22 +184,25 @@ fn main() -> Result<()> {
     output_findings(&cli, &findings, duration)?;
 
     // Check if we need to fail (exit 1) based on severity or findings count
-    let should_fail = if cli.error_on_findings && !findings.is_empty() {
-        true
+    let failure_reason = if cli.error_on_findings && !findings.is_empty() {
+        Some("findings found (--error-on-findings is set)".to_string())
     } else if let Some(ref fail_severity) = cli.fail_on_severity {
         let target_num = severity_to_num(fail_severity);
-        findings.iter().any(|f| severity_to_num(&f.severity) >= target_num)
+        let has_offending_finding = findings.iter().any(|f| severity_to_num(&f.severity) >= target_num);
+        if has_offending_finding {
+            Some(format!("findings at or above severity threshold ({})", fail_severity))
+        } else {
+            None
+        }
     } else {
-        false
+        None
     };
 
-    if should_fail {
-        let threshold = cli
-            .fail_on_severity
-            .as_deref()
-            .map(|s| format!(" (threshold: {})", s))
-            .unwrap_or_default();
-        sighthound::ui::error_line(&format!("exiting non-zero: findings above threshold{}", threshold));
+    if let Some(reason) = failure_reason {
+        sighthound::ui::error_line(&format!("exiting non-zero: {}", reason));
+        use std::io::{self, Write};
+        let _ = io::stdout().flush();
+        let _ = io::stderr().flush();
         std::process::exit(1);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -188,7 +188,8 @@ fn main() -> Result<()> {
         Some("findings found (--error-on-findings is set)".to_string())
     } else if let Some(ref fail_severity) = cli.fail_on_severity {
         let target_num = severity_to_num(fail_severity);
-        let has_offending_finding = findings.iter().any(|f| severity_to_num(&f.severity) >= target_num);
+        let has_offending_finding =
+            findings.iter().any(|f| severity_to_num(&f.severity) >= target_num);
         if has_offending_finding {
             Some(format!("findings at or above severity threshold ({})", fail_severity))
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,17 @@ fn validate_scan_flags(cli: &Cli) -> Result<()> {
     if cli.taint_analysis && cli.simple_analysis {
         return Err(anyhow::anyhow!("Cannot specify both --taint-analysis and --simple-analysis. Use one or neither (default: both modes)."));
     }
+    if let Some(ref severity) = cli.fail_on_severity {
+        match severity.to_lowercase().as_str() {
+            "critical" | "high" | "medium" | "low" => {}
+            _ => {
+                return Err(anyhow::anyhow!(
+                    "Invalid severity level: '{}'. Choose from: critical, high, medium, low",
+                    severity
+                ));
+            }
+        }
+    }
     Ok(())
 }
 
@@ -172,7 +183,37 @@ fn main() -> Result<()> {
     let duration = start_time.elapsed();
     output_findings(&cli, &findings, duration)?;
 
+    // Check if we need to fail (exit 1) based on severity or findings count
+    let should_fail = if cli.error_on_findings && !findings.is_empty() {
+        true
+    } else if let Some(ref fail_severity) = cli.fail_on_severity {
+        let target_num = severity_to_num(fail_severity);
+        findings.iter().any(|f| severity_to_num(&f.severity) >= target_num)
+    } else {
+        false
+    };
+
+    if should_fail {
+        let threshold = cli
+            .fail_on_severity
+            .as_deref()
+            .map(|s| format!(" (threshold: {})", s))
+            .unwrap_or_default();
+        sighthound::ui::error_line(&format!("exiting non-zero: findings above threshold{}", threshold));
+        std::process::exit(1);
+    }
+
     Ok(())
+}
+
+fn severity_to_num(severity: &str) -> u8 {
+    match severity.to_lowercase().as_str() {
+        "critical" => 4,
+        "high" => 3,
+        "medium" => 2,
+        "low" => 1,
+        _ => 0,
+    }
 }
 
 fn deduplicate_findings(findings: &mut Vec<sighthound::Finding>) {

--- a/src/models.rs
+++ b/src/models.rs
@@ -377,7 +377,11 @@ pub struct Cli {
     pub version: bool,
 
     /// Exit non-zero if any findings meet or exceed this severity (critical, high, medium, low)
-    #[arg(long, value_name = "SEVERITY", help = "Exit 1 if any finding is at or above SEVERITY (critical/high/medium/low)")]
+    #[arg(
+        long,
+        value_name = "SEVERITY",
+        help = "Exit 1 if any finding is at or above SEVERITY (critical/high/medium/low)"
+    )]
     pub fail_on_severity: Option<String>,
 
     /// Exit non-zero if any findings are found

--- a/src/models.rs
+++ b/src/models.rs
@@ -375,6 +375,14 @@ pub struct Cli {
     /// Print version information
     #[arg(long, help = "Print version information")]
     pub version: bool,
+
+    /// Exit non-zero if any findings meet or exceed this severity (critical, high, medium, low)
+    #[arg(long, value_name = "SEVERITY", help = "Exit 1 if any finding is at or above SEVERITY (critical/high/medium/low)")]
+    pub fail_on_severity: Option<String>,
+
+    /// Exit non-zero if any findings are found
+    #[arg(long, help = "Exit 1 if any findings are reported")]
+    pub error_on_findings: bool,
 }
 
 // Helper function for default search mode

--- a/tests/integration/integration_tests.rs
+++ b/tests/integration/integration_tests.rs
@@ -450,47 +450,71 @@ def malicious_functions():
             return;
         }
 
-        // os.system(cmd) is a known critical finding in the embedded python rules
-        let python_content = r#"
+        // os.system(cmd) is a known High finding in the embedded python rules.
+        // We will test that High triggers "--fail-on-severity high" but NOT "--fail-on-severity critical".
+        let python_content_high = r#"
 import os
-
 def run(cmd):
     os.system(cmd)
 "#;
-        let temp_file = create_test_python_file(python_content);
-        let file_path = temp_file.path().to_str().unwrap();
+        let temp_file_high = create_test_python_file(python_content_high);
+        let file_path_high = temp_file_high.path().to_str().unwrap();
+
+        // pickle.loads(data) is a known Critical finding in the embedded python rules.
+        // We will test that Critical triggers "--fail-on-severity critical".
+        let python_content_critical = r#"
+import pickle
+def run(data):
+    pickle.loads(data)
+"#;
+        let temp_file_critical = create_test_python_file(python_content_critical);
+        let file_path_critical = temp_file_critical.path().to_str().unwrap();
 
         // no gate flag — should always succeed
         let status = std::process::Command::new(&bin_path)
-            .args(&[file_path, "python", "--simple-analysis"])
+            .args(&[file_path_high, "python", "--simple-analysis"])
             .status()
             .expect("failed to run sighthound");
         assert!(status.success());
 
         // --error-on-findings should flip exit code when there are findings
         let status = std::process::Command::new(&bin_path)
-            .args(&[file_path, "python", "--simple-analysis", "--error-on-findings"])
+            .args(&[file_path_high, "python", "--simple-analysis", "--error-on-findings"])
             .status()
             .expect("failed to run sighthound");
         assert_eq!(status.code(), Some(1));
 
-        // critical threshold — os.system is Critical, so this should trigger
+        // critical threshold — os.system is High, so critical threshold should NOT trigger on it
         let status = std::process::Command::new(&bin_path)
-            .args(&[file_path, "python", "--simple-analysis", "--fail-on-severity", "critical"])
+            .args(&[file_path_high, "python", "--simple-analysis", "--fail-on-severity", "critical"])
+            .status()
+            .expect("failed to run sighthound");
+        assert!(status.success());
+
+        // critical threshold — pickle.loads is Critical, so critical threshold should trigger on it
+        let status = std::process::Command::new(&bin_path)
+            .args(&[file_path_critical, "python", "--simple-analysis", "--fail-on-severity", "critical"])
             .status()
             .expect("failed to run sighthound");
         assert_eq!(status.code(), Some(1));
 
-        // low threshold — still triggered since critical >= low
+        // high threshold — os.system is High, so high threshold should trigger on it
         let status = std::process::Command::new(&bin_path)
-            .args(&[file_path, "python", "--simple-analysis", "--fail-on-severity", "low"])
+            .args(&[file_path_high, "python", "--simple-analysis", "--fail-on-severity", "high"])
+            .status()
+            .expect("failed to run sighthound");
+        assert_eq!(status.code(), Some(1));
+
+        // low threshold — still triggered since high >= low
+        let status = std::process::Command::new(&bin_path)
+            .args(&[file_path_high, "python", "--simple-analysis", "--fail-on-severity", "low"])
             .status()
             .expect("failed to run sighthound");
         assert_eq!(status.code(), Some(1));
 
         // bad severity value — validation should reject it
         let output = std::process::Command::new(&bin_path)
-            .args(&[file_path, "python", "--simple-analysis", "--fail-on-severity", "invalid_level"])
+            .args(&[file_path_high, "python", "--simple-analysis", "--fail-on-severity", "invalid_level"])
             .output()
             .expect("failed to run sighthound");
         assert!(!output.status.success());

--- a/tests/integration/integration_tests.rs
+++ b/tests/integration/integration_tests.rs
@@ -486,14 +486,26 @@ def run(data):
 
         // critical threshold — os.system is High, so critical threshold should NOT trigger on it
         let status = std::process::Command::new(&bin_path)
-            .args(&[file_path_high, "python", "--simple-analysis", "--fail-on-severity", "critical"])
+            .args(&[
+                file_path_high,
+                "python",
+                "--simple-analysis",
+                "--fail-on-severity",
+                "critical",
+            ])
             .status()
             .expect("failed to run sighthound");
         assert!(status.success());
 
         // critical threshold — pickle.loads is Critical, so critical threshold should trigger on it
         let status = std::process::Command::new(&bin_path)
-            .args(&[file_path_critical, "python", "--simple-analysis", "--fail-on-severity", "critical"])
+            .args(&[
+                file_path_critical,
+                "python",
+                "--simple-analysis",
+                "--fail-on-severity",
+                "critical",
+            ])
             .status()
             .expect("failed to run sighthound");
         assert_eq!(status.code(), Some(1));
@@ -514,7 +526,13 @@ def run(data):
 
         // bad severity value — validation should reject it
         let output = std::process::Command::new(&bin_path)
-            .args(&[file_path_high, "python", "--simple-analysis", "--fail-on-severity", "invalid_level"])
+            .args(&[
+                file_path_high,
+                "python",
+                "--simple-analysis",
+                "--fail-on-severity",
+                "invalid_level",
+            ])
             .output()
             .expect("failed to run sighthound");
         assert!(!output.status.success());

--- a/tests/integration/integration_tests.rs
+++ b/tests/integration/integration_tests.rs
@@ -437,4 +437,64 @@ def malicious_functions():
         assert!(rule_matches_pattern_unified(url_rule, "t.co"));
         assert!(!rule_matches_pattern_unified(url_rule, "github.com"));
     }
+
+    #[test]
+    fn test_cli_exit_code_gating() {
+        let bin_path = if let Ok(path) = std::env::var("CARGO_BIN_EXE_sighthound") {
+            std::path::PathBuf::from(path)
+        } else {
+            std::path::PathBuf::from("target/debug/sighthound")
+        };
+
+        if !bin_path.exists() {
+            return;
+        }
+
+        // os.system(cmd) is a known critical finding in the embedded python rules
+        let python_content = r#"
+import os
+
+def run(cmd):
+    os.system(cmd)
+"#;
+        let temp_file = create_test_python_file(python_content);
+        let file_path = temp_file.path().to_str().unwrap();
+
+        // no gate flag — should always succeed
+        let status = std::process::Command::new(&bin_path)
+            .args(&[file_path, "python", "--simple-analysis"])
+            .status()
+            .expect("failed to run sighthound");
+        assert!(status.success());
+
+        // --error-on-findings should flip exit code when there are findings
+        let status = std::process::Command::new(&bin_path)
+            .args(&[file_path, "python", "--simple-analysis", "--error-on-findings"])
+            .status()
+            .expect("failed to run sighthound");
+        assert_eq!(status.code(), Some(1));
+
+        // critical threshold — os.system is Critical, so this should trigger
+        let status = std::process::Command::new(&bin_path)
+            .args(&[file_path, "python", "--simple-analysis", "--fail-on-severity", "critical"])
+            .status()
+            .expect("failed to run sighthound");
+        assert_eq!(status.code(), Some(1));
+
+        // low threshold — still triggered since critical >= low
+        let status = std::process::Command::new(&bin_path)
+            .args(&[file_path, "python", "--simple-analysis", "--fail-on-severity", "low"])
+            .status()
+            .expect("failed to run sighthound");
+        assert_eq!(status.code(), Some(1));
+
+        // bad severity value — validation should reject it
+        let output = std::process::Command::new(&bin_path)
+            .args(&[file_path, "python", "--simple-analysis", "--fail-on-severity", "invalid_level"])
+            .output()
+            .expect("failed to run sighthound");
+        assert!(!output.status.success());
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(stderr.contains("Invalid severity level: 'invalid_level'"), "got: {stderr}");
+    }
 }

--- a/tests/strictness/language_coverage.rs
+++ b/tests/strictness/language_coverage.rs
@@ -221,9 +221,9 @@ fn include_test_fixtures_flag_enables_scanning_tests_directory() {
     );
     assert!(
         with_flag.iter().any(|f| {
-            f["file"]
-                .as_str()
-                .is_some_and(|path| path.contains("strictness_languages/go/unsafe.go"))
+            f["file"].as_str().is_some_and(|path| {
+                path.replace("\\", "/").contains("strictness_languages/go/unsafe.go")
+            })
         }),
         "expected finding from strictness go fixture, got: {:?}",
         with_flag


### PR DESCRIPTION
Closes #36

## Problem

`sighthound` always exits 0 regardless of findings severity, making it
impossible to use as a hard gate in CI without a wrapper that parses JSON
output externally.

## Solution

Two new flags control exit behaviour:

- `--fail-on-severity <SEVERITY>` — exits 1 if any finding is at or above
  the given level (`critical`, `high`, `medium`, `low`). Severity is
  compared ordinally so `--fail-on-severity high` also catches `critical`.
- `--error-on-findings` — exits 1 if any finding is reported, regardless
  of severity.

Invalid values (e.g. `--fail-on-severity bogus`) are rejected early with a
clear error message and a non-zero exit before scanning begins.

Example CI usage:

```yaml
- run: sighthound --fail-on-severity high .
