### PR TITLE
fix(rules): do not hardcode js extensions in apply_centralized_exclusions

### DIFF
--- a/src/rules.rs
+++ b/src/rules.rs
@@ -336,19 +336,14 @@ impl Rules {
                     }
                 }
             } else {
-                // If rule doesn't have file_types, create one with centralized exclusions
+                // If rule doesn't have file_types, create one with centralized exclusions without restricting extensions
                 rule.file_types = Some(FileTypes {
                     python: None,
                     java: None,
                     javascript: None,
                     tsx: None,
                     html: None,
-                    extensions: Some(vec![
-                        ".js".to_string(),
-                        ".jsx".to_string(),
-                        ".ts".to_string(),
-                        ".tsx".to_string(),
-                    ]),
+                    extensions: None,
                     include_patterns: None,
                     exclude_patterns: Some(patterns.clone()),
                 });

--- a/tests/unit/exclusion_patterns_tests.rs
+++ b/tests/unit/exclusion_patterns_tests.rs
@@ -47,4 +47,39 @@ mod exclusion_patterns_tests {
         assert_eq!(p.get_patterns("backend"), Vec::<String>::new());
         assert_eq!(p.get_patterns("common"), Vec::<String>::new());
     }
+
+    #[test]
+    fn apply_centralized_exclusions_does_not_hardcode_js_extensions() {
+        let mut rules = sighthound::rules::Rules {
+            rules: vec![sighthound::UnifiedRule {
+                id: Some("test-rule".to_string()),
+                name: Some("Generic Rule".to_string()),
+                description: None,
+                category: None,
+                mode: "search".to_string(),
+                pattern: Some("eval(".to_string()),
+                patterns: None,
+                sources: None,
+                sinks: None,
+                propagators: None,
+                sanitizers: None,
+                finding_type: None,
+                severity: None,
+                confidence: None,
+                file_types: None,
+                conditions: None,
+                tags: None,
+                cwe_id: None,
+                message: None,
+            }],
+        };
+
+        rules.apply_centralized_exclusions(&patterns(), "backend");
+        let file_types = rules.rules[0].file_types.as_ref().unwrap();
+        assert!(file_types.extensions.is_none());
+        assert_eq!(
+            file_types.exclude_patterns.as_ref().unwrap(),
+            &vec!["*.min.js".to_string(), "*_test.go".to_string()]
+        );
+    }
 }

--- a/tests/unit/exclusion_patterns_tests.rs
+++ b/tests/unit/exclusion_patterns_tests.rs
@@ -75,11 +75,20 @@ mod exclusion_patterns_tests {
         };
 
         rules.apply_centralized_exclusions(&patterns(), "backend");
-        let file_types = rules.rules[0].file_types.as_ref().unwrap();
-        assert!(file_types.extensions.is_none());
+        let file_types = rules.rules[0].file_types.as_ref();
+        assert!(file_types.unwrap().extensions.is_none());
         assert_eq!(
-            file_types.exclude_patterns.as_ref().unwrap(),
+            file_types.unwrap().exclude_patterns.as_ref().unwrap(),
             &vec!["*.min.js".to_string(), "*_test.go".to_string()]
         );
+
+        // Exercise applicability: non-JS files match, but excluded files are skipped
+        assert!(sighthound::scanner::utils::rule_applies_to_file(file_types, "src/main.py"));
+        assert!(sighthound::scanner::utils::rule_applies_to_file(file_types, "src/service.go"));
+        assert!(!sighthound::scanner::utils::rule_applies_to_file(file_types, "src/app.min.js"));
+        assert!(!sighthound::scanner::utils::rule_applies_to_file(
+            file_types,
+            "src/handler_test.go"
+        ));
     }
 }


### PR DESCRIPTION
\, \.jsx\, \.ts\, \.tsx\])\.
- This previously caused rules loaded for Python, Java, Go, C#, Ruby, PHP, and generic search rules to be rejected during file scanning when evaluated by \ule_applies_to_file\.
- Sets \extensions: None\ so file extension matching remains unrestricted for generic rules.
- Adds regression unit test in \	ests/unit/exclusion_patterns_tests.rs\.