### PR TITLE
docs: highlight the Corgea platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Tree-sitter based static vulnerability scanner with pattern matching and taint-f
 
 </div>
 
+> **Want Sighthound without the setup?** [Sign up for Corgea](https://corgea.app),
+> where Sighthound is built in alongside AI SAST, secrets, container, dependency,
+> and IaC scanning—with false-positive reduction and automated fixes.
+
 ## What It Does
 
 - Scans source code for security issues using AST-aware rules.


### PR DESCRIPTION
## Summary
- add a concise Corgea platform callout to the README
- highlight built-in Sighthound and the broader scanning, false-positive reduction, and autofix capabilities

## Test plan
- [x] Review the rendered Markdown copy and link
- [x] Documentation-only change; no code tests required


Made with [Cursor](https://cursor.com)