### PR TITLE
fix(scanner): enable multi-file cross-taint analysis across all supported languages

### DIFF
--- a/src/scanner/dataflow.rs
+++ b/src/scanner/dataflow.rs
@@ -1102,23 +1102,29 @@ impl DataFlowTracer {
         Some(module_b_path)
     }
 
-    /// Fallback: scan Python files in the same directory as `calling_file` for one that
-    /// defines `function_name`.
-    fn find_in_sibling_python_files(
+    /// Fallback: scan source files with the same extension in the same directory as `calling_file`
+    /// for one that defines `function_name`.
+    fn find_in_sibling_source_files(
         &self,
         calling_dir: &str,
         calling_file: &str,
         function_name: &str,
     ) -> Option<String> {
         let entries = std::fs::read_dir(calling_dir).ok()?;
-        let calling_basename = std::path::Path::new(calling_file).file_name().unwrap_or_default();
+        let calling_path = std::path::Path::new(calling_file);
+        let calling_ext = calling_path.extension().and_then(|e| e.to_str()).unwrap_or("");
+        let calling_basename = calling_path.file_name().unwrap_or_default();
 
         for entry in entries.flatten() {
             let os_file_name = entry.file_name();
             let Some(file_name) = os_file_name.to_str() else {
                 continue;
             };
-            if !file_name.ends_with(".py") || file_name == calling_basename {
+            let ext = std::path::Path::new(file_name)
+                .extension()
+                .and_then(|e| e.to_str())
+                .unwrap_or("");
+            if ext != calling_ext || file_name == calling_basename {
                 continue;
             }
             let candidate_path = format!("{}/{}", calling_dir, file_name);
@@ -1167,8 +1173,8 @@ impl DataFlowTracer {
             {
                 Self::find_in_module_b(calling_dir, function_name)
             }
-            // Try to find in any Python file in the same directory
-            _ => self.find_in_sibling_python_files(calling_dir, calling_file, function_name),
+            // Try to find in any sibling source file in the same directory
+            _ => self.find_in_sibling_source_files(calling_dir, calling_file, function_name),
         };
 
         if found.is_none() {
@@ -1183,8 +1189,16 @@ impl DataFlowTracer {
     /// Check if a file contains a function definition
     fn file_contains_function(&self, file_path: &str, function_name: &str) -> bool {
         if let Ok(content) = std::fs::read_to_string(file_path) {
-            let pattern = format!("def {}(", function_name);
-            content.contains(&pattern)
+            let py_pattern = format!("def {}(", function_name);
+            let js_pattern1 = format!("function {}(", function_name);
+            let js_pattern2 = format!("const {} =", function_name);
+            let js_pattern3 = format!("let {} =", function_name);
+            let fn_pattern = format!("fn {}(", function_name);
+            content.contains(&py_pattern)
+                || content.contains(&js_pattern1)
+                || content.contains(&js_pattern2)
+                || content.contains(&js_pattern3)
+                || content.contains(&fn_pattern)
         } else {
             false
         }

--- a/src/scanner/dataflow.rs
+++ b/src/scanner/dataflow.rs
@@ -1120,10 +1120,8 @@ impl DataFlowTracer {
             let Some(file_name) = os_file_name.to_str() else {
                 continue;
             };
-            let ext = std::path::Path::new(file_name)
-                .extension()
-                .and_then(|e| e.to_str())
-                .unwrap_or("");
+            let ext =
+                std::path::Path::new(file_name).extension().and_then(|e| e.to_str()).unwrap_or("");
             if ext != calling_ext || file_name == calling_basename {
                 continue;
             }

--- a/src/scanner/dataflow.rs
+++ b/src/scanner/dataflow.rs
@@ -1184,19 +1184,31 @@ impl DataFlowTracer {
         found
     }
 
-    /// Check if a file contains a function definition
+    /// Helper to check if a source line declares a callable function definition
+    fn is_function_definition_line(line: &str, function_name: &str) -> bool {
+        let trimmed = line.trim();
+        trimmed.starts_with(&format!("def {}(", function_name))
+            || trimmed.starts_with(&format!("async def {}(", function_name))
+            || trimmed.starts_with(&format!("def {} ", function_name))
+            || trimmed.starts_with(&format!("function {}(", function_name))
+            || trimmed.starts_with(&format!("async function {}(", function_name))
+            || trimmed.starts_with(&format!("const {} = (", function_name))
+            || trimmed.starts_with(&format!("const {} = async (", function_name))
+            || trimmed.starts_with(&format!("let {} = (", function_name))
+            || trimmed.starts_with(&format!("let {} = async (", function_name))
+            || trimmed.starts_with(&format!("var {} = (", function_name))
+            || trimmed.starts_with(&format!("var {} = async (", function_name))
+            || trimmed.starts_with(&format!("fn {}(", function_name))
+            || trimmed.starts_with(&format!("pub fn {}(", function_name))
+            || trimmed.starts_with(&format!("pub(crate) fn {}(", function_name))
+            || trimmed.starts_with(&format!("async fn {}(", function_name))
+            || trimmed.starts_with(&format!("func {}(", function_name))
+    }
+
+    /// Check if a file contains a callable function definition
     fn file_contains_function(&self, file_path: &str, function_name: &str) -> bool {
         if let Ok(content) = std::fs::read_to_string(file_path) {
-            let py_pattern = format!("def {}(", function_name);
-            let js_pattern1 = format!("function {}(", function_name);
-            let js_pattern2 = format!("const {} =", function_name);
-            let js_pattern3 = format!("let {} =", function_name);
-            let fn_pattern = format!("fn {}(", function_name);
-            content.contains(&py_pattern)
-                || content.contains(&js_pattern1)
-                || content.contains(&js_pattern2)
-                || content.contains(&js_pattern3)
-                || content.contains(&fn_pattern)
+            content.lines().any(|line| Self::is_function_definition_line(line, function_name))
         } else {
             false
         }
@@ -1543,7 +1555,7 @@ impl DataFlowTracer {
         log::debug!("[EXTRACT_FUNCTION_BODY] Looking for function: {}", function_name);
 
         for (line_num, line) in lines.iter().enumerate() {
-            if line.trim().starts_with(&format!("def {}(", function_name)) {
+            if Self::is_function_definition_line(line, function_name) {
                 log::debug!(
                     "[EXTRACT_FUNCTION_BODY] Found function definition at line {}: {}",
                     line_num + 1,

--- a/src/scanner/multifile_taint.rs
+++ b/src/scanner/multifile_taint.rs
@@ -37,31 +37,33 @@ impl MultiFileTaintAnalyzer {
     }
 
     /// NEW: Analyze cross-file taint flows using the enhanced DataFlowTracer
-    /// Select the target language and its files for cross-file analysis: `language_filter`'s
-    /// files if present and non-empty (no fallback when it yields nothing), else Python (the
-    /// legacy default) if present and non-empty.
+    /// Select the target languages and files for cross-file analysis: `language_filter`'s
+    /// files if present and non-empty, else all languages present in `files_by_language`.
     fn select_cross_file_targets<'a>(
         files_by_language: &'a std::collections::BTreeMap<String, Vec<std::path::PathBuf>>,
         language_filter: Option<&'a str>,
-    ) -> Option<(Vec<std::path::PathBuf>, &'a str)> {
+    ) -> Vec<(Vec<std::path::PathBuf>, &'a str)> {
         if let Some(filter_lang) = language_filter {
-            let filtered_files = files_by_language.get(filter_lang)?;
-            if filtered_files.is_empty() {
-                return None;
+            if let Some(filtered_files) = files_by_language.get(filter_lang) {
+                if !filtered_files.is_empty() {
+                    log::debug!(
+                        "[CROSS_FILE_NEW] Using language_filter: {} ({} files)",
+                        filter_lang,
+                        filtered_files.len()
+                    );
+                    return vec![(filtered_files.clone(), filter_lang)];
+                }
             }
-            log::debug!(
-                "[CROSS_FILE_NEW] Using language_filter: {} ({} files)",
-                filter_lang,
-                filtered_files.len()
-            );
-            return Some((filtered_files.clone(), filter_lang));
+            return Vec::new();
         }
 
-        let python_files = files_by_language.get("python")?;
-        if python_files.is_empty() {
-            return None;
+        let mut targets = Vec::new();
+        for (lang, files) in files_by_language {
+            if !files.is_empty() {
+                targets.push((files.clone(), lang.as_str()));
+            }
         }
-        Some((python_files.clone(), "python"))
+        targets
     }
 
     /// Handle one sink's analysis result: for a definite taint flow, record a deduplicated
@@ -133,18 +135,18 @@ impl MultiFileTaintAnalyzer {
     ) -> Result<Vec<crate::models::Finding>> {
         log::debug!("[CROSS_FILE_NEW] Starting enhanced cross-file taint analysis");
 
-        // If still no files, skip cross-file analysis
-        let Some((target_files, language)) =
-            Self::select_cross_file_targets(files_by_language, language_filter)
-        else {
+        let target_groups = Self::select_cross_file_targets(files_by_language, language_filter);
+        if target_groups.is_empty() {
             log::debug!("[CROSS_FILE_NEW] No suitable files found for cross-file analysis");
             return Ok(Vec::new());
-        };
-        log::debug!(
-            "[CROSS_FILE_NEW] Analyzing {} {} files for cross-file taint flows",
-            target_files.len(),
-            language
-        );
+        }
+        for (target_files, language) in &target_groups {
+            log::debug!(
+                "[CROSS_FILE_NEW] Analyzing {} {} files for cross-file taint flows",
+                target_files.len(),
+                language
+            );
+        }
 
         let mut data_flow_tracer = DataFlowTracer::new();
 
@@ -327,16 +329,14 @@ impl MultiFileTaintAnalyzer {
                 }
             }
         } else {
-            // Original fallback logic: process JavaScript and Python files
+            // Process files for all available languages
             for (language, files) in files_by_language {
-                if language == "javascript" || language == "python" {
-                    for file_path in files {
-                        self.analyze_file_for_imports_exports(
-                            file_path,
-                            language,
-                            &rule_deduplicator,
-                        )?;
-                    }
+                for file_path in files {
+                    self.analyze_file_for_imports_exports(
+                        file_path,
+                        language,
+                        &rule_deduplicator,
+                    )?;
                 }
             }
         }

--- a/src/scanner/multifile_taint.rs
+++ b/src/scanner/multifile_taint.rs
@@ -332,11 +332,7 @@ impl MultiFileTaintAnalyzer {
             // Process files for all available languages
             for (language, files) in files_by_language {
                 for file_path in files {
-                    self.analyze_file_for_imports_exports(
-                        file_path,
-                        language,
-                        &rule_deduplicator,
-                    )?;
+                    self.analyze_file_for_imports_exports(file_path, language, &rule_deduplicator)?;
                 }
             }
         }

--- a/src/scanner/multifile_taint.rs
+++ b/src/scanner/multifile_taint.rs
@@ -321,18 +321,34 @@ impl MultiFileTaintAnalyzer {
             // If language_filter is specified, use that language exclusively
             if let Some(files) = files_by_language.get(filter_lang) {
                 for file_path in files {
-                    self.analyze_file_for_imports_exports(
+                    if let Err(e) = self.analyze_file_for_imports_exports(
                         file_path,
                         filter_lang,
                         &rule_deduplicator,
-                    )?;
+                    ) {
+                        log::warn!(
+                            "Failed to analyze imports/exports for file '{}': {}",
+                            file_path.display(),
+                            e
+                        );
+                    }
                 }
             }
         } else {
             // Process files for all available languages
             for (language, files) in files_by_language {
                 for file_path in files {
-                    self.analyze_file_for_imports_exports(file_path, language, &rule_deduplicator)?;
+                    if let Err(e) = self.analyze_file_for_imports_exports(
+                        file_path,
+                        language,
+                        &rule_deduplicator,
+                    ) {
+                        log::warn!(
+                            "Failed to analyze imports/exports for file '{}': {}",
+                            file_path.display(),
+                            e
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Generalizes select_cross_file_targets in src/scanner/multifile_taint.rs to target all active languages in iles_by_language instead of hardcoding Python only.
- Updates uild_import_export_maps to process all supported target languages.
- Generalizes sibling source file lookup and definition pattern matching in src/scanner/dataflow.rs to support non-Python extensions and multiple language function signatures.