### PR TITLE
docs: add agent skill install instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,7 @@ Pytest and scan fixtures both live under these trees — do not put Python/Djang
    - Name by topic: `sql_injection.py`, `command_injection.py`, `views.py`
    - Avoid `test_*.py` / `*_test.py` and `def test_*` so fixtures are not collected by pytest and do not collide with scanner test-skip patterns.
    - Django app samples use app-like names (`views.py`, `migration_sample.py`).
+
+## Agent skill
+
+CLI flag or output-format changes must also update the agent skill at https://github.com/Corgea/skills (`plugins/sighthound/skills/sighthound/SKILL.md`).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ DOCKER_BUILDKIT=1 docker build \
 
 Or run `./build_all_platforms.sh`.
 
+### Agent skill
+
+Using Claude Code, Cursor, Codex, or another coding agent? Install the
+[Sighthound skill](https://github.com/Corgea/skills) so your agent knows how
+to install the scanner, run it, and act on its findings:
+
+```bash
+npx skills add corgea/skills --skill sighthound
+```
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
Adds the agent-skill install one-liner (npx skills add corgea/skills --skill sighthound) to the README and an AGENTS.md note to keep the skill in sync with CLI changes. Skill lives in https://github.com/Corgea/skills.