### PR TITLE
Remove unused Crossbeam dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -253,28 +253,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,15 +267,6 @@ name = "crossbeam-epoch"
 version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1249,7 +1218,6 @@ version = "0.1.1"
 dependencies = [
  "anyhow",
  "clap",
- "crossbeam",
  "cucumber",
  "dbg_breakpoint",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,6 @@ once_cell = "1.18"
 rayon = "1.8"
 indicatif = "0.17"
 glob = "0.3"
-crossbeam = "0.8"
 num_cpus = "1.16"
 syntect = { version = "5.1", default-features = false, features = [
     "default-syntaxes",


### PR DESCRIPTION
## Summary

Remove the unused direct `crossbeam` dependency and refresh the lockfile. The
source tree has no `crossbeam` references, and removing it also drops the unused
`crossbeam-channel` and `crossbeam-queue` crates while retaining the Crossbeam
components required by active dependencies.

## Related issue

None.

## Impact

This reduces the resolved dependency graph and supply-chain surface without
changing runtime behavior.

## Checklist

- [x] `make ci` passes locally (the same command CI runs — see CONTRIBUTING.md)
- [x] Pre-commit and pre-push hooks are active
- [x] Existing all-feature tests cover the dependency-only change (200 passed)
- [x] Docs/rules are not affected

## Verification

- `cargo metadata --locked --format-version 1 --no-deps`
- `cargo check --locked --all-targets --all-features`
- `cargo test --locked --all-features --quiet`
- `make ci` (`MAKE_CI_EXIT=0`)
