### PR TITLE
fix(scanner): prevent mmap OS errors and stderr noise on 0-byte source files

### DIFF
--- a/src/scanner/vulnerability_scanner.rs
+++ b/src/scanner/vulnerability_scanner.rs
@@ -193,6 +193,17 @@ impl VulnerabilityScanner {
                 return Vec::new();
             }
         };
+        let metadata = match file.metadata() {
+            Ok(m) => m,
+            Err(err) => {
+                eprintln!("Failed to stat file {}: {}", filepath_str, err);
+                return Vec::new();
+            }
+        };
+        if metadata.len() == 0 {
+            return Vec::new();
+        }
+
         let mmap = match unsafe { Mmap::map(&file) } {
             Ok(mmap) => mmap,
             Err(e) => {
@@ -817,5 +828,21 @@ impl VulnerabilityScanner {
         }
 
         Ok(all_findings)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scan_single_file_with_rules_handles_zero_byte_file() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let empty_file_path = temp_dir.path().join("empty.py");
+        std::fs::File::create(&empty_file_path).expect("failed to create empty file");
+
+        let findings =
+            VulnerabilityScanner::scan_single_file_with_rules(&empty_file_path, "python", &[]);
+        assert!(findings.is_empty());
     }
 }

--- a/src/scanner/vulnerability_scanner.rs
+++ b/src/scanner/vulnerability_scanner.rs
@@ -177,6 +177,18 @@ impl VulnerabilityScanner {
         )
     }
 
+    /// Safely memory-maps a file for scanning.
+    /// Returns `Ok(None)` if the file is zero bytes (valid empty file, skip mmap without error).
+    /// Returns `Ok(Some(mmap))` if the file was successfully memory-mapped.
+    /// Returns `Err(err)` if obtaining file metadata or memory mapping fails.
+    fn mmap_file_content(file: &File) -> std::io::Result<Option<Mmap>> {
+        let metadata = file.metadata()?;
+        if metadata.len() == 0 {
+            return Ok(None);
+        }
+        unsafe { Mmap::map(file) }.map(Some)
+    }
+
     /// Parse and scan a single file with search rules; returns empty findings (after logging to
     /// stderr) on any open/mmap/parse failure.
     fn scan_single_file_with_rules(
@@ -193,19 +205,9 @@ impl VulnerabilityScanner {
                 return Vec::new();
             }
         };
-        let metadata = match file.metadata() {
-            Ok(m) => m,
-            Err(err) => {
-                eprintln!("Failed to stat file {}: {}", filepath_str, err);
-                return Vec::new();
-            }
-        };
-        if metadata.len() == 0 {
-            return Vec::new();
-        }
-
-        let mmap = match unsafe { Mmap::map(&file) } {
-            Ok(mmap) => mmap,
+        let mmap = match Self::mmap_file_content(&file) {
+            Ok(Some(mmap)) => mmap,
+            Ok(None) => return Vec::new(),
             Err(e) => {
                 eprintln!("Failed to mmap file {}: {}", filepath_str, e);
                 return Vec::new();
@@ -460,8 +462,9 @@ impl VulnerabilityScanner {
                 return Vec::new();
             }
         };
-        let mmap = match unsafe { Mmap::map(&file) } {
-            Ok(mmap) => mmap,
+        let mmap = match Self::mmap_file_content(&file) {
+            Ok(Some(mmap)) => mmap,
+            Ok(None) => return Vec::new(),
             Err(e) => {
                 eprintln!("Failed to mmap file {}: {}", filepath_str, e);
                 return Vec::new();
@@ -834,6 +837,31 @@ impl VulnerabilityScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+
+    #[test]
+    fn mmap_file_content_returns_none_for_zero_byte_file() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let empty_file_path = temp_dir.path().join("empty.py");
+        let file = std::fs::File::create(&empty_file_path).expect("failed to create empty file");
+
+        let result =
+            VulnerabilityScanner::mmap_file_content(&file).expect("mmap_file_content failed");
+        assert!(result.is_none(), "0-byte file must return Ok(None) to skip mmap");
+    }
+
+    #[test]
+    fn mmap_file_content_returns_some_mmap_for_non_empty_file() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let file_path = temp_dir.path().join("test.py");
+        let mut file = std::fs::File::create(&file_path).expect("failed to create file");
+        file.write_all(b"print('hello')").expect("failed to write content");
+
+        let file = std::fs::File::open(&file_path).expect("failed to open file");
+        let result =
+            VulnerabilityScanner::mmap_file_content(&file).expect("mmap_file_content failed");
+        assert!(result.is_some(), "non-empty file must return Ok(Some(mmap))");
+    }
 
     #[test]
     fn scan_single_file_with_rules_handles_zero_byte_file() {
@@ -843,6 +871,22 @@ mod tests {
 
         let findings =
             VulnerabilityScanner::scan_single_file_with_rules(&empty_file_path, "python", &[]);
+        assert!(findings.is_empty());
+    }
+
+    #[test]
+    fn scan_single_file_findings_handles_zero_byte_file() {
+        let temp_dir = tempfile::tempdir().expect("failed to create temp dir");
+        let empty_file_path = temp_dir.path().join("empty.py");
+        std::fs::File::create(&empty_file_path).expect("failed to create empty file");
+
+        let rules = ScanRuleSet {
+            has_search_rules: false,
+            has_taint_rules: false,
+            search_rules: &[],
+            taint_rules: &[],
+        };
+        let findings = VulnerabilityScanner::scan_single_file_findings(&empty_file_path, &rules);
         assert!(findings.is_empty());
     }
 }


### PR DESCRIPTION
Fixes #58 
## Description

This PR resolves an issue in [`src/scanner/vulnerability_scanner.rs`](file:///d:/Sighthound/src/scanner/vulnerability_scanner.rs) where memory mapping (`memmap2::Mmap::map(&file)`) was invoked directly on zero-byte (empty) source files.

On major operating systems (Windows, Linux, macOS), calling the memory mapping system call on a `0`-length file returns an operating system kernel error (`EINVAL` or `ERROR_FILE_INVALID`). When Sighthound encountered empty files (such as empty `__init__.py` modules, empty stub files, or placeholder files), it printed `Failed to mmap file ...` error logs to `stderr` and aborted file scanning.

This change adds an explicit file size check using `file.metadata()` prior to calling `Mmap::map(&file)`. If the file is zero bytes, `scan_single_file_with_rules` returns an empty findings vector immediately without calling `Mmap::map`, preventing `stderr` noise and OS mmap failures.

## Changes Made

- **`src/scanner/vulnerability_scanner.rs`**: Checked `metadata.len() == 0` prior to memory mapping in `scan_single_file_with_rules`.
- **`src/scanner/vulnerability_scanner.rs`**: Added unit test `scan_single_file_with_rules_handles_zero_byte_file` to verify 0-byte file scanning completes cleanly.

## Testing & Verification

- Formatted code using `cargo fmt`.
- Executed `cargo test`: all 105 unit tests passed cleanly.
- Verified zero-byte file scanning completes without any `stderr` errors.