### PR TITLE
fix: don't flag parameterized cursor.execute() as SQL injection

### DIFF
--- a/rules/python/sql_injection.ron
+++ b/rules/python/sql_injection.ron
@@ -10,7 +10,8 @@
             mode: "search",
             patterns: Some([
                 "execute_raw_query(",
-                "*cursor.execute(*%*",
+                // Match the % operator after a complete query expression, not DB-API placeholders.
+                "regex:(?s)cursor\\.execute\\(\\s*\\(*\\s*(?:(?:[rRuUbBfF]{0,2})?(?:\"\"\".*?\"\"\"|'''.*?'''|\"(?:\\\\.|[^\"\\\\])*\"|'(?:\\\\.|[^'\\\\])*')|[A-Za-z_][A-Za-z0-9_.]*)\\s*\\)*\\s*%\\s*[^\\s,)]",
                 "*cursor.execute(*.format(*",
                 "*cursor.execute(f\"*",
                 "*cursor.execute(f'*",

--- a/tests/features/false_positive_floor.feature
+++ b/tests/features/false_positive_floor.feature
@@ -7,3 +7,8 @@ Feature: False-positive floor
     Given a staged benign Python module "calculator.py"
     When I scan the staging directory as "python" with the production rules
     Then no findings should be reported
+
+  Scenario: Parameterized cursor execution produces zero findings
+    Given a staged copy of the fixture "tests/test_files/python/sql_parameterized_execute.py" as "parameterized_query.py"
+    When I scan the staging directory as "python" with the production rules
+    Then no findings should be reported

--- a/tests/features/python_injection.feature
+++ b/tests/features/python_injection.feature
@@ -8,3 +8,17 @@ Feature: Python injection detection
     When I scan the staging directory as "python" with the production rules
     Then the findings should include a "Command Injection" finding in "mixed_case.py"
     And the findings should include a "SQL Injection" finding in "mixed_case.py"
+
+  Scenario Outline: Dynamically formatted cursor execution is detected
+    Given a staged copy of the fixture "<fixture>" as "unsafe_query.py"
+    When I scan the staging directory as "python" with the production rules
+    Then the findings should include a "SQL Injection" finding in "unsafe_query.py"
+
+    Examples:
+      | fixture                                                    |
+      | tests/test_files/python/sql_percent_spaced.py              |
+      | tests/test_files/python/sql_percent_unspaced.py            |
+      | tests/test_files/python/sql_percent_variable.py            |
+      | tests/test_files/python/sql_fstring_interpolation.py        |
+      | tests/test_files/python/sql_concatenation.py                |
+      | tests/test_files/python/sql_format_interpolation.py         |

--- a/tests/test_files/python/sql_concatenation.py
+++ b/tests/test_files/python/sql_concatenation.py
@@ -1,0 +1,2 @@
+def load_user(cursor, user_id):
+    cursor.execute("SELECT * FROM users WHERE id = " + user_id)

--- a/tests/test_files/python/sql_format_interpolation.py
+++ b/tests/test_files/python/sql_format_interpolation.py
@@ -1,0 +1,2 @@
+def load_user(cursor, user_id):
+    cursor.execute("SELECT * FROM users WHERE id = {}".format(user_id))

--- a/tests/test_files/python/sql_fstring_interpolation.py
+++ b/tests/test_files/python/sql_fstring_interpolation.py
@@ -1,0 +1,2 @@
+def load_user(cursor, user_id):
+    cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")

--- a/tests/test_files/python/sql_parameterized_execute.py
+++ b/tests/test_files/python/sql_parameterized_execute.py
@@ -1,0 +1,13 @@
+def load_firms(cursor, firm_id, firm_name):
+    cursor.execute(
+        "SELECT * FROM firms WHERE firm_id = %s",
+        [firm_id],
+    )
+    cursor.execute(
+        "SELECT * FROM firms WHERE name = %(name)s",
+        {"name": firm_name},
+    )
+    cursor.execute(
+        "SELECT * FROM firms WHERE name LIKE %s",
+        [f"%{firm_name}%"],
+    )

--- a/tests/test_files/python/sql_percent_spaced.py
+++ b/tests/test_files/python/sql_percent_spaced.py
@@ -1,0 +1,2 @@
+def load_user(cursor, user_id):
+    cursor.execute("SELECT * FROM users WHERE id = %s" % user_id)

--- a/tests/test_files/python/sql_percent_unspaced.py
+++ b/tests/test_files/python/sql_percent_unspaced.py
@@ -1,0 +1,2 @@
+def load_user(cursor, user_id):
+    cursor.execute("SELECT * FROM users WHERE id = %s"%user_id)

--- a/tests/test_files/python/sql_percent_variable.py
+++ b/tests/test_files/python/sql_percent_variable.py
@@ -1,0 +1,2 @@
+def load_user(cursor, query, user_id):
+    cursor.execute(query % user_id)


### PR DESCRIPTION
## Summary

The `python-sql-raw-001` glob `*cursor.execute(*%*` treated any `%` in the call text as string interpolation, so canonical DB-API parameter binding (`cursor.execute("... WHERE firm_id = %s", [firm_id])`) was reported as Critical SQL Injection. The reporter measured ~60% of this rule's findings on a ~5k-file production codebase as this false positive (#35).

This replaces the glob with a `regex:` pattern (Pattern Type 4 in the rule guide) that only fires when `%` is a formatting operator after a complete query expression, a closing quote or a bare identifier, instead of matching `%s`/`%(name)s` placeholders inside the string literal. Placeholders bound via `execute()`'s second argument now pass clean; every interpolation form still flags.

Regression coverage both ways, wired into the acceptance harness:
- `false_positive_floor.feature`: parameterized `%s`, `%(name)s`, and a bound `f"%{name}%"` LIKE argument produce zero findings
- `python_injection.feature`: spaced `"..." % x`, unspaced `"..."%x`, variable-held `q % x`, f-string, concatenation, and `.format()` all still report SQL Injection

One part of #35 is intentionally not covered here: the rule's `*cursor.execute(*.format(*` pattern still flags psycopg's safe `sql.SQL(...).format(...)` composition API. Search rules have no pattern-level exclude mechanism, so that case needs its own treatment rather than being bundled into this fix.

Verified with a rebuilt binary against the issue's exact repro: `Found 0 vulnerabilities`. `cargo test --test acceptance` passes 15/15 scenarios.

## Related issue

Closes #35

## Checklist

- [x] `cargo build --release` succeeds
- [x] Ran any test harness relevant to this change (note results; suite under repair) - `cargo test --test acceptance`: 15 scenarios / 52 steps pass, including the 7 new scenarios covering this rule
- [x] Updated docs/rules where relevant - the change is to `rules/python/sql_injection.ron` itself, with an inline comment explaining what the pattern matches
