### PR TITLE
fix: skip taint pass instead of erroring when a language has no taint rules

### DIFF
--- a/src/scanner/modes.rs
+++ b/src/scanner/modes.rs
@@ -528,7 +528,7 @@ pub fn run_taint_analysis_with_verbosity(
     verbose_mode: bool,
 ) -> Result<Vec<Finding>> {
     // When taint runs as the second pass of a combined scan (verbose_mode = false),
-    // stay completely silent so we don't duplicate the banner, progress bar, or tallies.
+    // suppress the banner, progress bar, and tallies so we don't duplicate the first pass.
     let report = show_progress && verbose_mode;
     let scan_start = std::time::Instant::now();
 
@@ -541,10 +541,16 @@ pub fn run_taint_analysis_with_verbosity(
     // Check if we have taint flow rules
     let taint_rules_count = rules.rules.iter().filter(|r| r.is_taint_rule()).count();
 
+    // Some rule packs ship search-mode rules only (e.g. html, objectscript). Skip the taint
+    // pass instead of failing the scan and discarding the search-pass findings.
     if taint_rules_count == 0 {
-        return Err(anyhow::anyhow!(
-            "No taint flow rules found. Please ensure your rules contain rules with mode='taint'."
-        ));
+        if show_progress {
+            crate::ui::warn(&format!(
+                "no taint-mode rules for {} - skipping taint analysis",
+                context.detected_languages.join(", ")
+            ));
+        }
+        return Ok(Vec::new());
     }
     if show_progress && verbose_mode {
         print_taint_analysis_intro(root_dir, taint_rules_count, context.total_files);

--- a/tests/strictness/language_coverage.rs
+++ b/tests/strictness/language_coverage.rs
@@ -230,11 +230,97 @@ fn include_test_fixtures_flag_enables_scanning_tests_directory() {
     );
 }
 
+/// A language whose rule pack ships search rules but no `mode = "taint"` rules must not
+/// abort the scan. Scanning a SINGLE FILE is load-bearing: a directory scan merges in
+/// python/javascript taint rules, the zero-taint-rule guard never fires, and the test
+/// passes with or without the fix.
+#[cfg(feature = "html")]
+#[test]
+fn html_only_single_file_scan_succeeds_without_taint_rules() {
+    let staging = stage_dir();
+    let file = write_staged_file(
+        staging.path(),
+        "page.html",
+        "<html><body><h1>hello</h1><p>plain markup</p></body></html>\n",
+    );
+    let path = file.to_str().unwrap();
+
+    assert_taint_skip_contract(path);
+
+    // Locked decision Q2: the explicit --taint-analysis path degrades the same way.
+    run_json_scan_ok(&[path, "--taint-analysis", "--output-format", "json"]);
+}
+
+#[cfg(feature = "objectscript")]
+#[test]
+fn objectscript_only_single_file_scan_succeeds_without_taint_rules() {
+    let staging = stage_dir();
+    let file = write_staged_file(
+        staging.path(),
+        "Sample.cls",
+        r#"Class Demo.Sample Extends %RegisteredObject
+{
+
+ClassMethod Run(input As %String) As %String
+{
+  Quit input
+}
+
+}
+"#,
+    );
+    assert_taint_skip_contract(file.to_str().unwrap());
+}
+
+/// json invocation: exit 0, stdout parses as a JSON array, no notice on stdout.
+/// text invocation: exit 0, notice on stderr only, and never the benchmark-grepped string.
+#[cfg(any(feature = "html", feature = "objectscript"))]
+fn assert_taint_skip_contract(path: &str) {
+    const NOTICE: &str = "skipping taint analysis";
+    const OLD_ERROR: &str = "No taint flow rules found";
+
+    let json = run_json_scan_ok(&[path, "--output-format", "json"]);
+    let json_stdout = String::from_utf8_lossy(&json.stdout);
+    assert!(
+        !json_stdout.contains(NOTICE),
+        "{path}: json stdout must stay pure JSON, got: {json_stdout}"
+    );
+
+    let text = run_cli_raw(&[path]);
+    let stdout = String::from_utf8_lossy(&text.stdout);
+    let stderr = String::from_utf8_lossy(&text.stderr);
+    assert_eq!(text.status.code(), Some(0), "{path}: text scan should exit 0, stderr: {stderr}");
+    assert!(stderr.contains(NOTICE), "{path}: expected skip notice on stderr, got: {stderr}");
+    assert!(!stdout.contains(NOTICE), "{path}: skip notice leaked to stdout: {stdout}");
+    assert!(
+        !stderr.contains(OLD_ERROR) && !stdout.contains(OLD_ERROR),
+        "{path}: legacy '{OLD_ERROR}' text must be gone, stdout: {stdout} stderr: {stderr}"
+    );
+}
+
+/// Run the CLI and assert exit 0 with a parseable JSON array on stdout. Deliberately says
+/// nothing about length: a minimal fixture legitimately yields `[]`.
+#[cfg(any(feature = "html", feature = "objectscript"))]
+fn run_json_scan_ok(args: &[&str]) -> std::process::Output {
+    let output = run_cli_raw(args);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(output.status.code(), Some(0), "{args:?}: expected exit 0, stderr: {stderr}");
+    serde_json::from_slice::<Vec<Value>>(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "{args:?}: stdout is not a JSON array ({e}): {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    });
+    output
+}
+
+/// Raw process output — exit code, stdout, and stderr kept separate.
+fn run_cli_raw(args: &[&str]) -> std::process::Output {
+    Command::new(sighthound_binary()).args(args).output().expect("failed to run sighthound binary")
+}
+
 fn run_cli_json(args: &[&str]) -> Vec<Value> {
-    let output = Command::new(sighthound_binary())
-        .args(args)
-        .output()
-        .expect("failed to run sighthound binary");
+    let output = run_cli_raw(args);
     assert!(
         output.status.success(),
         "sighthound failed with status {:?}: {}",


### PR DESCRIPTION
## Problem

Scanning any single `.html` file failed with exit 1:

```
Error: No taint flow rules found. Please ensure your rules contain rules with mode='taint'.
```

Our release benchmark saw 179/179 html file scans error out.

## Root cause

`src/scanner/modes.rs:544-548` — `run_taint_analysis_with_verbosity` returned a hard `Err` when the loaded rule set contained zero `mode = "taint"` rules. The default scan mode (`src/main.rs:119-130`) runs the search pass first and the taint pass second; the `?` on the taint call discarded the already-computed search findings and aborted the process.

`rules/html` (7 rules) and `rules/objectscript` (5 rules) are search-mode only, so every single-file scan of those languages hit the guard. Directory scans were unaffected — the guard counts over the *merged* rule set for all detected languages, so any python/javascript file in the tree masked it. That is why this shipped unnoticed; the per-file invocation contract (`sighthound --output-format json <file>`) is what bites.

## Fix

A rule pack with no taint rules is a corpus property, not a failure. The guard now emits a `show_progress`-gated notice on **stderr** and returns `Ok(Vec::new())`, so the search-pass findings survive and the process exits 0. This matches `vulnerability_scanner.rs:777-783`, which already answers the strictly worse condition (both rule halves empty) with `Ok(Vec::new())`.

No language is special-cased — the condition is a count over the merged rule set — so `objectscript` is fixed by the same change. No new CLI flag; the invocation contract is unchanged. stdout stays pure JSON under `--output-format json`.

## Tests

Two feature-gated regression tests in `tests/strictness/language_coverage.rs`, one for html and one for objectscript. Each scans a **single file** — load-bearing, since a directory scan merges in python/javascript taint rules and would pass without the fix. Verified by stashing the `modes.rs` hunk: both tests fail (`left: Some(1) right: Some(0)`), and pass with it.

They assert exit 0, stdout parses as a JSON array, the notice appears on stderr only, and the old error string is gone.

## Verification

- `cargo test` — 258 passed, exit 0
- `make ci` — exit 0 (only pre-existing advisory CRAP/complexity lines)
- `sighthound --output-format json <pygoat .html>` — prints `[]`, exit 0 (was exit 1)
- Release benchmark over `realvuln-pygoat` + `realvuln-lets-be-bad-guys`: `No taint flow rules found` warnings **148 → 0**, zero failed scans. Every scoreboard row is numerically identical to the pre-fix baseline, including `language:javascript` (`TP=1 PREC=1.000 REC=1.000`) and `language:python` (`TP=13 FN=70`) — no behavior change for languages that do have taint rules.
- Findings for a javascript file (`datasets/insecure-js/server.js`) are byte-identical before and after.

## Known gap (separate work, not this PR)

The `language:html` scoreboard row stays `TP=0 FP=0 FN=17 TN=6`. That row is unchanged because the benchmark already scored a *failed* scan as "found nothing" — TP cases became FN, hard negatives became TN. The observable win here is exit 1 → exit 0 and 148 warnings → 0.

html recall is a separate rules-coverage gap, not part of this regression. `main`'s html pack is Thymeleaf / inline-`<script>` tuned and verifiably fires on those shapes; the benchmark corpus is Django/Jinja templates (`{{ query|safe }}`, `<form method="POST">` with no `{% csrf_token %}`), which no current html rule matches. The 7 html TPs the 0.1.2 release binary scored came from a generic rule pack (`rules/html/html_security.ron`) that only ever existed on the orphan release lineage, and they were line-window coincidences — e.g. `CASE-1536` expects CWE-79 at `xss_lab.html:27` (the `|safe` line) and 0.1.2 matched it with an *inline `onclick` handler* finding at line 36. Porting that pack back would trade precision on the curated hard negatives for coincidental recall, so it is deliberately out of scope.
