### PR TITLE
Add ObjectScript scanning and security rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1277,6 +1277,8 @@ dependencies = [
  "tree-sitter-html",
  "tree-sitter-java",
  "tree-sitter-javascript",
+ "tree-sitter-objectscript",
+ "tree-sitter-objectscript-routine",
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-ruby",
@@ -1556,6 +1558,28 @@ name = "tree-sitter-language"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4013970217383f67b18aef68f6fb2e8d409bc5755227092d32efb0422ba24b8"
+
+[[package]]
+name = "tree-sitter-objectscript"
+version = "1.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c72df9f9a7beb0be606e222b7354f20d5ab7b4923c2456a2770147a6ef4a58"
+dependencies = [
+ "cc",
+ "tree-sitter",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-objectscript-routine"
+version = "1.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47bbb60005e756c1ad89f562997ca746a90964d086bc974a731de3cb8b660c6b"
+dependencies = [
+ "cc",
+ "tree-sitter",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-php"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ path = "harness.rs"
 edition = "2024"
 
 [features]
-default = ["python", "java", "javascript", "tsx", "typescript", "go", "ruby", "csharp", "html", "django", "php"]
+default = ["python", "java", "javascript", "tsx", "typescript", "go", "ruby", "csharp", "html", "django", "php", "objectscript"]
 python = ["tree-sitter-python"]
 java = ["tree-sitter-java"]
 javascript = ["tree-sitter-javascript"]
@@ -31,6 +31,7 @@ csharp = ["tree-sitter-c-sharp"]
 html = ["tree-sitter-html"]
 django = ["tree-sitter-html"]  # Reuse HTML parser for Django templates
 php = ["tree-sitter-php"]
+objectscript = ["dep:tree-sitter-objectscript", "dep:tree-sitter-objectscript-routine"]
 
 [dependencies]
 tree-sitter = "0.26"
@@ -68,6 +69,8 @@ env_logger = "0.10"
 ignore = "0.4"
 lazy_static = "1.4"
 dbg_breakpoint="0.1.1"
+tree-sitter-objectscript = { version = "1.9.11", optional = true }
+tree-sitter-objectscript-routine = { version = "1.9.11", optional = true }
 [dev-dependencies]
 tempfile = "3.8"
 proptest = "1"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Tree-sitter based static vulnerability scanner with pattern matching and taint-f
 | C# | `.cs`, `.csx` | Yes | Yes |
 | Go | `.go` | Yes | Yes |
 | Ruby | `.rb` | Yes | Yes |
+| ObjectScript | `.cls`, `.mac`, `.inc`, `.int`, `.rtn` | Yes (class and routine grammars) | Yes |
 | HTML | `.html`, `.htm`, `.twig`, `.ejs`, `.hbs`, ... | Yes | Yes |
 | Django templates | `.html` (Django syntax) | Yes | Yes (HTML rules) |
 

--- a/rules/objectscript/code_injection.ron
+++ b/rules/objectscript/code_injection.ron
@@ -1,0 +1,22 @@
+(
+    rules: [
+        (
+            id: Some("objectscript-code-injection-xecute"),
+            name: Some("Dynamic ObjectScript execution"),
+            category: Some("code-injection"),
+            mode: "search",
+            patterns: Some([
+                "*XECUTE*_*",
+                "*$XECUTE(*_*",
+                "=__sh_fullctx__"
+            ]),
+            finding_type: Some("Code Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
+            description: Some("ObjectScript code assembled through string concatenation is executed dynamically."),
+            file_types: Some((extensions: Some([".cls", ".mac", ".inc", ".int", ".rtn"]))),
+            tags: Some(["code-injection", "cwe-95", "objectscript"])
+        )
+    ]
+)

--- a/rules/objectscript/command_injection.ron
+++ b/rules/objectscript/command_injection.ron
@@ -1,0 +1,21 @@
+(
+    rules: [
+        (
+            id: Some("objectscript-command-injection-zf"),
+            name: Some("Dynamic operating-system command execution"),
+            category: Some("command-injection"),
+            mode: "search",
+            patterns: Some([
+                "*$ZF(*_*",
+                "=__sh_fullctx__"
+            ]),
+            finding_type: Some("Command Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-78"),
+            description: Some("An operating-system command is assembled dynamically before being passed to $ZF."),
+            file_types: Some((extensions: Some([".cls", ".mac", ".inc", ".int", ".rtn"]))),
+            tags: Some(["command-injection", "cwe-78", "objectscript"])
+        )
+    ]
+)

--- a/rules/objectscript/path_traversal.ron
+++ b/rules/objectscript/path_traversal.ron
@@ -1,0 +1,22 @@
+(
+    rules: [
+        (
+            id: Some("objectscript-path-traversal-file-open"),
+            name: Some("Dynamic path passed to file API"),
+            category: Some("path-traversal"),
+            mode: "search",
+            patterns: Some([
+                "*%Library.File*Open(*_*",
+                "*%Stream.FileBinary*%New(*_*",
+                "=__sh_fullctx__"
+            ]),
+            finding_type: Some("Path Traversal"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-22"),
+            description: Some("A file path is assembled dynamically before use. Resolve and allowlist the final path."),
+            file_types: Some((extensions: Some([".cls", ".mac", ".inc", ".int", ".rtn"]))),
+            tags: Some(["path-traversal", "cwe-22", "objectscript"])
+        )
+    ]
+)

--- a/rules/objectscript/sql_injection.ron
+++ b/rules/objectscript/sql_injection.ron
@@ -1,0 +1,21 @@
+(
+    rules: [
+        (
+            id: Some("objectscript-sql-injection-execdirect"),
+            name: Some("Dynamic SQL passed to %ExecDirect"),
+            category: Some("sql-injection"),
+            mode: "search",
+            patterns: Some([
+                "*%ExecDirect(*_*",
+                "=__sh_fullctx__"
+            ]),
+            finding_type: Some("SQL Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-89"),
+            description: Some("A dynamically concatenated SQL statement is executed directly. Use placeholders and bind values as parameters."),
+            file_types: Some((extensions: Some([".cls", ".mac", ".inc", ".int", ".rtn"]))),
+            tags: Some(["sql-injection", "cwe-89", "objectscript"])
+        )
+    ]
+)

--- a/rules/objectscript/ssrf.ron
+++ b/rules/objectscript/ssrf.ron
@@ -1,0 +1,22 @@
+(
+    rules: [
+        (
+            id: Some("objectscript-ssrf-http-get"),
+            name: Some("Request data used as an outbound HTTP target"),
+            category: Some("ssrf"),
+            mode: "search",
+            patterns: Some([
+                "*Get(*%request.Data(*",
+                "*Get(*%request.Get(*",
+                "=__sh_fullctx__"
+            ]),
+            finding_type: Some("Server-Side Request Forgery"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-918"),
+            description: Some("Untrusted HTTP request data is passed directly to an outbound HTTP request."),
+            file_types: Some((extensions: Some([".cls", ".mac", ".inc", ".int", ".rtn"]))),
+            tags: Some(["ssrf", "cwe-918", "objectscript"])
+        )
+    ]
+)

--- a/src/code_type_detector.rs
+++ b/src/code_type_detector.rs
@@ -248,9 +248,8 @@ impl CodeTypeDetector {
         // Default fallback based on language
         match language.to_lowercase().as_str() {
             "javascript" | "typescript" | "tsx" | "jsx" => CodeType::Frontend,
-            "python" | "java" | "rust" | "go" | "php" | "ruby" | "c" | "cpp" | "c#" | "csharp" => {
-                CodeType::Backend
-            }
+            "python" | "java" | "rust" | "go" | "php" | "ruby" | "objectscript" | "c" | "cpp"
+            | "c#" | "csharp" => CodeType::Backend,
             _ => CodeType::Unknown,
         }
     }

--- a/src/language.rs
+++ b/src/language.rs
@@ -1,5 +1,6 @@
 use crate::parser::get_node_text_slice;
 use anyhow::Result;
+use std::path::Path;
 use tree_sitter::{Language, Node};
 
 pub trait LanguageSupport: Send + Sync {
@@ -35,6 +36,8 @@ pub fn get_language_support(language_name: &str) -> Result<Box<dyn LanguageSuppo
         "django" | "django-html" => Ok(Box::new(DjangoTemplateLanguage)),
         #[cfg(feature = "php")]
         "php" => Ok(Box::new(PHPLanguage)),
+        #[cfg(feature = "objectscript")]
+        "objectscript" => Ok(Box::new(ObjectScriptLanguage::udl())),
         _ => {
             let mut supported = Vec::new();
             #[cfg(feature = "python")]
@@ -59,6 +62,8 @@ pub fn get_language_support(language_name: &str) -> Result<Box<dyn LanguageSuppo
             supported.push("django");
             #[cfg(feature = "php")]
             supported.push("php");
+            #[cfg(feature = "objectscript")]
+            supported.push("objectscript");
 
             anyhow::bail!(
                 "Unsupported language: {}. Supported languages: {}",
@@ -67,6 +72,31 @@ pub fn get_language_support(language_name: &str) -> Result<Box<dyn LanguageSuppo
             )
         }
     }
+}
+
+pub fn get_language_support_for_path(
+    language_name: &str,
+    path: &Path,
+) -> Result<Box<dyn LanguageSupport>> {
+    #[cfg(feature = "objectscript")]
+    if language_name.eq_ignore_ascii_case("objectscript") {
+        let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or_default();
+        let grammar =
+            if matches!(extension.to_ascii_lowercase().as_str(), "mac" | "inc" | "int" | "rtn") {
+                ObjectScriptGrammar::Routine
+            } else {
+                ObjectScriptGrammar::Udl
+            };
+        return Ok(Box::new(ObjectScriptLanguage { grammar }));
+    }
+
+    get_language_support(language_name)
+}
+
+fn direct_named_child_of_kind<'a>(node: &Node<'a>, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    let child = node.named_children(&mut cursor).find(|child| child.kind() == kind);
+    child
 }
 
 // Python Implementation
@@ -407,6 +437,88 @@ impl LanguageSupport for PHPLanguage {
 
     fn get_arguments_node<'a>(&self, node: &'a Node) -> Option<Node<'a>> {
         node.child_by_field_name("arguments")
+    }
+}
+
+#[cfg(feature = "objectscript")]
+#[derive(Clone, Copy)]
+enum ObjectScriptGrammar {
+    Udl,
+    Routine,
+}
+
+#[cfg(feature = "objectscript")]
+pub struct ObjectScriptLanguage {
+    grammar: ObjectScriptGrammar,
+}
+
+#[cfg(feature = "objectscript")]
+impl ObjectScriptLanguage {
+    fn udl() -> Self {
+        Self { grammar: ObjectScriptGrammar::Udl }
+    }
+}
+
+#[cfg(feature = "objectscript")]
+impl LanguageSupport for ObjectScriptLanguage {
+    fn name(&self) -> &'static str {
+        "objectscript"
+    }
+
+    fn file_extension(&self) -> &'static str {
+        ".cls"
+    }
+
+    fn tree_sitter_language(&self) -> Language {
+        match self.grammar {
+            ObjectScriptGrammar::Udl => tree_sitter_objectscript::LANGUAGE_OBJECTSCRIPT_UDL.into(),
+            ObjectScriptGrammar::Routine => {
+                tree_sitter_objectscript_routine::LANGUAGE_OBJECTSCRIPT_ROUTINE.into()
+            }
+        }
+    }
+
+    fn call_node_types(&self) -> &[&'static str] {
+        &[
+            "class_method_call",
+            "oref_method",
+            "superclass_method_call",
+            "extrinsic_function",
+            "system_defined_function",
+            "routine_tag_call",
+            "command_xecute",
+        ]
+    }
+
+    fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str> {
+        match node.kind() {
+            "class_method_call" | "oref_method" => direct_named_child_of_kind(node, "method_name")
+                .map(|child| get_node_text_slice(&child, source)),
+            "extrinsic_function" | "routine_tag_call" => {
+                direct_named_child_of_kind(node, "line_ref")
+                    .map(|child| get_node_text_slice(&child, source))
+            }
+            "superclass_method_call" => Some("##SUPER"),
+            "command_xecute" => Some("XECUTE"),
+            "system_defined_function" => {
+                let text = get_node_text_slice(node, source);
+                Some(text.split_once('(').map_or(text, |(name, _)| name))
+            }
+            _ => None,
+        }
+    }
+
+    fn get_arguments_node<'a>(&self, node: &'a Node) -> Option<Node<'a>> {
+        match node.kind() {
+            "class_method_call"
+            | "oref_method"
+            | "superclass_method_call"
+            | "extrinsic_function"
+            | "routine_tag_call" => direct_named_child_of_kind(node, "method_args"),
+            "command_xecute" => direct_named_child_of_kind(node, "xecute_argument"),
+            "system_defined_function" => node.named_child(0),
+            _ => None,
+        }
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -293,7 +293,9 @@ pub struct Cli {
     pub root_dir: Option<String>,
 
     /// Language to scan (optional - triggers explicit mode when used with rules_path)
-    #[arg(help = "Programming language to scan (python, java, javascript, tsx, html, django)")]
+    #[arg(
+        help = "Programming language to scan (python, java, javascript, tsx, html, django, objectscript)"
+    )]
     pub language: Option<String>,
 
     /// Rules file or directory path (optional - triggers explicit mode when used with language)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
