### PR TITLE
docs: align contribution flow with actual CI gate (make ci)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,6 +8,7 @@
 
 ## Checklist
 
-- [ ] `cargo build --release` succeeds
-- [ ] Ran any test harness relevant to this change (note results; suite under repair)
+- [ ] `make ci` passes locally (the same command CI runs — see CONTRIBUTING.md)
+- [ ] Ran `make bootstrap` once so pre-commit/pre-push hooks are active
+- [ ] Added/updated tests for the change
 - [ ] Updated docs/rules where relevant

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:
@@ -16,6 +17,8 @@ jobs:
         with:
           components: clippy, rustfmt, llvm-tools-preview
 
+      - uses: Swatinem/rust-cache@v2
+
       - name: Install uv (for uvx lizard)
         uses: astral-sh/setup-uv@v5
 
@@ -26,6 +29,3 @@ jobs:
 
       - name: make ci
         run: make ci
-
-      - name: make audit
-        run: make audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,44 +5,64 @@ and contribution workflow.
 
 ## Prerequisites
 
-- Rust 1.70+ (install from https://rustup.rs/)
+- Rust stable 1.88+ via [rustup](https://rustup.rs/) (the dev harness uses
+  edition 2024)
 - Git
 
-## Build
+For full CI parity, install the tools CI uses:
+
+```bash
+make tools    # llvm-tools-preview component + cargo-audit, cargo-llvm-cov, cargo-modules
+```
+
+`cargo-audit` is required — `make ci` fails without it. The others degrade to a
+skipped check, but installing them gives you the exact CI result. The complexity
+gate additionally uses [uv](https://docs.astral.sh/uv/) (`uvx`); it is advisory,
+so skipping it never blocks.
+
+## Setup
 
 ```bash
 git clone https://github.com/Corgea/Sighthound.git
 cd Sighthound
+make bootstrap                 # install git pre-commit + pre-push hooks
 cargo build --release          # binary at target/release/sighthound
 ```
 
-`cargo build --release` is the command CI gates on and should succeed before
-you open a PR.
+## Before you open a PR
+
+```bash
+make ci
+```
+
+This is the exact command CI runs: clippy (`-D warnings`) → `cargo fmt --check` →
+`cargo audit` → complexity (advisory) → `cargo test` → acceptance → coverage →
+CRAP (advisory) → architecture check. If `make ci` passes locally, CI passes.
+
+Faster inner-loop targets:
+
+| Target           | Action                                            |
+|------------------|---------------------------------------------------|
+| `make check`     | auto-fix clippy + format, run tests               |
+| `make fix`       | `cargo clippy --fix` + `cargo fmt`                |
+| `make lint`      | clippy + `fmt --check` (read-only)                |
+| `make test`      | `cargo test`                                      |
+| `make ci`        | full CI pipeline — run before every PR            |
+| `make bootstrap` | install git hooks                                 |
+
+The hooks from `make bootstrap` run `make pre-commit` (staged Rust files) and
+`make pre-push` (lint + acceptance + arch) automatically, catching most CI
+failures before they leave your machine.
 
 ## Tests
 
-The repository ships three test harnesses (`unit_tests`, `integration_tests`,
-and `end_to_end_tests`). They are being realigned to the crate's refactored
-rule API — some modules are temporarily disabled and `cargo test` is not yet
-fully green, so CI gates on `cargo build --release`. Restoring `cargo test` to
-green is tracked in its own PR; contributions that fix a harness are welcome.
+`cargo test` runs the unit, integration, and end-to-end harnesses and is a
+blocking CI gate — keep it green.
 
 ```bash
-cargo build --release          # the CI-gated command
-cargo test --test unit_tests   # a single harness (some modules under repair)
+cargo test                     # all harnesses
+cargo test --test unit_tests   # a single harness
 ```
-
-### Make targets
-
-| Target           | Action                              |
-|------------------|-------------------------------------|
-| `make build`     | `cargo build --release`             |
-| `make clean`     | clean build artifacts               |
-| `make install`   | `cargo install --path .`            |
-| `make help`      | list targets                        |
-
-`make test` / `test-unit` / `test-all` invoke `cargo test`, which is under
-repair (see above).
 
 ## Multi-platform builds
 
@@ -60,8 +80,8 @@ authoring guidance.
 
 1. Fork the repository.
 2. Create a feature branch: `git checkout -b feature/your-feature`.
-3. Make your changes and add tests where practical.
-4. Confirm `cargo build --release` succeeds.
+3. Make your changes and add tests.
+4. Run `make ci` — the same command CI runs — and confirm it passes.
 5. Submit a pull request.
 
 By contributing, you agree your contributions are licensed under the MIT

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Sighthound Vulnerability Scanner Makefile
 
-.PHONY: all build test test-unit test-all clean install help
+.PHONY: all build test test-unit test-all clean install help tools
 
 # Default target
 all: build test
@@ -10,7 +10,7 @@ build:
 	@echo "🔨 Building Sighthound..."
 	cargo build --release
 
-# Run the Rust test suite via cargo test (under repair)
+# Run the Rust test suite via cargo test (blocking CI gate)
 test-unit:
 	@echo "🦀 Running Rust tests..."
 	cargo test
@@ -32,6 +32,12 @@ install: build
 	@echo "📦 Installing Sighthound..."
 	cargo install --path .
 
+# Install the cargo tools `make ci` uses (same set CI installs)
+tools:
+	@echo "🧰 Installing CI tools..."
+	rustup component add llvm-tools-preview
+	cargo install cargo-audit cargo-llvm-cov cargo-modules
+
 # Show help
 help:
 	@echo "Sighthound Vulnerability Scanner Build System"
@@ -39,9 +45,12 @@ help:
 	@echo ""
 	@echo "Available targets:"
 	@echo "  build       - Build the release binary"
-	@echo "  test        - Run cargo test (under repair; some modules disabled)"
+	@echo "  test        - Run cargo test (unit + integration + end_to_end)"
 	@echo "  test-unit   - Run cargo test"
 	@echo "  test-all    - Run cargo test"
+	@echo "  ci          - Full CI pipeline — run before every PR"
+	@echo "  bootstrap   - Install git pre-commit + pre-push hooks"
+	@echo "  tools       - Install the cargo tools CI uses"
 	@echo "  clean       - Clean build artifacts"
 	@echo "  install     - Install binary to system"
 	@echo "  help        - Show this help message"


### PR DESCRIPTION
## Summary

Contributors were seeing frequent CI failures because **the local instructions and the CI gate were different commands**. `CONTRIBUTING.md` told them CI gates on `cargo build --release` and that the test suite was "under repair" — both false. CI actually runs `make ci`: clippy `-D warnings` → `cargo fmt --check` → `cargo audit` → complexity → **blocking `cargo test`** → acceptance → coverage → arch (`harness.rs:987`). Contributors never ran locally what CI checks.

This makes **`make ci` the single canonical pre-PR command** documented identically in CONTRIBUTING, the PR template, the Makefile help, and README (which already named it).

## Changes

- **CONTRIBUTING.md** — rewritten around `make ci` (the exact CI command) and `make bootstrap` (git hooks). Removes the false "under repair / gates on build" narrative. Documents the real toolchain (Rust stable **1.88+**, edition 2024) and the CI-parity tool set via new `make tools`.
- **.github/pull_request_template.md** — checklist now asks for `make ci` passing locally + `make bootstrap` hooks active.
- **Makefile** — adds `make tools` (installs the same cargo tools CI installs: `llvm-tools-preview`, `cargo-audit`, `cargo-llvm-cov`, `cargo-modules`); surfaces `ci`/`bootstrap`/`tools` in `make help`; fixes the stale "under repair" comment.
- **.github/workflows/ci.yml** — drops the redundant `make audit` step (`make ci` already runs a strict audit internally), adds `Swatinem/rust-cache@v2`, and limits the `push` trigger to `main` so PR branches don't run CI twice.

## Why this fixes the churn

`make ci` locally == CI byte-for-byte. `make bootstrap` installs pre-commit/pre-push hooks that catch most failures before they leave a contributor's machine. Every doc surface now points at the same command instead of contradicting each other.

## Verification

- `make -n tools` and `make help` verified (targets parse, help lists new targets).
- CI gate steps verified against `harness.rs` `cmd_ci` (redundant `make audit` confirmed).
- Docs-and-config only; no scanner/rule code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)