### PR TITLE
Add HTML security rules with markup search semantics

### DIFF
--- a/rules/html/html_security.ron
+++ b/rules/html/html_security.ron
@@ -1,0 +1,248 @@
+(
+    rules: [
+        // Generic HTML security patterns: dangerous markup that is unsafe on its own,
+        // independent of any template engine. Twelve rules, all `mode: "search"`, all
+        // scoped to `.html` / `.htm`.
+        //
+        // ENGINE NOTE: `.html` files are matched with `SearchSemantics::Markup`
+        // (src/language.rs), so both the prefilter and the final match run against the
+        // full text of each candidate node — `attribute`, `start_tag`, `script_element`
+        // and `element` — rather than against the resolved "function" name. That is what
+        // lets a pattern span two attributes (`html-xss-011`) or sit inside a `<script>`
+        // body (`html-xss-012`, `html-xss-013`, `html-sec-001`), neither of which the
+        // name-based prefilter can reach.
+        //
+        // PATTERN FORM: every pattern must be a plain literal (no `\`, no `*`) or
+        // `regex:`-prefixed. `rules::first_positive_match_range` resolves a byte range
+        // only for those two forms, and that range is what lands a finding on the source
+        // line the offending markup actually sits on. A glob or escaped pattern would
+        // still match but would silently fall back to heuristic line attribution.
+        //
+        // SCOPING: `html-xss-012` and `html-xss-013` carry a `node_kind` condition
+        // pinning them to `script_element`. Without it, `-013` would double-report the
+        // `onclick="eval(...)"` lines already covered by `-004`.
+        (
+            id: Some("html-xss-001"),
+            name: Some("JavaScript URL in href Attribute"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "href=\"javascript:",
+                "href='javascript:",
+                "href=javascript:",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
+            description: Some("JavaScript URLs in href attributes can execute arbitrary code when clicked"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "javascript-url", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-002"),
+            name: Some("JavaScript URL in form action"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "action=\"javascript:",
+                "action='javascript:",
+                "action=javascript:",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
+            description: Some("JavaScript URLs in form action attributes can execute arbitrary code on form submission"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "javascript-url", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-004"),
+            name: Some("Inline Event Handler with eval()"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "regex:onclick\\s*=\\s*[^>]*\\beval\\s*\\(",
+                "regex:onmouseover\\s*=\\s*[^>]*\\beval\\s*\\(",
+                "regex:onload\\s*=\\s*[^>]*\\beval\\s*\\(",
+                "regex:onerror\\s*=\\s*[^>]*\\beval\\s*\\(",
+                "regex:onchange\\s*=\\s*[^>]*\\beval\\s*\\(",
+                "regex:onfocus\\s*=\\s*[^>]*\\beval\\s*\\(",
+                "regex:onblur\\s*=\\s*[^>]*\\beval\\s*\\(",
+                "regex:onsubmit\\s*=\\s*[^>]*\\beval\\s*\\(",
+            ]),
+            finding_type: Some("Code Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
+            description: Some("Using eval() in inline event handlers can execute arbitrary code, especially with user-controlled input"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["html", "code-injection", "eval", "cwe-95"])
+        ),
+        (
+            id: Some("html-xss-008"),
+            name: Some("Dangerous srcdoc Attribute"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "regex:srcdoc\\s*=\\s*[\"'][^\"']*(?:<script|\\$\\{|\\{\\{)",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("High"),
+            confidence: Some("Medium"),
+            cwe_id: Some("cwe-79"),
+            description: Some("The srcdoc attribute can inject HTML/JavaScript into an iframe, creating XSS vulnerabilities"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "iframe", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-010"),
+            name: Some("CSS Expression (IE Legacy)"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "regex:style\\s*=\\s*[\"'][^\"']*\\bexpression\\s*\\(",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("Medium"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
+            description: Some("CSS expressions in IE can execute JavaScript code (legacy vulnerability but still relevant)"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "css-expression", "ie", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-011"),
+            name: Some("Meta Refresh with JavaScript URL"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "regex:(?i)http-equiv\\s*=\\s*[\"']refresh[\"'][^>]*url\\s*=\\s*javascript:",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
+            description: Some("Meta refresh tags with JavaScript URLs can execute arbitrary code"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "meta-refresh", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-012"),
+            name: Some("Script Tag with document.write"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "regex:document\\.write(?:ln)?\\s*\\([^)]*(?:user|input|data|param|location|\\$\\{)",
+            ]),
+            conditions: Some([(
+                field: "",
+                operator: "",
+                value: "",
+                condition_type: Some("node_kind"),
+                node_type: Some("script_element"),
+            )]),
+            finding_type: Some("DOM XSS"),
+            severity: Some("High"),
+            confidence: Some("Medium"),
+            cwe_id: Some("cwe-79"),
+            description: Some("document.write can inject HTML/JavaScript into the page, potentially leading to XSS"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "dom", "document-write", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-013"),
+            name: Some("eval() in Script Tag"),
+            category: Some("code-injection"),
+            mode: "search",
+            patterns: Some([
+                "regex:\\beval\\s*\\([^)]*(?:user|input|data|param|location|\\$\\{)",
+            ]),
+            conditions: Some([(
+                field: "",
+                operator: "",
+                value: "",
+                condition_type: Some("node_kind"),
+                node_type: Some("script_element"),
+            )]),
+            finding_type: Some("Code Injection"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-95"),
+            description: Some("eval() can execute arbitrary JavaScript code, especially dangerous with user input"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["html", "code-injection", "eval", "cwe-95"])
+        ),
+        (
+            id: Some("html-sec-001"),
+            name: Some("postMessage with Wildcard Origin"),
+            category: Some("security-misconfiguration"),
+            mode: "search",
+            patterns: Some([
+                "regex:postMessage\\s*\\([^,]+,\\s*[\"']\\*[\"']\\s*\\)",
+            ]),
+            finding_type: Some("Insecure postMessage"),
+            severity: Some("Medium"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-346"),
+            description: Some("Using wildcard (*) as targetOrigin in postMessage allows any site to receive the message"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["security", "html", "postmessage", "origin", "cwe-346"])
+        ),
+        (
+            id: Some("html-xss-014"),
+            name: Some("Inline Event Handler with Template Syntax"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "regex:onclick\\s*=.*\\$\\{",
+                "regex:onmouseover\\s*=.*\\$\\{",
+                "regex:onerror\\s*=.*\\$\\{",
+                "regex:onload\\s*=.*\\$\\{",
+                "regex:onchange\\s*=.*\\$\\{",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
+            description: Some("Template expressions in event handlers can inject user-controlled data, leading to XSS"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "inline-event", "template-injection", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-019"),
+            name: Some("JavaScript URL in src Attribute"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "src=\"javascript:",
+                "src='javascript:",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("High"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
+            description: Some("JavaScript URLs in src attributes can execute arbitrary code"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "javascript-url", "cwe-79"])
+        ),
+        (
+            id: Some("html-xss-020"),
+            name: Some("Data URL with Script"),
+            category: Some("xss"),
+            mode: "search",
+            patterns: Some([
+                "regex:data:text/html[^\\s\"']*<script",
+                "regex:data:[^\\s\"']*<script",
+            ]),
+            finding_type: Some("Cross-Site Scripting (XSS)"),
+            severity: Some("Critical"),
+            confidence: Some("High"),
+            cwe_id: Some("cwe-79"),
+            description: Some("Data URLs containing script tags can execute arbitrary JavaScript"),
+            file_types: Some((extensions: Some([".html", ".htm"]))),
+            tags: Some(["xss", "html", "data-url", "script", "cwe-79"])
+        ),
+    ]
+)

--- a/src/language.rs
+++ b/src/language.rs
@@ -3,6 +3,18 @@ use anyhow::Result;
 use std::path::Path;
 use tree_sitter::{Language, Node};
 
+/// How search-mode rules are matched against the parse tree.
+///
+/// `Ast` is the default every language inherits: the prefilter and the final match both
+/// run against the resolved "function" name. `Markup` matches against the full text of
+/// the candidate node instead, which is what lets a pattern span two attributes or sit
+/// inside a `<script>` body — neither of which a name is able to express.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SearchSemantics {
+    Ast,
+    Markup,
+}
+
 pub trait LanguageSupport: Send + Sync {
     fn name(&self) -> &'static str;
     fn file_extension(&self) -> &'static str;
@@ -10,6 +22,9 @@ pub trait LanguageSupport: Send + Sync {
     fn call_node_types(&self) -> &[&'static str];
     fn get_function_name<'a>(&self, node: &Node, source: &'a [u8]) -> Option<&'a str>;
     fn get_arguments_node<'a>(&self, node: &'a Node) -> Option<Node<'a>>;
+    fn search_semantics(&self) -> SearchSemantics {
+        SearchSemantics::Ast
+    }
 }
 
 pub fn get_language_support(language_name: &str) -> Result<Box<dyn LanguageSupport>> {
@@ -528,6 +543,10 @@ pub struct HTMLLanguage;
 
 #[cfg(feature = "html")]
 impl LanguageSupport for HTMLLanguage {
+    fn search_semantics(&self) -> SearchSemantics {
+        SearchSemantics::Markup
+    }
+
     fn name(&self) -> &'static str {
         "html"
     }
@@ -594,6 +613,10 @@ pub struct DjangoTemplateLanguage;
 
 #[cfg(feature = "django")]
 impl LanguageSupport for DjangoTemplateLanguage {
+    fn search_semantics(&self) -> SearchSemantics {
+        SearchSemantics::Markup
+    }
+
     fn name(&self) -> &'static str {
         "django"
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -410,6 +410,47 @@ pub fn rule_matches_pattern_unified(rule: &UnifiedRule, text: &str) -> bool {
     false
 }
 
+/// Byte range of the first match of `pattern` inside `text`, when the pattern form can
+/// express one.
+///
+/// Mirrors `CommonUtils::matches_unified_pattern` (src/common.rs) branch for branch, in
+/// its exact order. If match and range dispatch disagree, a finding lands on the wrong
+/// line.
+fn pattern_match_range(pattern: &str, text: &str) -> Option<std::ops::Range<usize>> {
+    if pattern == text {
+        return Some(0..text.len());
+    }
+    if let Some(stripped) = pattern.strip_prefix("regex:") {
+        return Regex::new(stripped).ok()?.find(text).map(|m| m.range());
+    }
+    if pattern.contains("\\\\") || pattern.contains("\\.") {
+        return Regex::new(pattern).ok()?.find(text).map(|m| m.range());
+    }
+    if pattern.contains('\\') || pattern.contains('*') {
+        // Escaped and glob forms are not range-resolvable; the caller falls back to
+        // today's line attribution when no pattern resolves.
+        return None;
+    }
+    text.find(pattern).map(|start| start..start + pattern.len())
+}
+
+/// Byte range of the first of the rule's patterns that resolves one against `text`.
+///
+/// Because `find_map` skips `None`, a `None` from the escaped/glob branch is
+/// indistinguishable from "this pattern did not match" — iteration simply continues.
+/// The caller therefore falls back to heuristic line attribution only when *every*
+/// pattern returns `None`.
+pub(crate) fn first_positive_match_range(
+    rule: &UnifiedRule,
+    text: &str,
+) -> Option<std::ops::Range<usize>> {
+    // Same pattern order as rule_matches_pattern_unified: `pattern` then `patterns`,
+    // returning the first pattern that resolves a range.
+    rule.pattern.as_deref().and_then(|pattern| pattern_match_range(pattern, text)).or_else(|| {
+        rule.patterns.as_ref()?.iter().find_map(|pattern| pattern_match_range(pattern, text))
+    })
+}
+
 pub fn validate_unified_rule_patterns(rule: &UnifiedRule) -> Result<(), String> {
     if rule.is_search_rule() {
         if let Some(pattern) = &rule.pattern {

--- a/src/scanner/conditions.rs
+++ b/src/scanner/conditions.rs
@@ -61,6 +61,9 @@ pub fn check_single_condition(
             check_argument_not_sanitized_condition(node, source, condition, language_support)
         }
         "has_sibling_pattern" => check_has_sibling_pattern_condition(node, source, condition),
+        "node_kind" => {
+            condition.node_type.as_deref().is_some_and(|expected| node.kind() == expected)
+        }
         _ => false,
     }
 }

--- a/src/scanner/scanning_logic.rs
+++ b/src/scanner/scanning_logic.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::too_many_arguments, clippy::large_enum_variant, clippy::needless_range_loop)]
 
 use crate::common::CommonUtils;
+use crate::language::SearchSemantics;
 use crate::scanner::ast_provenance;
 use crate::scanner::flow_tracker::{TaintVariableInfo, VariableFlowTracker};
 use crate::scanner::scan_context::{EnhancedSearchContext, SinkSite, TaintScanContext};
@@ -17,12 +18,13 @@ impl ScanningLogic {
         func_name: &str,
         language_support: &dyn crate::language::LanguageSupport,
     ) -> Option<crate::models::Finding> {
-        let pattern_matches = if Self::rule_needs_full_context(rule) {
-            let node_text = crate::parser::get_node_text(node, source);
-            crate::rules::rule_matches_pattern_unified(rule, &node_text)
-        } else {
-            crate::rules::rule_matches_pattern_unified(rule, func_name)
-        };
+        let markup = language_support.search_semantics() == SearchSemantics::Markup;
+        let mut node_text = (markup || Self::rule_needs_full_context(rule))
+            .then(|| crate::parser::get_node_text(node, source));
+        let pattern_matches = crate::rules::rule_matches_pattern_unified(
+            rule,
+            node_text.as_deref().unwrap_or(func_name),
+        );
 
         if !pattern_matches {
             return None;
@@ -44,8 +46,10 @@ impl ScanningLogic {
         }
 
         if language_support.name() == "javascript" || language_support.name() == "typescript" {
-            let node_text = crate::parser::get_node_text(node, source);
-            if !Self::should_apply_rule_with_sanitization(rule, &node_text) {
+            let node_text = node_text
+                .get_or_insert_with(|| crate::parser::get_node_text(node, source))
+                .as_str();
+            if !Self::should_apply_rule_with_sanitization(rule, node_text) {
                 return None;
             }
         }
@@ -67,6 +71,23 @@ impl ScanningLogic {
         );
 
         Self::add_finding_metadata(&mut finding, rule, node);
+
+        // Markup line attribution. `find_vulnerable_line_in_node` cannot resolve a
+        // `regex:` pattern (it searches for the pattern literally), so for markup we
+        // recompute the line from the first pattern that resolves a byte range.
+        //
+        // This must stay *inside* `check_rule_against_node`, before `scan_file_with_rules`
+        // derives the dedup key from the returned finding — reversing that order silently
+        // breaks dedup. Only `line` is corrected; `column`, `end_line` and `end_column`
+        // stay node-derived on purpose.
+        if markup {
+            let node_text = node_text.as_deref().expect("markup matching initializes node text");
+            if let Some(range) = crate::rules::first_positive_match_range(rule, node_text) {
+                finding.line = node.start_position().row
+                    + 1
+                    + node_text[..range.start].bytes().filter(|b| *b == b'\n').count();
+            }
+        }
 
         if let Some(source_info) = Self::detect_source_pattern(node, source, language_support) {
             finding.source_info = Some(source_info);
@@ -135,18 +156,30 @@ impl ScanningLogic {
         rules: &[&crate::rules::UnifiedRule],
         language_support: &dyn crate::language::LanguageSupport,
     ) -> Vec<crate::models::Finding> {
-        let mut findings = Vec::new();
+        let mut findings: Vec<crate::models::Finding> = Vec::new();
         let mut processed_lines = std::collections::HashSet::new();
+        let markup = language_support.search_semantics() == SearchSemantics::Markup;
+        // Markup only: key -> index into `findings`, so a collision replaces the right
+        // finding. A `findings.iter_mut().find(..)` over the key would match the first
+        // finding on that line regardless of which rule produced it, and clobber an
+        // unrelated finding when two rules hit one line.
+        let mut markup_index: std::collections::HashMap<(usize, &str), usize> =
+            std::collections::HashMap::new();
 
         let call_nodes: Vec<tree_sitter::Node> =
             crate::parser::traverse_calls_only(tree.root_node(), language_support).collect();
 
         for node in call_nodes.iter() {
             if let Some(func_name) = language_support.get_function_name(node, source) {
+                // Computed once per node, not once per rule.
+                let markup_text = markup.then(|| crate::parser::get_node_text(node, source));
                 let relevant_rules: Vec<(usize, &crate::rules::UnifiedRule)> = rules
                     .iter()
                     .enumerate()
-                    .filter(|(_, rule)| Self::rule_might_match_function(rule, func_name))
+                    .filter(|(_, rule)| match &markup_text {
+                        Some(text) => crate::rules::rule_matches_pattern_unified(rule, text),
+                        None => Self::rule_might_match_function(rule, func_name),
+                    })
                     .map(|(idx, rule)| (idx, *rule))
                     .collect();
 
@@ -159,11 +192,42 @@ impl ScanningLogic {
                         func_name,
                         language_support,
                     ) {
-                        let line_key =
-                            (finding.line, finding.function.clone(), finding.finding_type.clone());
-                        if !processed_lines.contains(&line_key) {
-                            processed_lines.insert(line_key);
-                            findings.push(finding);
+                        if markup {
+                            // Markup needs rule identity: ancestor and descendant findings carry
+                            // different `function` values ("a" for the start tag, "href" for the
+                            // attribute) and would not collapse under the AST key. `id` is Option
+                            // on UnifiedRule, so fall back name -> finding_type.
+                            let rule_key = rule
+                                .id
+                                .as_deref()
+                                .or(rule.name.as_deref())
+                                .unwrap_or_else(|| rule.get_finding_type());
+                            let line_key = (finding.line, rule_key);
+                            match markup_index.get(&line_key) {
+                                Some(&idx) => {
+                                    // Tightest node span wins: the snippet is
+                                    // get_node_text of the matching node, so a shorter
+                                    // snippet is a smaller byte span. Strict `<` keeps
+                                    // the first-seen (outermost) finding on a tie.
+                                    if finding.snippet.len() < findings[idx].snippet.len() {
+                                        findings[idx] = finding;
+                                    }
+                                }
+                                None => {
+                                    markup_index.insert(line_key, findings.len());
+                                    findings.push(finding);
+                                }
+                            }
+                        } else {
+                            let line_key = (
+                                finding.line,
+                                finding.function.clone(),
+                                finding.finding_type.clone(),
+                            );
+                            if !processed_lines.contains(&line_key) {
+                                processed_lines.insert(line_key);
+                                findings.push(finding);
+                            }
                         }
                     }
                 }

--- a/tests/strictness/helpers.rs
+++ b/tests/strictness/helpers.rs
@@ -3,6 +3,7 @@ use sighthound::rules::Rules;
 use sighthound::VulnerabilityScanner;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use tempfile::TempDir;
 
 pub fn manifest_dir() -> PathBuf {
@@ -221,4 +222,46 @@ pub fn assert_has_cross_file_finding_near(
             .map(|f| (f.file.as_str(), f.line))
             .collect::<Vec<_>>()
     );
+}
+
+/// Raw process output from the shipped `sighthound` binary — exit code, stdout, and
+/// stderr kept separate. Lives here so several strictness suites can drive the CLI.
+#[allow(dead_code)]
+pub fn run_cli_raw(args: &[&str]) -> std::process::Output {
+    Command::new(sighthound_binary()).args(args).output().expect("failed to run sighthound binary")
+}
+
+/// Run the shipped `sighthound` binary and parse its JSON output.
+///
+/// The `status.success()` assert is load-bearing: it fires *before* the empty-stdout
+/// fallback below, so a non-zero exit surfaces as a loud panic instead of an empty
+/// finding set. Do not replace it with a silent `Vec::new()`.
+#[allow(dead_code)]
+pub fn run_cli_json(args: &[&str]) -> Vec<serde_json::Value> {
+    let output = run_cli_raw(args);
+    assert!(
+        output.status.success(),
+        "sighthound failed with status {:?}: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    match serde_json::from_slice(&output.stdout) {
+        Ok(findings) => findings,
+        Err(_) => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            if stdout.trim().is_empty() || stdout.trim_start().starts_with("No ") {
+                Vec::new()
+            } else {
+                panic!("failed to parse scanner JSON output: {stdout}");
+            }
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn sighthound_binary() -> PathBuf {
+    if let Ok(path) = std::env::var("CARGO_BIN_EXE_sighthound") {
+        return PathBuf::from(path);
+    }
+    fixture_path("target/debug/sighthound")
 }

--- a/tests/strictness/html_security.rs
+++ b/tests/strictness/html_security.rs
@@ -1,0 +1,263 @@
+//! Strictness coverage for the generic HTML security rule pack.
+//!
+//! Drives the shipped binary through CLI auto-detection — no `--language`, no rules
+//! path — which is exactly what routes `run_simple_analysis` to
+//! `run_auto_detection_scan` (`src/main.rs`).
+
+use super::helpers::*;
+use serde_json::Value;
+use std::collections::BTreeSet;
+
+const POSITIVE_FIXTURE: &str = "html_security_positive.html";
+const SAFE_FIXTURE: &str = "html_security_safe.html";
+
+/// (rule id — documentation only, `Finding` has no rule-id field; fixture line;
+/// `finding_type`; `description`; `snippet`).
+///
+/// `description` is the discriminator: eight of the twelve share
+/// "Cross-Site Scripting (XSS)", two share "Code Injection", and `tags` are identical
+/// across -001 / -002 / -019. **Do not simplify these assertions back to
+/// `finding_type`** — they would stop distinguishing eight of the twelve rules.
+///
+/// `snippet` is the verbatim `get_node_text` of the node that matched, which is what
+/// pins "tightest node span wins" (assertion 4). Nine are attribute-level; the four
+/// tag-level ones are not typos — see the comment on assertion 4.
+const EXPECTED: &[(&str, u64, &str, &str, &str)] = &[
+    (
+        "html-xss-011",
+        7,
+        "Cross-Site Scripting (XSS)",
+        "Meta refresh tags with JavaScript URLs can execute arbitrary code",
+        "<meta http-equiv=\"refresh\" content=\"0;url=javascript:alert(1)\">",
+    ),
+    (
+        "html-xss-001",
+        11,
+        "Cross-Site Scripting (XSS)",
+        "JavaScript URLs in href attributes can execute arbitrary code when clicked",
+        "href=\"javascript:alert(1)\"",
+    ),
+    (
+        "html-xss-002",
+        13,
+        "Cross-Site Scripting (XSS)",
+        "JavaScript URLs in form action attributes can execute arbitrary code on form submission",
+        "action=\"javascript:alert(1)\"",
+    ),
+    (
+        "html-xss-019",
+        15,
+        "Cross-Site Scripting (XSS)",
+        "JavaScript URLs in src attributes can execute arbitrary code",
+        "src=\"javascript:alert(1)\"",
+    ),
+    (
+        "html-xss-020",
+        17,
+        "Cross-Site Scripting (XSS)",
+        "Data URLs containing script tags can execute arbitrary JavaScript",
+        "href=\"data:text/html,<script>alert(1)</script>\"",
+    ),
+    (
+        "html-xss-004",
+        19,
+        "Code Injection",
+        "Using eval() in inline event handlers can execute arbitrary code, especially with user-controlled input",
+        "onclick=\"eval(userInput)\"",
+    ),
+    (
+        "html-xss-014",
+        21,
+        "Cross-Site Scripting (XSS)",
+        "Template expressions in event handlers can inject user-controlled data, leading to XSS",
+        "onclick=\"greet('${userName}')\"",
+    ),
+    (
+        "html-xss-008",
+        23,
+        "Cross-Site Scripting (XSS)",
+        "The srcdoc attribute can inject HTML/JavaScript into an iframe, creating XSS vulnerabilities",
+        "srcdoc=\"${userContent}\"",
+    ),
+    (
+        "html-xss-010",
+        25,
+        "Cross-Site Scripting (XSS)",
+        "CSS expressions in IE can execute JavaScript code (legacy vulnerability but still relevant)",
+        "style=\"width:expression(alert(1))\"",
+    ),
+    (
+        "html-xss-012",
+        27,
+        "DOM XSS",
+        "document.write can inject HTML/JavaScript into the page, potentially leading to XSS",
+        "<script>document.write(userInput);</script>",
+    ),
+    (
+        "html-xss-013",
+        29,
+        "Code Injection",
+        "eval() can execute arbitrary JavaScript code, especially dangerous with user input",
+        "<script>eval(userInput);</script>",
+    ),
+    (
+        "html-sec-001",
+        31,
+        "Insecure postMessage",
+        "Using wildcard (*) as targetOrigin in postMessage allows any site to receive the message",
+        "<script>window.postMessage(payload, \"*\");</script>",
+    ),
+];
+
+fn scan_staged_html_fixtures() -> Vec<Value> {
+    scan_staged_html_fixtures_with(&["--simple-analysis"])
+}
+
+/// `extra_args` sits between the scan path and `--output-format json`. Passing `&[]`
+/// reproduces the fusion contract exactly: default mode, no language, no simple flag.
+fn scan_staged_html_fixtures_with(extra_args: &[&str]) -> Vec<Value> {
+    let staging = stage_dir();
+    stage_file(
+        staging.path(),
+        "tests/test_files/html/html_security_positive.html",
+        POSITIVE_FIXTURE,
+        &[],
+    );
+    stage_file(staging.path(), "tests/test_files/html/html_security_safe.html", SAFE_FIXTURE, &[]);
+    let dir = staging.path().to_str().expect("staging path is not valid UTF-8").to_string();
+    let mut args = vec![dir.as_str()];
+    args.extend_from_slice(extra_args);
+    args.extend_from_slice(&["--output-format", "json"]);
+    run_cli_json(&args)
+}
+
+fn findings_for_file<'a>(findings: &'a [Value], filename: &str) -> Vec<&'a Value> {
+    findings.iter().filter(|f| f["file"].as_str().is_some_and(|p| p.ends_with(filename))).collect()
+}
+
+fn line_description_pairs(findings: &[&Value]) -> BTreeSet<(u64, String)> {
+    findings
+        .iter()
+        .map(|f| {
+            (
+                f["line"].as_u64().unwrap_or(0),
+                f["description"].as_str().unwrap_or("<none>").to_string(),
+            )
+        })
+        .collect()
+}
+
+#[cfg(feature = "html")]
+#[test]
+fn html_security_rules_fire_through_cli_auto_detection() {
+    let findings = scan_staged_html_fixtures();
+    let positives = findings_for_file(&findings, POSITIVE_FIXTURE);
+    let observed = line_description_pairs(&positives);
+
+    // 1. All twelve triples present at their marked lines.
+    for (id, line, finding_type, description, _) in EXPECTED {
+        assert!(
+            positives.iter().any(|f| {
+                f["line"].as_u64() == Some(*line)
+                    && f["finding_type"].as_str() == Some(*finding_type)
+                    && f["description"].as_str() == Some(*description)
+            }),
+            "{id}: expected a finding at line {line} of {POSITIVE_FIXTURE}; observed {observed:?}"
+        );
+    }
+
+    // 2. Zero findings in the safe fixture.
+    let safe = findings_for_file(&findings, SAFE_FIXTURE);
+    assert!(
+        safe.is_empty(),
+        "{SAFE_FIXTURE} must produce no findings, got {:?}",
+        line_description_pairs(&safe)
+    );
+
+    // 3. Nested markup collapses: exactly one finding per (line, description).
+    //    `description`, not `finding_type` — eight of the twelve share a finding_type.
+    let mut counts: std::collections::BTreeMap<(u64, String), usize> =
+        std::collections::BTreeMap::new();
+    for f in &positives {
+        let key = (
+            f["line"].as_u64().unwrap_or(0),
+            f["description"].as_str().unwrap_or("<none>").to_string(),
+        );
+        *counts.entry(key).or_default() += 1;
+    }
+    for (key, count) in &counts {
+        assert_eq!(*count, 1, "nested markup dedup failed for {key:?}: {count} findings");
+    }
+
+    // 4. Tightest node span wins, pinned as per-finding snippet equality rather than as
+    //    a negative: `traverse_calls_only` yields a parent before its children, so under
+    //    first-seen the enclosing `start_tag` wins and every attribute-level equality
+    //    below breaks.
+    //
+    //    Nine snippets are attribute-level and four are tag-level. That asymmetry is the
+    //    tightest span, not an oversight: html-xss-011 (line 7) matches across two
+    //    attributes (`http-equiv` and the `javascript:` URL), and lines 27/29/31 match
+    //    inside a `<script>` body — in neither case does any single `attribute` node's
+    //    text contain the match, so the enclosing node is the smallest one that does.
+    //
+    //    Keyed on (line, description), matching assertion 3: one line may legitimately
+    //    carry two findings from different rules.
+    let expected_snippets: std::collections::BTreeMap<(u64, &str), &str> = EXPECTED
+        .iter()
+        .map(|(_, line, _, description, snippet)| ((*line, *description), *snippet))
+        .collect();
+    for f in &positives {
+        let snippet = f["snippet"].as_str().unwrap_or("");
+        assert!(!snippet.is_empty(), "finding carries an empty snippet: {f:?}");
+        let key = (f["line"].as_u64().unwrap_or(0), f["description"].as_str().unwrap_or("<none>"));
+        let expected = expected_snippets
+            .get(&key)
+            .unwrap_or_else(|| panic!("finding at unexpected (line, description) {key:?}: {f:?}"));
+        assert_eq!(
+            &snippet, expected,
+            "snippet at line {} is not the tightest matching node span",
+            key.0
+        );
+    }
+}
+
+/// Keyed on the fixture basename, not the full path: each call stages into its own
+/// `TempDir`, so absolute paths differ between the two invocations by construction.
+fn finding_identity_set(findings: &[Value]) -> BTreeSet<(String, u64, String, String)> {
+    findings
+        .iter()
+        .map(|f| {
+            let path = f["file"].as_str().unwrap_or("<none>");
+            (
+                path.rsplit(['/', '\\']).next().unwrap_or("").to_string(),
+                f["line"].as_u64().unwrap_or(0),
+                f["finding_type"].as_str().unwrap_or("<none>").to_string(),
+                f["description"].as_str().unwrap_or("<none>").to_string(),
+            )
+        })
+        .collect()
+}
+
+#[cfg(feature = "html")]
+#[test]
+fn html_security_rules_fire_in_default_mode() {
+    // Default mode is the fusion contract: `sighthound --output-format json <path>`,
+    // no `--language`, no `--simple-analysis`. Without the zero-taint-rule skip in
+    // `src/scanner/modes.rs` this call panics with
+    // `sighthound failed with status Some(1): Error: No taint flow rules found. ...`,
+    // because `run_cli_json` asserts exit 0 before it parses stdout.
+    let default_mode = scan_staged_html_fixtures_with(&[]);
+    let simple_mode = scan_staged_html_fixtures();
+
+    assert!(
+        !default_mode.is_empty(),
+        "default mode must report the HTML findings; an empty set would make the parity \
+         assertion below vacuous"
+    );
+    assert_eq!(
+        finding_identity_set(&default_mode),
+        finding_identity_set(&simple_mode),
+        "default mode must report exactly what --simple-analysis reports: for a language \
+         with zero taint rules the taint pass must add nothing and drop nothing"
+    );
+}

--- a/tests/strictness/language_coverage.rs
+++ b/tests/strictness/language_coverage.rs
@@ -4,8 +4,6 @@ use super::helpers::*;
 use serde_json::Value;
 use sighthound::rules::Rules;
 use std::collections::BTreeSet;
-use std::path::PathBuf;
-use std::process::Command;
 
 #[cfg(feature = "php")]
 #[test]
@@ -312,39 +310,6 @@ fn run_json_scan_ok(args: &[&str]) -> std::process::Output {
         )
     });
     output
-}
-
-/// Raw process output — exit code, stdout, and stderr kept separate.
-fn run_cli_raw(args: &[&str]) -> std::process::Output {
-    Command::new(sighthound_binary()).args(args).output().expect("failed to run sighthound binary")
-}
-
-fn run_cli_json(args: &[&str]) -> Vec<Value> {
-    let output = run_cli_raw(args);
-    assert!(
-        output.status.success(),
-        "sighthound failed with status {:?}: {}",
-        output.status.code(),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    match serde_json::from_slice(&output.stdout) {
-        Ok(findings) => findings,
-        Err(_) => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            if stdout.trim().is_empty() || stdout.trim_start().starts_with("No ") {
-                Vec::new()
-            } else {
-                panic!("failed to parse scanner JSON output: {stdout}");
-            }
-        }
-    }
-}
-
-fn sighthound_binary() -> PathBuf {
-    if let Ok(path) = std::env::var("CARGO_BIN_EXE_sighthound") {
-        return PathBuf::from(path);
-    }
-    fixture_path("target/debug/sighthound")
 }
 
 fn finding_key_set(findings: &[Value]) -> BTreeSet<(String, u64, String, String)> {

--- a/tests/strictness/main.rs
+++ b/tests/strictness/main.rs
@@ -10,6 +10,7 @@ mod ast_provenance;
 mod cross_file_taint;
 mod django_security;
 mod false_positive_regressions;
+mod html_security;
 mod language_coverage;
 mod sanitizer_and_scope;
 mod search_conditions;

--- a/tests/test_files/html/html_security_positive.html
+++ b/tests/test_files/html/html_security_positive.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>HTML security positives</title>
+<!-- EXPECT html-xss-011 -->
+<meta http-equiv="refresh" content="0;url=javascript:alert(1)">
+</head>
+<body>
+<!-- EXPECT html-xss-001 -->
+<a href="javascript:alert(1)">Click</a>
+<!-- EXPECT html-xss-002 -->
+<form action="javascript:alert(1)"></form>
+<!-- EXPECT html-xss-019 -->
+<img src="javascript:alert(1)">
+<!-- EXPECT html-xss-020 -->
+<a href="data:text/html,<script>alert(1)</script>">Data</a>
+<!-- EXPECT html-xss-004 -->
+<button onclick="eval(userInput)">Run</button>
+<!-- EXPECT html-xss-014 -->
+<button onclick="greet('${userName}')">Greet</button>
+<!-- EXPECT html-xss-008 -->
+<iframe srcdoc="${userContent}"></iframe>
+<!-- EXPECT html-xss-010 -->
+<div style="width:expression(alert(1))">Legacy</div>
+<!-- EXPECT html-xss-012 -->
+<script>document.write(userInput);</script>
+<!-- EXPECT html-xss-013 -->
+<script>eval(userInput);</script>
+<!-- EXPECT html-sec-001 -->
+<script>window.postMessage(payload, "*");</script>
+</body>
+</html>

--- a/tests/test_files/html/html_security_safe.html
+++ b/tests/test_files/html/html_security_safe.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>HTML security negatives</title>
+<meta http-equiv="refresh" content="5;url=/dashboard">
+</head>
+<body>
+<a href="/login">Login</a>
+<a href="https://example.com/javascript-guide">Guide</a>
+<form action="/submit" method="post"></form>
+<img src="/static/logo.png">
+<a href="data:text/plain,hello">Data</a>
+<button onclick="submitForm()">Run</button>
+<button onclick="greet(userName)">Greet</button>
+<iframe srcdoc="Static content only"></iframe>
+<div style="width:120px">Sized</div>
+<script>document.write("static banner");</script>
+<script>parseInt(userInput, 10);</script>
+<script>window.postMessage(payload, "https://example.com");</script>
+</body>
+</html>

--- a/tests/unit/pattern_matching_tests.rs
+++ b/tests/unit/pattern_matching_tests.rs
@@ -1,7 +1,9 @@
 use sighthound::models::UnifiedRule;
 use sighthound::rules::{
     match_any_pattern, match_pattern, rule_matches_pattern_unified, validate_unified_rule_patterns,
+    Rules,
 };
+use std::collections::BTreeSet;
 
 // Build a search-mode UnifiedRule carrying the given pattern/patterns.
 // UnifiedRule does not derive Default, so this helper fills the remaining fields.
@@ -240,6 +242,43 @@ mod pattern_matching_tests {
         assert!(match_any_pattern(&crypto_patterns, "crypto.SHA1"));
         assert!(match_any_pattern(&crypto_patterns, "file.md5"));
         assert!(match_any_pattern(&crypto_patterns, "hashlib.md5"));
+    }
+
+    #[test]
+    fn html_security_pack_declares_exactly_the_twelve_rule_ids() {
+        // Relative path works from a test — tests/strictness/helpers.rs already does
+        // Rules::load_from_directory("rules/python/").
+        let rules = Rules::load_from_file("rules/html/html_security.ron")
+            .expect("failed to load rules/html/html_security.ron");
+
+        let ids: BTreeSet<&str> =
+            rules.rules.iter().filter_map(|rule| rule.id.as_deref()).collect();
+        let expected: BTreeSet<&str> = [
+            "html-xss-001",
+            "html-xss-002",
+            "html-xss-004",
+            "html-xss-008",
+            "html-xss-010",
+            "html-xss-011",
+            "html-xss-012",
+            "html-xss-013",
+            "html-xss-014",
+            "html-xss-019",
+            "html-xss-020",
+            "html-sec-001",
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(ids, expected, "html_security.ron must declare exactly the twelve rule ids");
+        assert_eq!(rules.rules.len(), 12, "every rule in the pack must carry an id");
+
+        // validate_unified_rule_patterns has no production call site (src/rules.rs), so a
+        // malformed `regex:` would otherwise fail silently at scan time.
+        for rule in &rules.rules {
+            validate_unified_rule_patterns(rule)
+                .unwrap_or_else(|e| panic!("invalid pattern in {:?}: {e}", rule.id));
+        }
     }
 }
 


### PR DESCRIPTION
**Stacked on #74.** This branch sits on `fix-html-taint-regression` (`af1443e`) and must merge **after** it. A diff against `main` will also show #74's taint fix; the 12 files below are this PR's own.

### What this adds

12 HTML security rule IDs in a new `rules/html/html_security.ron`, plus a minimal AST-vs-Markup boundary so HTML and Django match search-mode rules against node text rather than resolved function names.

- `src/language.rs` — new `SearchSemantics { Ast, Markup }`; `LanguageSupport::search_semantics()` defaults to `Ast`; HTML and Django override to `Markup`.
- `src/scanner/scanning_logic.rs` — markup prefiltering and final matching against node text, line attribution to the first positive match, and tightest-span dedup for nested markup findings.
- `src/scanner/conditions.rs` — `node_kind` condition arm.
- `src/rules.rs` — `first_positive_match_range` for line attribution.
- `tests/strictness/html_security.rs` (new), registered in `tests/strictness/main.rs`.
- `tests/strictness/helpers.rs` / `language_coverage.rs` — `run_cli_raw`, `run_cli_json`, `sighthound_binary` promoted from private-in-`language_coverage` to `pub` in `helpers` so the new suite can drive the CLI. Pure relocation; no coverage lost.

### Why it depends on #74

Before #74, `src/scanner/modes.rs` hard-errored when a language had zero taint-mode rules. HTML has none, so every HTML scan exited 1 with zero findings.

Verified rather than assumed: revert `modes.rs` to its pre-#74 state and `html_security_rules_fire_in_default_mode` fails with `Error: No taint flow rules found`. With #74 in the base it passes. This PR adds **no** hunk to `modes.rs`.

### Review notes

- **Shared surface with #74**: `tests/strictness/helpers.rs` and `tests/strictness/language_coverage.rs`. If #74 is amended or force-pushed, the helper move here needs re-deriving.
- **`include_dir!` staleness**: rules are embedded at compile time via `include_dir!` in `src/rules.rs`, and there is no `build.rs`. Editing a `.ron` with a warm `target/` yields zero findings until you `touch src/rules.rs`. Flagging it so the next person loses less time than I did.
- **Pre-existing gap**: `call_node_types()` omits `self_closing_tag`, so rules do not fire on self-closing elements. Not introduced here, not fixed here.
- **Dead code**: `"element"` in `call_node_types()` never produces findings — `get_function_name` resolves `tag_name` via `CommonUtils::find_child`, which walks direct children only, and per tree-sitter-html's node-types an `element` has no direct `tag_name`.

### Not covered by tests

- Django running `Markup`. The override exists; no test exercises it.
- The `.expect()` in the markup line-attribution block. Unreachable by construction (`markup == true` implies `node_text.is_some()`), but unasserted.
- The `get_finding_type()` → `"vulnerability"` fallback.

### Relationship to #9

#9 carries the same 12 rule IDs from the same lineage; this PR supersedes that portion. #9's sql/xml/properties/config rules, its parser-free text-scanning engine, and its `unless` exclusion mechanism are **not** included here — all were on this chunk's exclusion list. #9 stays open for that work.

### Verification

- `cargo test --test strictness_tests` — 47 passed
- `make test-unit` — 261 passed
- `cargo fmt --all -- --check` — clean
- Fusion contract (`sighthound --output-format json <path>`): positive fixture → exit 0, 12 findings at lines 7, 11, 13, 15, 17, 19, 21, 23, 25, 27, 29, 31, empty stderr; safe fixture → `[]`
- `--taint-analysis --output-format json` → stdout is `[]`, notice routed to stderr via `ui::warn`