-use crate::language::{get_language_support, LanguageSupport};
+use crate::language::{get_language_support, get_language_support_for_path, LanguageSupport};
 use anyhow::{Context, Result};
+use std::path::Path;
 use tree_sitter::{Node, Parser as TSParser, Tree};
 
 pub struct LanguageParser {
@@ -10,6 +11,15 @@ pub struct LanguageParser {
 impl LanguageParser {
     pub fn new(language_name: &str) -> Result<Self> {
         let language_support = get_language_support(language_name)?;
+        Self::with_support(language_support)
+    }
+
+    pub fn new_for_path(language_name: &str, path: &Path) -> Result<Self> {
+        let language_support = get_language_support_for_path(language_name, path)?;
+        Self::with_support(language_support)
+    }
+
+    fn with_support(language_support: Box<dyn LanguageSupport>) -> Result<Self> {
         let language = language_support.tree_sitter_language();
         let mut parser = TSParser::new();
         parser.set_language(&language).context("Failed to set language")?;

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -26,6 +26,7 @@ static RULES_GO: Dir = include_dir!("$CARGO_MANIFEST_DIR/rules/go");
 static RULES_RUBY: Dir = include_dir!("$CARGO_MANIFEST_DIR/rules/ruby");
 static RULES_HTML: Dir = include_dir!("$CARGO_MANIFEST_DIR/rules/html");
 static RULES_PHP: Dir = include_dir!("$CARGO_MANIFEST_DIR/rules/php");
+static RULES_OBJECTSCRIPT: Dir = include_dir!("$CARGO_MANIFEST_DIR/rules/objectscript");
 
 // Structure for centralized exclusion patterns
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -153,6 +154,9 @@ impl Rules {
             "ruby" => all_rules.extend(Self::parse_embedded_dir(&RULES_RUBY, "Ruby")?),
             "html" | "django" => all_rules.extend(Self::parse_embedded_dir(&RULES_HTML, "HTML")?),
             "php" => all_rules.extend(Self::parse_embedded_dir(&RULES_PHP, "PHP")?),
+            "objectscript" => {
+                all_rules.extend(Self::parse_embedded_dir(&RULES_OBJECTSCRIPT, "ObjectScript")?)
+            }
             _ => {
                 return Err(anyhow::anyhow!(
                     "No embedded rules available for language: {}",

--- a/src/scanner/multifile_taint.rs
+++ b/src/scanner/multifile_taint.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use crate::common::CommonUtils;
 use crate::scanner::dataflow::DataFlowTracer;
 use crate::scanner::flow_tracker::{AnalysisResult, CrossFileFlowKey, VerifiedTaintFlow};
-use crate::scanner::parser_helper::with_local_parser;
+use crate::scanner::parser_helper::with_local_parser_for_path;
 use crate::scanner::scanning_logic::ScanningLogic;
 use crate::scanner::taint_utils::TaintRuleDeduplicator;
 
@@ -291,16 +291,15 @@ impl MultiFileTaintAnalyzer {
         let filepath = file_path.to_string_lossy();
         let source = std::fs::read(file_path)?;
 
-        with_local_parser(language, |parser| {
+        with_local_parser_for_path(language, file_path, |parser| {
             let tree = parser.parse(&source)?;
-            let language_support = crate::language::get_language_support(language)?;
 
             self.analyze_file_imports_exports(
                 &filepath,
                 &source,
                 &tree,
                 rule_deduplicator,
-                language_support.as_ref(),
+                parser.language_support(),
             );
 
             Ok(())

--- a/src/scanner/parser_helper.rs
+++ b/src/scanner/parser_helper.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use std::cell::RefCell;
+use std::path::Path;
 
 use crate::parser::LanguageParser;
 
@@ -7,18 +8,29 @@ thread_local! {
     static TLS_PARSER: RefCell<Option<(String, LanguageParser)>> = const { RefCell::new(None) };
 }
 
-pub(crate) fn with_local_parser<F, R>(language: &str, f: F) -> Result<R>
+pub(crate) fn with_local_parser_for_path<F, R>(language: &str, path: &Path, f: F) -> Result<R>
 where
     F: FnOnce(&mut LanguageParser) -> Result<R>,
 {
+    let extension = path.extension().and_then(|ext| ext.to_str()).unwrap_or_default();
+    let cache_key = if language.eq_ignore_ascii_case("objectscript")
+        && matches!(extension.to_ascii_lowercase().as_str(), "mac" | "inc" | "int" | "rtn")
+    {
+        "objectscript:routine".to_string()
+    } else if language.eq_ignore_ascii_case("objectscript") {
+        "objectscript:udl".to_string()
+    } else {
+        language.to_string()
+    };
+
     TLS_PARSER.try_with(|cell| {
         let mut opt = cell.borrow_mut();
         match *opt {
-            Some((ref lang, ref mut parser)) if lang == language => f(parser),
+            Some((ref key, ref mut parser)) if key == &cache_key => f(parser),
             _ => {
-                let mut parser = LanguageParser::new(language)?;
+                let mut parser = LanguageParser::new_for_path(language, path)?;
                 let result = f(&mut parser)?;
-                *opt = Some((language.to_string(), parser));
+                *opt = Some((cache_key, parser));
                 Ok(result)
             }
         }

--- a/src/scanner/prefilter.rs
+++ b/src/scanner/prefilter.rs
@@ -185,7 +185,7 @@ impl PreFilter {
     /// Extract all import statements as a single text blob
     fn extract_imports(&self, file_path: &str) -> Result<String> {
         let source = fs::read(file_path)?;
-        let mut parser = LanguageParser::new(&self.language)?;
+        let mut parser = LanguageParser::new_for_path(&self.language, Path::new(file_path))?;
         let tree = parser.parse(&source)?;
 
         let mut imports_text = String::new();

--- a/src/scanner/utils.rs
+++ b/src/scanner/utils.rs
@@ -259,6 +259,9 @@ pub fn detect_language_from_path(file_path: &Path) -> Option<&'static str> {
         // PHP extensions
         "php" | "php3" | "php4" | "php5" | "php7" | "phtml" => Some("php"),
 
+        // InterSystems ObjectScript class and routine sources
+        "cls" | "mac" | "inc" | "int" | "rtn" => Some("objectscript"),
+
         // JavaScript extensions (including modern variants)
         "js" | "mjs" | "cjs" | "jsx" => Some("javascript"),
 

--- a/src/scanner/vulnerability_scanner.rs
+++ b/src/scanner/vulnerability_scanner.rs
@@ -12,7 +12,7 @@ use crate::parser::LanguageParser;
 use crate::rules::Rules;
 use crate::scanner::multifile_taint::MultiFileTaintAnalyzer;
 use crate::scanner::output::ProgressManager;
-use crate::scanner::parser_helper::with_local_parser;
+use crate::scanner::parser_helper::with_local_parser_for_path;
 use crate::scanner::scan_context::{FilesByLanguage, ScanRuleSet};
 use crate::scanner::scanning_logic::ScanningLogic;
 
@@ -103,6 +103,7 @@ impl VulnerabilityScanner {
                     | "jade"
             ),
             "django" => matches!(ext, "html" | "htm"),
+            "objectscript" => matches!(ext, "cls" | "mac" | "inc" | "int" | "rtn"),
             _ => file_extension == target_extension,
         }
     }
@@ -201,7 +202,7 @@ impl VulnerabilityScanner {
         };
         let source: &[u8] = &mmap;
 
-        match with_local_parser(language, |parser| {
+        match with_local_parser_for_path(language, path, |parser| {
             let tree = parser.parse(source)?;
             Ok(ScanningLogic::scan_file_with_rules(
                 &filepath_str,
@@ -457,7 +458,7 @@ impl VulnerabilityScanner {
         };
         let source: &[u8] = &mmap;
 
-        match with_local_parser(detected_language, |parser| {
+        match with_local_parser_for_path(detected_language, path, |parser| {
             let tree = parser.parse(source)?;
 
             let mut file_findings = Vec::new();


### PR DESCRIPTION
## Summary
- add one ObjectScript language backed by path-aware class and routine tree-sitter grammars
- discover `.cls`, `.mac`, `.inc`, `.int`, and `.rtn` files in explicit and automatic scans
- ship embedded rules for SQL injection, command/code injection, path traversal, and SSRF

## Test plan
- [x] `cargo +1.89.0 harness check` (193 tests)
- [x] `cargo +1.89.0 check --no-default-features --features objectscript --lib --bin sighthound`
- [x] scan mixed `.cls` and `.mac` fixture with embedded rules
- [x] local curated benchmark: TP 5, FP 0, TN 5, FN 0; precision/recall/F1 100%

Made with [Cursor](https://cursor.com)