### PR TITLE
fix(codetype): support multiline and side-effect import detection

### DIFF
--- a/src/code_type_detector.rs
+++ b/src/code_type_detector.rs
@@ -257,11 +257,12 @@ impl CodeTypeDetector {
     fn extract_imports(&self, content: &str, _language: &str) -> Vec<String> {
         let mut imports = Vec::new();
 
-        // Extract require() calls
+        // Extract require() calls and ES import statements (including multiline and side-effect imports)
         let require_patterns = vec![
             regex::Regex::new(r#"require\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap(),
-            regex::Regex::new(r#"import\s+.*from\s+['"]([^'"]+)['"]"#).unwrap(),
+            regex::Regex::new(r#"(?s)import\s+.*?from\s+['"]([^'"]+)['"]"#).unwrap(),
             regex::Regex::new(r#"import\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap(),
+            regex::Regex::new(r#"import\s+['"]([^'"]+)['"]"#).unwrap(),
         ];
 
         for pattern in require_patterns {
@@ -512,5 +513,30 @@ mod tests {
         let detector = CodeTypeDetector::new();
 
         assert_eq!(detector.detect_from_ast(&tree, source), CodeType::Backend);
+    }
+
+    #[test]
+    fn detect_code_type_handles_multiline_imports() {
+        let detector = CodeTypeDetector::new();
+        let code = r#"
+            import {
+                Injectable,
+                NestMiddleware,
+            } from '@nestjs/common';
+
+            @Injectable()
+            export class AuthMiddleware {}
+        "#;
+        assert_eq!(detector.detect_code_type("auth.ts", code, "typescript"), CodeType::Backend);
+    }
+
+    #[test]
+    fn detect_code_type_handles_side_effect_imports() {
+        let detector = CodeTypeDetector::new();
+        let code = r#"
+            import 'express';
+            export const app = {};
+        "#;
+        assert_eq!(detector.detect_code_type("server.ts", code, "typescript"), CodeType::Backend);
     }
 }

--- a/src/code_type_detector.rs
+++ b/src/code_type_detector.rs
@@ -254,13 +254,20 @@ impl CodeTypeDetector {
         }
     }
 
-    fn extract_imports(&self, content: &str, _language: &str) -> Vec<String> {
+    fn extract_imports(&self, content: &str, language: &str) -> Vec<String> {
+        let lang = language.to_lowercase();
+        if !matches!(lang.as_str(), "javascript" | "typescript" | "tsx" | "jsx" | "js" | "ts") {
+            return Vec::new();
+        }
+
         let mut imports = Vec::new();
 
-        // Extract require() calls and ES import statements (including multiline and side-effect imports)
+        // Extract require() calls and ES import statements (including multiline and side-effect imports).
+        // The import ... from pattern is constrained to not match across statement boundaries (semicolons).
         let require_patterns = vec![
             regex::Regex::new(r#"require\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap(),
-            regex::Regex::new(r#"(?s)import\s+.*?from\s+['"]([^'"]+)['"]"#).unwrap(),
+            regex::Regex::new(r#"(?s)import\s+(?:\{[^};]*\}|[^;]+?)\s+from\s*['"]([^'"]+)['"]"#)
+                .unwrap(),
             regex::Regex::new(r#"import\s*\(\s*['"]([^'"]+)['"]\s*\)"#).unwrap(),
             regex::Regex::new(r#"import\s+['"]([^'"]+)['"]"#).unwrap(),
         ];
@@ -538,5 +545,22 @@ mod tests {
             export const app = {};
         "#;
         assert_eq!(detector.detect_code_type("server.ts", code, "typescript"), CodeType::Backend);
+    }
+
+    #[test]
+    fn import_regex_does_not_capture_across_statement_boundaries() {
+        let detector = CodeTypeDetector::new();
+        // Semicolon ends the import statement; subsequent `from` in unrelated code must not form a match with `import`
+        let code = "import foo;\nlet x = calculate(from, 'react');\n";
+        let imports = detector.extract_imports(code, "javascript");
+        assert!(!imports.contains(&"react".to_string()));
+    }
+
+    #[test]
+    fn non_js_imports_do_not_override_backend_default() {
+        let detector = CodeTypeDetector::new();
+        // A Go file importing rxgo should not match JS frontend react signature
+        let code = "package main\n\nimport \"github.com/reactivex/rxgo\"\n";
+        assert_eq!(detector.detect_code_type("main.go", code, "go"), CodeType::Backend);
     }
 }


### PR DESCRIPTION
## Summary
- Adds dot-all flag \(?s)\ and non-greedy matching to the ES \import\ regex in \CodeTypeDetector::extract_imports\ so multiline import blocks are captured accurately.
- Adds regex pattern support for side-effect imports (\import 'package'\).
- Fixes false-positive Frontend classifications for Node/NestJS backend TypeScript files using multiline imports, which previously prevented backend security rules from loading.
- Adds regression unit tests in \src/code_type_detector.rs\.