### PR TITLE
Fix CSV field escaping

### DIFF
--- a/src/scanner/output.rs
+++ b/src/scanner/output.rs
@@ -315,8 +315,8 @@ pub fn print_findings_sarif(findings: &[Finding]) -> Result<()> {
 }
 
 #[cfg(test)]
-mod sarif_tests {
-    use super::{build_sarif_log, sarif_uri};
+mod output_tests {
+    use super::{build_sarif_log, csv_field, sarif_uri};
     use crate::models::Finding;
     use std::path::Path;
 
@@ -441,15 +441,35 @@ mod sarif_tests {
         assert_eq!(sarif_uri("/repo/src/app.py", Some(repository_root)), "src/app.py");
         assert_eq!(sarif_uri("backend/src/app.py", Some(repository_root)), "backend/src/app.py");
     }
+
+    #[test]
+    fn escapes_csv_field_delimiters_quotes_and_newlines() {
+        assert_eq!(csv_field("plain"), "plain");
+        assert_eq!(csv_field("path,with,commas.py"), "\"path,with,commas.py\"");
+        assert_eq!(csv_field("say \"hello\""), "\"say \"\"hello\"\"\"");
+        assert_eq!(csv_field("first\nsecond"), "\"first\nsecond\"");
+        assert_eq!(csv_field("first\r\nsecond"), "\"first\r\nsecond\"");
+    }
 }
 
 /// Print findings in CSV format
+fn csv_quoted_field(value: &str) -> String {
+    format!("\"{}\"", value.replace('"', "\"\""))
+}
+
+fn csv_field(value: &str) -> String {
+    if value.contains([',', '"', '\r', '\n']) {
+        csv_quoted_field(value)
+    } else {
+        value.to_string()
+    }
+}
+
 pub fn print_findings_csv(findings: &[Finding]) -> Result<()> {
     let stdout = std::io::stdout();
     let mut out = BufWriter::new(stdout.lock());
     writeln!(out, "file,line,function,finding_type,code,severity,confidence,cwe_id,source_type,source_context,sink_type,sink_function,traces")?;
     for finding in findings {
-        let code = finding.snippet.replace('"', "\"\"");
         let source_type =
             finding.source_info.as_ref().map(|s| s.source_type.as_str()).unwrap_or("");
         let source_context = finding.source_info.as_ref().map(|s| s.context.as_str()).unwrap_or("");
@@ -468,23 +488,22 @@ pub fn print_findings_csv(findings: &[Finding]) -> Result<()> {
             String::new()
         };
 
-        writeln!(
-            out,
-            "{},{},{},{},\"{}\",{},{},{},{},{},{},{},\"{}\"",
-            finding.file,
-            finding.line,
-            finding.function,
-            finding.finding_type,
-            code,
-            finding.severity,
-            finding.confidence,
-            cwe_id,
-            source_type,
-            source_context,
-            sink_type,
-            sink_function,
-            traces
-        )?;
+        let record = [
+            csv_field(&finding.file),
+            finding.line.to_string(),
+            csv_field(&finding.function),
+            csv_field(&finding.finding_type),
+            csv_quoted_field(&finding.snippet),
+            csv_field(&finding.severity),
+            csv_field(&finding.confidence),
+            csv_field(cwe_id),
+            csv_field(source_type),
+            csv_field(source_context),
+            csv_field(sink_type),
+            csv_field(sink_function),
+            csv_quoted_field(&traces),
+        ];
+        writeln!(out, "{}", record.join(","))?;
     }
     out.flush()?;
     Ok(())

--- a/tests/integration/integration_tests.rs
+++ b/tests/integration/integration_tests.rs
@@ -439,6 +439,46 @@ def malicious_functions():
     }
 
     #[test]
+    fn test_csv_quotes_file_paths_with_commas() {
+        let bin_path = if let Ok(path) = std::env::var("CARGO_BIN_EXE_sighthound") {
+            std::path::PathBuf::from(path)
+        } else {
+            std::path::PathBuf::from("target/debug/sighthound")
+        };
+
+        if !bin_path.exists() {
+            return;
+        }
+
+        let mut python_file = tempfile::Builder::new()
+            .prefix("vulnerable,")
+            .suffix(".py")
+            .tempfile()
+            .expect("Failed to create temp file");
+        writeln!(python_file, "import os\nos.system(input())")
+            .expect("Failed to write to temp file");
+
+        let output = std::process::Command::new(&bin_path)
+            .args([
+                python_file.path().to_str().unwrap(),
+                "python",
+                "--simple-analysis",
+                "--output-format",
+                "csv",
+            ])
+            .output()
+            .expect("failed to run sighthound");
+
+        assert!(output.status.success());
+        let stdout = String::from_utf8(output.stdout).expect("CSV output should be UTF-8");
+        let expected_prefix = format!("\"{}\",", python_file.path().display());
+        assert!(
+            stdout.lines().skip(1).any(|line| line.starts_with(&expected_prefix)),
+            "CSV path containing a comma was not quoted:\n{stdout}"
+        );
+    }
+
+    #[test]
     fn test_cli_exit_code_gating() {
         let bin_path = if let Ok(path) = std::env::var("CARGO_BIN_EXE_sighthound") {
             std::path::PathBuf::from(path)


### PR DESCRIPTION
## Summary

Fix CSV serialization so every textual field is quoted when it contains a comma, quote, CR, or LF. The previous formatter only escaped the code field, so valid finding values such as a path containing a comma shifted subsequent columns and produced malformed CSV.

Add a focused escaping unit test and a CLI regression test that scans a Python file whose path contains a comma. No dependency was added, and ordinary CSV output remains unchanged.

## Related issue

None.

## Checklist

- [x] `make ci` passes locally (the same command CI runs — see CONTRIBUTING.md)
- [x] Ran `make bootstrap` once so pre-commit/pre-push hooks are active
- [x] Added/updated tests for the change
- [x] Updated docs/rules where relevant (not applicable; no interface or rule change)
